### PR TITLE
[LIVY-393] [Minor] Update httpclient to 4.5.3

### DIFF
--- a/client-http/pom.xml
+++ b/client-http/pom.xml
@@ -66,12 +66,12 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.1</version>
+      <version>${httpclient.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
-      <version>4.4.4</version>
+      <version>${httpcore.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <hadoop.scope>compile</hadoop.scope>
     <spark.version>1.6.2</spark.version>
     <commons-codec.version>1.9</commons-codec.version>
-    <httpclient.version>4.5.2</httpclient.version>
+    <httpclient.version>4.5.3</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>
     <jackson.version>2.4.4</jackson.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>


### PR DESCRIPTION
Currently the httpclient version in the root pom is 4.5.2 and in the client-http module it is 4.5.1

Now both use a common version and it's been updated to the latest version 4.5.3