### PR TITLE
[LIVY-390][BUILD] Only using JDK8 to build with Spark 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,25 @@ dist: trusty
 language: scala
 
 env:
-  - MVN_FLAG='-Pspark-1.6 -DskipTests'
-  - MVN_FLAG='-Pspark-2.0 -DskipTests'
-  - MVN_FLAG='-Pspark-2.1 -DskipTests'
-  - MVN_FLAG='-Pspark-2.2 -DskipTests'
-  - MVN_FLAG='-Pspark-1.6 -DskipITs'
-  - MVN_FLAG='-Pspark-2.0 -DskipITs'
-  - MVN_FLAG='-Pspark-2.1 -DskipITs'
-  - MVN_FLAG='-Pspark-2.2 -DskipITs'
+  matrix:
+    - MVN_FLAG='-Pspark-1.6 -DskipTests'
+    - MVN_FLAG='-Pspark-2.0 -DskipTests'
+    - MVN_FLAG='-Pspark-2.1 -DskipTests'
+    - MVN_FLAG='-Pspark-1.6 -DskipITs'
+    - MVN_FLAG='-Pspark-2.0 -DskipITs'
+    - MVN_FLAG='-Pspark-2.1 -DskipITs'
+
+matrix:
+  include:
+      # Spark 2.2 will only be verified using JDK8
+    - env: MVN_FLAG='-Pspark-2.2 -DskipTests'
+      jdk: oraclejdk8
+    - env: MVN_FLAG='-Pspark-2.2 -DskipITs'
+      jdk: oraclejdk8
+
 
 jdk:
-  - oraclejdk8
+  - openjdk7
 
 addons:
   apt:

--- a/pom.xml
+++ b/pom.xml
@@ -1027,6 +1027,7 @@
       </activation>
       <properties>
         <spark.version>2.2.0</spark.version>
+        <java.version>1.8</java.version>
       </properties>
     </profile>
 


### PR DESCRIPTION
Because Spark 2.2 removes JDK7 support but Livy still supports JDK7, so updating travis file to use JDK8 to build against Spark 2.2, whereas still using JDK7 to build with Spark 2.2-.