### PR TITLE
[LIVY-381] Bump supported Spark version to 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   - MVN_FLAG='-Pspark-2.2 -DskipITs'
 
 jdk:
-  - openjdk8
+  - oraclejdk8
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,11 @@ env:
   - MVN_FLAG='-Pspark-1.6 -DskipTests'
   - MVN_FLAG='-Pspark-2.0 -DskipTests'
   - MVN_FLAG='-Pspark-2.1 -DskipTests'
+  - MVN_FLAG='-Pspark-2.2 -DskipTests'
   - MVN_FLAG='-Pspark-1.6 -DskipITs'
   - MVN_FLAG='-Pspark-2.0 -DskipITs'
   - MVN_FLAG='-Pspark-2.1 -DskipITs'
+  - MVN_FLAG='-Pspark-2.2 -DskipITs'
 
 jdk:
   - openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   - MVN_FLAG='-Pspark-2.2 -DskipITs'
 
 jdk:
-  - openjdk7
+  - openjdk8
 
 addons:
   apt:

--- a/pom.xml
+++ b/pom.xml
@@ -1024,6 +1024,18 @@
     </profile>
 
     <profile>
+      <id>spark-2.2</id>
+      <activation>
+        <property>
+          <name>spark-2.2</name>
+        </property>
+      </activation>
+      <properties>
+        <spark.version>2.2.0</spark.version>
+      </properties>
+    </profile>
+
+    <profile>
       <id>skip-parent-modules</id>
       <activation>
         <file>

--- a/server/src/main/scala/org/apache/livy/utils/LivySparkUtils.scala
+++ b/server/src/main/scala/org/apache/livy/utils/LivySparkUtils.scala
@@ -30,6 +30,8 @@ object LivySparkUtils extends Logging {
   // For each Spark version we supported, we need to add this mapping relation in case Scala
   // version cannot be detected from "spark-submit --version".
   private val _defaultSparkScalaVersion = SortedMap(
+    // Spark 2.2 + Scala 2.11
+    (2, 2) -> "2.11",
     // Spark 2.1 + Scala 2.11
     (2, 1) -> "2.11",
     // Spark 2.0 + Scala 2.11
@@ -40,7 +42,7 @@ object LivySparkUtils extends Logging {
 
   // Supported Spark version
   private val MIN_VERSION = (1, 6)
-  private val MAX_VERSION = (2, 2)
+  private val MAX_VERSION = (2, 3)
 
   private val sparkVersionRegex = """version (.*)""".r.unanchored
   private val scalaVersionRegex = """Scala version (.*), Java""".r.unanchored

--- a/server/src/test/scala/org/apache/livy/utils/LivySparkUtilsSuite.scala
+++ b/server/src/test/scala/org/apache/livy/utils/LivySparkUtilsSuite.scala
@@ -61,6 +61,7 @@ class LivySparkUtilsSuite extends FunSuite with Matchers with LivyBaseUnitTestSu
     testSparkVersion("2.0")
     testSparkVersion("2.1.0")
     testSparkVersion("2.1.1")
+    testSparkVersion("2.2.0")
   }
 
   test("should not support Spark older than 1.6") {
@@ -136,5 +137,6 @@ class LivySparkUtilsSuite extends FunSuite with Matchers with LivyBaseUnitTestSu
     sparkScalaVersion(formatSparkVersion("2.0.0"), None, livyConf) shouldBe "2.11"
     sparkScalaVersion(formatSparkVersion("2.0.1"), None, livyConf) shouldBe "2.11"
     sparkScalaVersion(formatSparkVersion("2.1.0"), None, livyConf) shouldBe "2.11"
+    sparkScalaVersion(formatSparkVersion("2.2.0"), None, livyConf) shouldBe "2.11"
   }
 }


### PR DESCRIPTION
Spark 2.2 has been released. It's better for us to update the max version supported.