### PR TITLE
[LIVY-389][BUILD] Add maven plugin to generate license for all the dependencies

### DIFF
--- a/assembly/assembly.xml
+++ b/assembly/assembly.xml
@@ -37,6 +37,7 @@
         <include>LICENSE</include>
         <include>NOTICE</include>
         <include>DISCLAIMER</include>
+        <include>THIRD-PARTY</include>
       </includes>
     </fileSet>
     <fileSet>

--- a/dev/third-party-file.ftl
+++ b/dev/third-party-file.ftl
@@ -1,0 +1,65 @@
+<#--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<#function artifactFormat p>
+  <#if p.name?index_of('Unnamed') &gt; -1>
+    <#return p.artifactId + " (" + p.groupId + ":" + p.artifactId + ":" + p.version + " - " + (p.url!"no url defined") + ")">
+  <#else>
+    <#return p.name + " (" + p.groupId + ":" + p.artifactId + ":" + p.version + " - " + (p.url!"no url defined") + ")">
+ </#if>
+</#function>
+
+<#if licenseMap?size == 0>
+The project has no dependencies.
+<#else>
+
+===============================================================================
+
+APACHE LIVY SUBCOMPONENTS:
+
+The Apache Livy binary distribution includes a number of subcomponents
+with separate copyright notices and license terms. Your use of the
+code for the these subcomponents is subject to the terms and
+conditions of the following licenses.
+
+===============================================================================
+
+We have listed all of these third party libraries and their licenses
+below. This file can be regenerated at any time by simply running:
+
+    mvn clean package
+
+---------------------------------------------------
+Third party Java libraries listed by License type.
+
+PLEASE NOTE: Some dependencies may be listed under multiple licenses if they
+are dual-licensed. This is especially true of anything listed as
+"GNU General Public Library" below.
+---------------------------------------------------
+  <#list licenseMap as e>
+    <#assign license = e.getKey()/>
+    <#assign projects = e.getValue()/>
+    <#if projects?size &gt; 0>
+
+  ${license}:
+
+    <#list projects as project>
+    * ${artifactFormat(project)}
+    </#list>
+    </#if>
+  </#list>
+</#if>

--- a/pom.xml
+++ b/pom.xml
@@ -778,6 +778,12 @@
           <version>1.5</version>
         </plugin>
 
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>1.13</version>
+        </plugin>
+
       </plugins>
     </pluginManagement>
 
@@ -1031,6 +1037,26 @@
                 <resourceBundle>org.apache.apache.resources:apache-incubator-disclaimer-resource-bundle:1.2-SNAPSHOT</resourceBundle>
               </resourceBundles>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <inherited>false</inherited>
+        <configuration>
+          <outputDirectory>${execution.root}</outputDirectory>
+          <thirdPartyFilename>THIRD-PARTY</thirdPartyFilename>
+          <sortArtifactByName>true</sortArtifactByName>
+          <fileTemplate>${execution.root}/dev/third-party-file.ftl</fileTemplate>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>aggregate-add-third-party</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
This change will generate a THIRD-PARTY file with license of all dependencies in `${execution.root}` folder, and will copy it to release assembly's root dir.

@lresende @ajbozarth can you please review the current solution, is it OK for an Apache way.

Here is the snippet of this THIRD-PARTY file:

```
===============================================================================

APACHE LIVY SUBCOMPONENTS:

The Apache Livy binary distribution includes a number of subcomponents
with separate copyright notices and license terms. Your use of the
code for the these subcomponents is subject to the terms and
conditions of the following licenses.

===============================================================================

We have listed all of these third party libraries and their licenses
below. This file can be regenerated at any time by simply running:

    mvn clean package

---------------------------------------------------
Third party Java libraries listed by License type.

PLEASE NOTE: Some dependencies may be listed under multiple licenses if they
are dual-licensed. This is especially true of anything listed as
"GNU General Public Library" below.
---------------------------------------------------

  ASL:

    * json4s-ast (org.json4s:json4s-ast_2.10:3.2.10 - https://github.com/json4s/json4s)
    * json4s-core (org.json4s:json4s-core_2.10:3.2.10 - https://github.com/json4s/json4s)
    * json4s-jackson (org.json4s:json4s-jackson_2.10:3.2.10 - https://github.com/json4s/json4s)

  Apache 2:

    * Apache Derby Database Engine and Embedded JDBC Driver (org.apache.derby:derby:10.10.2.0 - http://db.apache.org/derby/derby/)
    * JDO API (javax.jdo:jdo-api:3.0.1 - http://db.apache.org/jdo)
    * JavaEWAH (com.googlecode.javaewah:JavaEWAH:0.3.2 - http://code.google.com/p/javaewah/)
    * Joda-Convert (org.joda:joda-convert:1.6 - http://www.joda.org/joda-convert/)
    * Joda-Time (joda-time:joda-time:2.3 - http://www.joda.org/joda-time/)
    * Objenesis (org.objenesis:objenesis:1.2 - http://objenesis.googlecode.com/svn/docs/index.html)
    * RoaringBitmap (org.roaringbitmap:RoaringBitmap:0.5.11 - https://github.com/lemire/RoaringBitmap)
    * breeze (org.scalanlp:breeze_2.10:0.11.2 - http://scalanlp.org/)
    * breeze-macros (org.scalanlp:breeze-macros_2.10:0.11.2 - http://scalanlp.org/)
    * chill (com.twitter:chill_2.10:0.5.0 - https://github.com/twitter/chill)
    * chill-java (com.twitter:chill-java:0.5.0 - https://github.com/twitter/chill)
    * metrics-scala (nl.grons:metrics-scala_2.10:3.3.0_a2.3 - https://github.com/erikvanoosten/metrics-scala)
    * opencsv (net.sf.opencsv:opencsv:2.3 - http://opencsv.sf.net)
    * scala-ssh (com.decodified:scala-ssh_2.10:0.7.0 - https://github.com/sirthias/scala-ssh)
    * sshj (net.schmizz:sshj:0.10.0 - http://github.com/shikhar/sshj)

  Apache 2.0 License:

    * Spark Project Bagel (org.apache.spark:spark-bagel_2.10:1.6.2 - http://spark.apache.org/)
    * Spark Project Catalyst (org.apache.spark:spark-catalyst_2.10:1.6.2 - http://spark.apache.org/)
    * Spark Project Core (org.apache.spark:spark-core_2.10:1.6.2 - http://spark.apache.org/)
    * Spark Project GraphX (org.apache.spark:spark-graphx_2.10:1.6.2 - http://spark.apache.org/)
    * Spark Project Hive (org.apache.spark:spark-hive_2.10:1.6.2 - http://spark.apache.org/)
    * Spark Project Launcher (org.apache.spark:spark-launcher_2.10:1.6.2 - http://spark.apache.org/)
    * Spark Project ML Library (org.apache.spark:spark-mllib_2.10:1.6.2 - http://spark.apache.org/)
    * Spark Project Networking (org.apache.spark:spark-network-common_2.10:1.6.2 - http://spark.apache.org/)
    * Spark Project REPL (org.apache.spark:spark-repl_2.10:1.6.2 - http://spark.apache.org/)
    * Spark Project SQL (org.apache.spark:spark-sql_2.10:1.6.2 - http://spark.apache.org/)
    * Spark Project Shuffle Streaming Service (org.apache.spark:spark-network-shuffle_2.10:1.6.2 - http://spark.apache.org/)
    * Spark Project Streaming (org.apache.spark:spark-streaming_2.10:1.6.2 - http://spark.apache.org/)
    * Spark Project Unsafe (org.apache.spark:spark-unsafe_2.10:1.6.2 - http://spark.apache.org/)
    * Spark Project YARN (org.apache.spark:spark-yarn_2.10:1.6.2 - http://spark.apache.org/spark-yarn_2.10/)

  Apache License:

    * HttpClient (commons-httpclient:commons-httpclient:3.1 - http://jakarta.apache.org/httpcomponents/httpclient-3.x/)
    * Tachyon Clients - Distribution (org.tachyonproject:tachyon-client:0.8.2 - http://tachyon-project.org/tachyon-clients/tachyon-client/)
    * Tachyon Under File System - HDFS (org.tachyonproject:tachyon-underfs-hdfs:0.8.2 - http://tachyon-project.org/tachyon-underfs/tachyon-underfs-hdfs/)
    * Tachyon Under File System - Local FS (org.tachyonproject:tachyon-underfs-local:0.8.2 - http://tachyon-project.org/tachyon-underfs/tachyon-underfs-local/)
    * Tachyon Under File System - S3 (org.tachyonproject:tachyon-underfs-s3:0.8.2 - http://tachyon-project.org/tachyon-underfs/tachyon-underfs-s3/)
```
