### PR TITLE
Minor. Fix deprecated conf warning log issue

### DIFF
--- a/client-common/src/main/java/org/apache/livy/client/common/ClientConf.java
+++ b/client-common/src/main/java/org/apache/livy/client/common/ClientConf.java
@@ -17,10 +17,7 @@
 
 package org.apache.livy.client.common;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -213,11 +210,11 @@ public abstract class ClientConf<T extends ClientConf>
 
   /** Logs a warning message if the given config key is deprecated. */
   private void logDeprecationWarning(String key) {
-    DeprecatedConf altConfs = getConfigsWithAlternatives().get(key);
-    if (altConfs != null) {
-      LOG.warn("The configuration key " + altConfs.key() + " has been deprecated as of Livy "
-        + altConfs.version() + " and may be removed in the future. Please use the new key "
-        + key + " instead.");
+    ConfPair altConf = allAlternativeKeys().get(key);
+    if (altConf != null) {
+      LOG.warn("The configuration key " + key + " has been deprecated as of Livy "
+        + altConf.depConf.version() + " and may be removed in the future. Please use the new key "
+        + altConf.newKey + " instead.");
       return;
     }
 
@@ -234,6 +231,33 @@ public abstract class ClientConf<T extends ClientConf>
 
   /** Maps deprecated key to DeprecatedConf with the same key. */
   protected abstract Map<String, DeprecatedConf> getDeprecatedConfigs();
+
+  private static class ConfPair {
+    final String newKey;
+    final DeprecatedConf depConf;
+
+    ConfPair(String key, DeprecatedConf conf) {
+      this.newKey = key;
+      this.depConf = conf;
+    }
+  }
+  private volatile Map<String, ConfPair> altToNewKeyMap = null;
+
+  private Map<String, ConfPair> allAlternativeKeys() {
+    if (altToNewKeyMap == null) {
+      synchronized (this) {
+        if (altToNewKeyMap == null) {
+          Map<String, ConfPair> configs = new HashMap<>();
+          for (String e : getConfigsWithAlternatives().keySet()) {
+            DeprecatedConf depConf = getConfigsWithAlternatives().get(e);
+            configs.put(depConf.key(), new ConfPair(e, depConf));
+          }
+          altToNewKeyMap = Collections.unmodifiableMap(configs);
+        }
+      }
+    }
+    return altToNewKeyMap;
+  }
 
   public static interface DeprecatedConf {
 


### PR DESCRIPTION
```
./livy-sshao-server.out.5:17/05/08 16:50:44 WARN LivyConf: The configuration key livy.spark.deployMode has been deprecated as of Livy 0.4 and may be removed in the future. Please use the new key livy.spark.deploy-mode instead.
./livy-sshao-server.out.5:17/05/08 16:50:45 WARN LivyConf: The configuration key livy.spark.scalaVersion has been deprecated as of Livy 0.4 and may be removed in the future. Please use the new key livy.spark.scala-version instead.
./livy-sshao-server.out.5:17/05/08 16:51:04 WARN RSCConf: The configuration key livy.rsc.driver_class has been deprecated as of Livy 0.4 and may be removed in the future. Please use the new key livy.rsc.driver-class instead.
```

This log is incorrect even if we use new configuration key. This is mainly because the logic in logDeprecationWarning to check alternative configurations is not correct.