### PR TITLE
LIVY-353. Web UI: Added link to Spark UI for Sessions running on Yarn

### DIFF
--- a/server/src/main/resources/com/cloudera/livy/server/ui/static/all-sessions.js
+++ b/server/src/main/resources/com/cloudera/livy/server/ui/static/all-sessions.js
@@ -16,6 +16,15 @@
  * limitations under the License.
  */
 
+function appIdLink(session) {
+  var appUiUrl = session.appInfo.sparkUiUrl;
+  if (appUiUrl != null) {
+    return '<a href="' + appUiUrl + '">' + session.appId + "</a>";
+  } else {
+    return session.appId;
+  }
+}
+
 function tdWrap(str) {
   return "<td>" + str + "</td>";
 }
@@ -25,7 +34,7 @@ function loadSessionsTable(sessions) {
     $("#interactive-sessions .sessions-table-body").append(
       "<tr>" +
         tdWrap(session.id) +
-        tdWrap(session.appId) +
+        tdWrap(appIdLink(session)) +
         tdWrap(session.owner) +
         tdWrap(session.proxyUser) +
         tdWrap(session.kind) +
@@ -40,7 +49,7 @@ function loadBatchesTable(sessions) {
     $("#batches .sessions-table-body").append(
       "<tr>" +
         tdWrap(session.id) +
-        tdWrap(session.appId) +
+        tdWrap(appIdLink(session)) +
         tdWrap(session.state) +
        "</tr>"
     );

--- a/server/src/main/resources/com/cloudera/livy/server/ui/static/batches-table.html
+++ b/server/src/main/resources/com/cloudera/livy/server/ui/static/batches-table.html
@@ -22,7 +22,13 @@
   <thead class="sessions-table-head">
   <tr>
     <th>Batch Id</th>
-    <th>Application Id</th>
+    <th>
+      <span data-toggle="tooltip"
+            title="Spark Application Id for this session.
+            If available, links to Spark Application Web UI">
+        Application Id
+      </span>
+    </th>
     <th>
       <span data-toggle="tooltip"
             title="Session State (not_started, starting, idle, busy,

--- a/server/src/main/resources/com/cloudera/livy/server/ui/static/sessions-table.html
+++ b/server/src/main/resources/com/cloudera/livy/server/ui/static/sessions-table.html
@@ -22,7 +22,13 @@
   <thead class="sessions-table-head">
   <tr>
     <th>Session Id</th>
-    <th>Application Id</th>
+    <th>
+      <span data-toggle="tooltip"
+            title="Spark Application Id for this session.
+            If available, links to Spark Application Web UI">
+        Application Id
+      </span>
+    </th>
     <th>
       <span data-toggle="tooltip" title="Remote user who submitted this session">
         Owner


### PR DESCRIPTION
PR moved from old repo https://github.com/cloudera/livy/pull/327

[LIVY-353](https://issues.cloudera.org/browse/LIVY-353)

Followup to https://github.com/cloudera/livy/pull/319 adding a link to the Application Id that links to the Spark UI. The link is grabbed from session.appInfo.sparkUiUrl if it exists, otherwise no link is created.

Screenshots

With an appId without link (in this case before the UI is generated):
![no-link](https://cloud.githubusercontent.com/assets/13952758/25873597/0307dd40-34c4-11e7-9993-925cbf7c749b.png)
With an appId link:
![link](https://cloud.githubusercontent.com/assets/13952758/25873599/0454c69a-34c4-11e7-85d2-31ebe993c5a3.png)
What it links to:
![spark](https://cloud.githubusercontent.com/assets/13952758/25873602/05864318-34c4-11e7-8e2c-2222ef7f6116.png)
