### PR TITLE
LIVY-357. Web UI: Updated staticResourceServlet to return 404s and not throw WARNs

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
@@ -29,9 +29,9 @@ import scala.concurrent.Future
 import org.apache.hadoop.security.{SecurityUtil, UserGroupInformation}
 import org.apache.hadoop.security.authentication.server._
 import org.eclipse.jetty.servlet.FilterHolder
+import org.scalatra.{NotFound, ScalatraServlet}
 import org.scalatra.metrics.MetricsBootstrap
 import org.scalatra.metrics.MetricsSupportExtensions._
-import org.scalatra.{NotFound, ScalatraServlet}
 import org.scalatra.servlet.{MultipartConfig, ServletApiImplicits}
 
 import com.cloudera.livy._


### PR DESCRIPTION
PR moved from old repo https://github.com/cloudera/livy/pull/339

[LIVY-357](https://issues.cloudera.org/browse/LIVY-357)

Since https://github.com/cloudera/livy/pull/319 added the UI whenever a static resource is accessed a `MimeException` is thrown as a `WARN`. This was caused because a `InputStream` must be wrapped in a `BufferedInputStream` for a full implementation.

I updated `staticResourceServlet` with the wrapper as well as adding a `404 File not found` return when a file does not exist (currently an empty file is returned in such a case)

Tested manually