### PR TITLE
[LIVY-364] livy-server writes one log file when set LIVY_MAX_LOG_FILE…

### DIFF
--- a/bin/livy-server
+++ b/bin/livy-server
@@ -49,6 +49,11 @@ pid="$LIVY_PID_DIR/livy-$LIVY_IDENT_STRING-server.pid"
 livy_rotate_log() {
   log=$1
   num=$LIVY_MAX_LOG_FILES
+
+  if [ $LIVY_MAX_LOG_FILES -lt 1 ]; then
+    num=5
+  fi
+
   if [ -f "$log" ]; then # rotate logs
 	while [ $num -gt 1 ]; do
 	  prev=`expr $num - 1`


### PR DESCRIPTION
[https://issues.cloudera.org/browse/LIVY-364](https://issues.cloudera.org/browse/LIVY-364)
When set LIVY_MAX_LOG_FILES to 0, livy-server renames old log file to livy-root-server.out.0 while startup. So there has one log file which is inconsistent with LIVY_MAX_LOG_FILES value 0.