### PR TITLE
[LIVY-389][BUILD][FOLLOWUP] Enable generating third-party license by profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1041,26 +1041,6 @@
         </executions>
       </plugin>
 
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>license-maven-plugin</artifactId>
-        <inherited>false</inherited>
-        <configuration>
-          <outputDirectory>${execution.root}</outputDirectory>
-          <thirdPartyFilename>THIRD-PARTY</thirdPartyFilename>
-          <sortArtifactByName>true</sortArtifactByName>
-          <fileTemplate>${execution.root}/dev/third-party-file.ftl</fileTemplate>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>aggregate-add-third-party</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
     </plugins>
 
   </build>
@@ -1158,6 +1138,40 @@
         </plugins>
       </build>
     </profile>
+
+  <profile>
+    <!-- This will search remote and local repos to generate THIRD-PARTY license file, make sure
+    livy artifacts existed in either remote or local repos, otherwise run mvn install before. -->
+    <id>generate-third-party</id>
+    <activation>
+      <property>
+        <name>generate-third-party</name>
+      </property>
+    </activation>
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <inherited>false</inherited>
+          <configuration>
+            <outputDirectory>${execution.root}</outputDirectory>
+            <thirdPartyFilename>THIRD-PARTY</thirdPartyFilename>
+            <sortArtifactByName>true</sortArtifactByName>
+            <fileTemplate>${execution.root}/dev/third-party-file.ftl</fileTemplate>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>prepare-package</phase>
+              <goals>
+                <goal>aggregate-add-third-party</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+  </profile>
 
   </profiles>
 


### PR DESCRIPTION
Move `license-maven-plugin` to a specific profile which can only be enabled by `-Dlicense-maven-plugin` to avoid generating every time in packaging.
