### PR TITLE
[LIVY-361] If LIVY_PID_DIR contains space, stop livy-server failed

### DIFF
--- a/bin/livy-server
+++ b/bin/livy-server
@@ -144,7 +144,7 @@ case $option in
     ;;
 
   (stop)
-    if [ -f $pid ]; then
+    if [ -f "$pid" ]; then
       TARGET_ID="$(cat "$pid")"
       if [[ $(ps -p "$TARGET_ID" -o comm=) =~ "java" ]]; then
         echo "stopping livy-server"


### PR DESCRIPTION
[https://issues.cloudera.org/browse/LIVY-361](https://issues.cloudera.org/browse/LIVY-361)
There is an error in cheking pid file existence while stop livy-server. If LIVY_PID_DIR contains space, It is unable to get the pid file within it, so stop livy-server failed.