### PR TITLE
[MINOR] Fix some potential security leak issue

### DIFF
--- a/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
@@ -331,7 +331,7 @@ public class RSCClient implements LivyClient {
 
         @Override
         public void onFailure(Throwable error) throws Exception {
-          error.printStackTrace();
+          LOG.error("RPC error.", error);
           promise.tryFailure(error);
         }
       });

--- a/rsc/src/main/java/org/apache/livy/rsc/driver/RSCDriverBootstrapper.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/driver/RSCDriverBootstrapper.java
@@ -17,6 +17,7 @@
 
 package org.apache.livy.rsc.driver;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -47,7 +48,13 @@ public final class RSCDriverBootstrapper {
 
     case 1:
       props = new Properties();
-      Reader r = new InputStreamReader(new FileInputStream(args[0]), UTF_8);
+      File propertyFile = new File(args[0]);
+      String fileName = propertyFile.getName();
+      if (!fileName.startsWith("livyConf") && fileName.endsWith("properties")) {
+        throw new IllegalArgumentException("File name " + fileName + "is not a legal file name.");
+      }
+
+      Reader r = new InputStreamReader(new FileInputStream(propertyFile), UTF_8);
       try {
         props.load(r);
       } finally {

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -157,7 +157,6 @@ class InteractiveSessionServlet(
       Created(new JobStatus(jobId, JobHandle.State.SENT, null, null))
       } catch {
         case e: Throwable =>
-          e.printStackTrace()
         throw e
       }
     }


### PR DESCRIPTION
Fix two potential security leak issue based on the security code scan:

1. Add file name checking code in `RSCDriverBootstrapper`'s main method argument to avoid malicious file.
2. Avoid dumping exception stack to output.

CC @yanboliang @zjffdu please help to review.