### PR TITLE
LIVY-365. Include statement code in statement object

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -914,6 +914,8 @@ A statement represents the result of an execution statement.
 +========+======================+=====================+
 | id     | The statement id     | integer             |
 +--------+----------------------+---------------------+
+| code   | The execution code   | string              |
++--------+----------------------+---------------------+
 | state  | The execution state  | statement state     |
 +--------+----------------------+---------------------+
 | output | The execution output | statement output    |

--- a/repl/src/main/scala/com/cloudera/livy/repl/Session.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/Session.scala
@@ -103,7 +103,7 @@ class Session(
 
   def execute(code: String): Int = {
     val statementId = newStatementId.getAndIncrement()
-    val statement = new Statement(statementId, StatementState.Waiting, null)
+    val statement = new Statement(statementId, code, StatementState.Waiting, null)
     _statements.synchronized { _statements(statementId) = statement }
 
     Future {

--- a/rsc/src/main/java/com/cloudera/livy/rsc/driver/Statement.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/driver/Statement.java
@@ -23,20 +23,22 @@ import com.fasterxml.jackson.annotation.JsonRawValue;
 
 public class Statement {
   public final Integer id;
+  public final String code;
   public final AtomicReference<StatementState> state;
   @JsonRawValue
   public volatile String output;
   public double progress;
 
-  public Statement(Integer id, StatementState state, String output) {
+  public Statement(Integer id, String code, StatementState state, String output) {
     this.id = id;
+    this.code = code;
     this.state = new AtomicReference<>(state);
     this.output = output;
     this.progress = 0.0;
   }
 
   public Statement() {
-    this(null, null, null);
+    this(null, null, null, null);
   }
 
   public boolean compareAndTransit(final StatementState from, final StatementState to) {

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
@@ -69,10 +69,7 @@ class InteractiveSessionServletSpec extends BaseInteractiveServletSpec {
         new Answer[Statement]() {
           override def answer(args: InvocationOnMock): Statement = {
             val id = statementCounter.getAndIncrement
-            val statement = new Statement(
-              id,
-              StatementState.Available,
-              "1")
+            val statement = new Statement(id, "1+1", StatementState.Available, "1")
 
             statements :+= statement
             statement
@@ -82,7 +79,7 @@ class InteractiveSessionServletSpec extends BaseInteractiveServletSpec {
         new Answer[Unit] {
           override def answer(args: InvocationOnMock): Unit = {
             statements = IndexedSeq(
-              new Statement(statementCounter.get(), StatementState.Cancelled, null))
+              new Statement(statementCounter.get(), null, StatementState.Cancelled, null))
           }
         }
       )
@@ -121,6 +118,7 @@ class InteractiveSessionServletSpec extends BaseInteractiveServletSpec {
 
     jpost[Map[String, Any]]("/0/statements", ExecuteRequest("foo")) { data =>
       data("id") should be (0)
+      data("code") should be "1+1"
       data("progress") should be (0.0)
       data("output") shouldBe 1
     }

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
@@ -118,7 +118,7 @@ class InteractiveSessionServletSpec extends BaseInteractiveServletSpec {
 
     jpost[Map[String, Any]]("/0/statements", ExecuteRequest("foo")) { data =>
       data("id") should be (0)
-      data("code") should be "1+1"
+      data("code") shouldBe "1+1"
       data("progress") should be (0.0)
       data("output") shouldBe 1
     }


### PR DESCRIPTION
PR moved from old repo https://github.com/cloudera/livy/pull/339

[LIVY-365](https://issues.cloudera.org/browse/LIVY-365)

Based on a user list request and my work on the Livy Web UI including the code that was run in the statement return is useful. Currently there is no way for a user to check what code was run through the Livy REST API. This will be helpful when the Session Page in the Web UI is added in [LIVY-343](https://issues.cloudera.org/browse/LIVY-343) which will include a table of statements. Currently such a table could only display output without context.

I choose to insert `code` between `id` and `state` because it does not change value during execution like `state` and `output`. Since it can also makes sense to include between `state` and `output` given the potential length of its value, I can make such a change if requested.

Tested manually and passes current Livy UTs and ITs