### PR TITLE
Minor. Fix travis build error due to unsupported oraclejdk7 in trusty container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - MVN_FLAG='-Pspark-2.1 -DskipITs'
 
 jdk:
-  - oraclejdk7
+  - openjdk7
 
 addons:
   apt:


### PR DESCRIPTION
Because of the [issue](https://github.com/travis-ci/travis-ci/issues/7019) in Travis build for oraclejdk7, so here propose to change to openjdk7.