### PR TITLE
[MINOR] Disable hive in integration test

### DIFF
--- a/integration-test/src/main/scala/org/apache/livy/test/framework/MiniCluster.scala
+++ b/integration-test/src/main/scala/org/apache/livy/test/framework/MiniCluster.scala
@@ -170,7 +170,7 @@ object MiniLivyMain extends MiniClusterBase {
 
     val server = new LivyServer()
     server.start()
-    server.livyConf.set(LivyConf.ENABLE_HIVE_CONTEXT, true)
+    server.livyConf.set(LivyConf.ENABLE_HIVE_CONTEXT, false)
     // Write a serverUrl.conf file to the conf directory with the location of the Livy
     // server. Do it atomically since it's used by MiniCluster to detect when the Livy server
     // is up and ready.


### PR DESCRIPTION
Straightforward change to disable hive in integration test, because there's no hive related setup in integration test, (no hive-site.xml and no datanulear jars uploaded)