### PR TITLE
[LIVY-360] The usage of livy-server description is not correct

### DIFF
--- a/bin/livy-server
+++ b/bin/livy-server
@@ -19,7 +19,7 @@
 # Runs Livy server.
 
 
-usage="Usage: livy-server (start|stop)"
+usage="Usage: livy-server (start|stop|status)"
 
 export LIVY_HOME=$(cd $(dirname $0)/.. && pwd)
 LIVY_CONF_DIR=${LIVY_CONF_DIR:-"$LIVY_HOME/conf"}


### PR DESCRIPTION
[https://issues.cloudera.org/browse/LIVY-360](https://issues.cloudera.org/browse/LIVY-360)
The description of the usage of livy-server contains the start and stop parameters, but missing status parameter.