### PR TITLE
[WIP]: [Livy-336]: Livy should not spawn one thread per job to track the job on Yarn (Use YARN REST API)

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -110,7 +110,8 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <scope>test</scope>
+      <version>${httpclient.version}</version>
+      <scope>compile</scope>
     </dependency>
 
     <dependency>

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -122,6 +122,21 @@ object LivyConf {
   // Livy will cache the max no of logs specified. 0 means don't cache the logs.
   val SPARK_LOGS_SIZE = Entry("livy.cache-log.size", 200)
 
+  // The resource manager address for YARN's REST API.
+  val YARN_REST_SCHEMA = Entry("livy.server.yarn.rest.schema", "http")
+
+  // The resource manager address for YARN's REST API.
+  val YARN_REST_HOST = Entry("livy.server.yarn.rest.host", "localhost")
+
+  // The resource manager port for YARN's REST API.
+  val YARN_REST_PORT = Entry("livy.server.yarn.rest.port", 0)
+
+  // The resource manager port for YARN's REST API.
+  val YARN_REST_PATH = Entry("livy.server.yarn.rest.path", "/ws/v1/cluster/apps")
+
+  // The limit to the number of application reports to get on each REST call from YARN RM.
+  val YARN_REST_REPORTS_LIMIT = Entry("livy.server.yarn.resource-manager.report-limit", 100000)
+
   // If Livy can't find the yarn app within this time, consider it lost.
   val YARN_APP_LOOKUP_TIMEOUT = Entry("livy.server.yarn.app-lookup-timeout", "60s")
 

--- a/server/src/main/scala/org/apache/livy/server/LivyServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/LivyServer.scala
@@ -22,9 +22,6 @@ import java.util.concurrent._
 import java.util.EnumSet
 import javax.servlet._
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-
 import org.apache.hadoop.security.{SecurityUtil, UserGroupInformation}
 import org.apache.hadoop.security.authentication.server._
 import org.eclipse.jetty.servlet.FilterHolder
@@ -40,9 +37,8 @@ import org.apache.livy.server.recovery.{SessionStore, StateStore}
 import org.apache.livy.server.ui.UIServlet
 import org.apache.livy.sessions.{BatchSessionManager, InteractiveSessionManager}
 import org.apache.livy.sessions.SessionManager.SESSION_RECOVERY_MODE_OFF
-import org.apache.livy.utils.{SparkApp, SparkYarnApp, YarnInterface}
+import org.apache.livy.utils.{SparkApp, YarnInterface}
 import org.apache.livy.utils.LivySparkUtils._
-import org.apache.livy.utils.SparkYarnApp
 
 class LivyServer extends Logging {
 
@@ -122,7 +118,8 @@ class LivyServer extends Logging {
 
     // Initialize YarnClient ASAP to save time.
     if (livyConf.isRunningOnYarn()) {
-      val yarnInterface = new YarnInterface(livyConf, YarnInterface.yarnClient)
+      val yarnInterface = new YarnInterface(livyConf,
+        YarnInterface.yarnClient, YarnInterface.httpClient)
       SparkApp.withYarnInterFace(yarnInterface)
     }
 

--- a/server/src/main/scala/org/apache/livy/server/LivyServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/LivyServer.scala
@@ -40,6 +40,7 @@ import org.apache.livy.server.recovery.{SessionStore, StateStore}
 import org.apache.livy.server.ui.UIServlet
 import org.apache.livy.sessions.{BatchSessionManager, InteractiveSessionManager}
 import org.apache.livy.sessions.SessionManager.SESSION_RECOVERY_MODE_OFF
+import org.apache.livy.utils.{SparkApp, SparkYarnApp, YarnInterface}
 import org.apache.livy.utils.LivySparkUtils._
 import org.apache.livy.utils.SparkYarnApp
 
@@ -121,8 +122,8 @@ class LivyServer extends Logging {
 
     // Initialize YarnClient ASAP to save time.
     if (livyConf.isRunningOnYarn()) {
-      SparkYarnApp.init(livyConf)
-      Future { SparkYarnApp.yarnClient }
+      val yarnInterface = new YarnInterface(livyConf, YarnInterface.yarnClient)
+      SparkApp.withYarnInterFace(yarnInterface)
     }
 
     StateStore.init(livyConf)

--- a/server/src/main/scala/org/apache/livy/utils/ApplicationReport.scala
+++ b/server/src/main/scala/org/apache/livy/utils/ApplicationReport.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.utils
+
+/**
+  * A case class to keep all Application data that we get form YARN.
+  */
+case class ApplicationReport(
+                              id: String,
+                              name: String,
+                              user: String,
+                              applicationTags: Option[String],
+                              applicationType: String,
+//                              clusterId: Long,
+//                              clusterUsagePercentage: Float,
+                              diagnostics: String,
+                              elapsedTime: Long,
+                              finalStatus: String,
+                              finishedTime: Long,
+                              amContainerLogs: Option[String],
+//                              logAggregationStatus: String,
+//                              priority: Int,
+//                              progress: Float,
+                              queue: String,
+//                              runningContainers: Int,
+                              startedTime: Long,
+                              state: String,
+                              trackingUI: Option[String],
+                              trackingUrl: Option[String]
+                            )

--- a/server/src/main/scala/org/apache/livy/utils/SparkYarnApp.scala
+++ b/server/src/main/scala/org/apache/livy/utils/SparkYarnApp.scala
@@ -16,20 +16,15 @@
  */
 package org.apache.livy.utils
 
-import java.util.concurrent.TimeoutException
-
-import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.language.postfixOps
-import scala.util.Try
 
-import org.apache.hadoop.yarn.api.records.{ApplicationId, ApplicationReport, FinalApplicationStatus, YarnApplicationState}
+import org.apache.hadoop.yarn.api.records.{ApplicationId, FinalApplicationStatus, YarnApplicationState}
 import org.apache.hadoop.yarn.client.api.YarnClient
 import org.apache.hadoop.yarn.conf.YarnConfiguration
-import org.apache.hadoop.yarn.exceptions.ApplicationAttemptNotFoundException
 import org.apache.hadoop.yarn.util.ConverterUtils
 
 import org.apache.livy.{LivyConf, Logging, Utils}
@@ -111,17 +106,20 @@ object SparkYarnApp extends Logging {
  * @param listener Optional listener for notification of appId discovery and app state changes.
  */
 class SparkYarnApp private[utils] (
-    appTag: String,
-    appIdOption: Option[String],
-    process: Option[LineBufferedProcess],
-    listener: Option[SparkAppListener],
+    val appTag: String,
+    val appIdOption: Option[String],
+    val process: Option[LineBufferedProcess],
+    val listener: Option[SparkAppListener],
     livyConf: LivyConf,
-    yarnClient: => YarnClient = SparkYarnApp.yarnClient) // For unit test.
+    yarnInterface: YarnInterface)
   extends SparkApp
   with Logging {
-  import SparkYarnApp._
 
-  private val appIdPromise: Promise[ApplicationId] = Promise()
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  val appId: Future[ApplicationId] = Future {
+    appIdOption.fold(yarnInterface.getAppIdFromTag(appTag, process))(ConverterUtils.toApplicationId)
+  }
   private[utils] var state: SparkApp.State = SparkApp.State.STARTING
   private var yarnDiagnostics: IndexedSeq[String] = IndexedSeq.empty[String]
 
@@ -130,73 +128,20 @@ class SparkYarnApp private[utils] (
     ("\nstderr: " +: process.map(_.errorLines).getOrElse(ArrayBuffer.empty[String])) ++
     ("\nYARN Diagnostics: " +: yarnDiagnostics)
 
-  override def kill(): Unit = synchronized {
-    if (isRunning) {
-      try {
-        val timeout = SparkYarnApp.getYarnTagToAppIdTimeout(livyConf)
-        yarnClient.killApplication(Await.result(appIdPromise.future, timeout))
-      } catch {
-        // We cannot kill the YARN app without the app id.
-        // There's a chance the YARN app hasn't been submitted during a livy-server failure.
-        // We don't want a stuck session that can't be deleted. Emit a warning and move on.
-        case _: TimeoutException | _: InterruptedException =>
-          warn("Deleting a session while its YARN application is not found.")
-          yarnAppMonitorThread.interrupt()
-      } finally {
-        process.foreach(_.destroy())
-      }
-    }
-  }
+  override def kill(): Unit = yarnInterface.kill(this)
 
-  private def changeState(newState: SparkApp.State.Value): Unit = {
+  private[utils] def changeState(newState: SparkApp.State.Value): Unit = {
     if (state != newState) {
       listener.foreach(_.stateChanged(state, newState))
       state = newState
     }
   }
 
-  /**
-   * Find the corresponding YARN application id from an application tag.
-   *
-   * @param appTag The application tag tagged on the target application.
-   *               If the tag is not unique, it returns the first application it found.
-   *               It will be converted to lower case to match YARN's behaviour.
-   * @return ApplicationId or the failure.
-   */
-  @tailrec
-  private def getAppIdFromTag(
-      appTag: String,
-      pollInterval: Duration,
-      deadline: Deadline): ApplicationId = {
-    val appTagLowerCase = appTag.toLowerCase()
-
-    // FIXME Should not loop thru all YARN applications but YarnClient doesn't offer an API.
-    // Consider calling rmClient in YarnClient directly.
-    yarnClient.getApplications(appType).asScala.find(_.getApplicationTags.contains(appTagLowerCase))
-    match {
-      case Some(app) => app.getApplicationId
-      case None =>
-        if (deadline.isOverdue) {
-          process.foreach(_.destroy())
-          leakedAppTags.put(appTag, System.currentTimeMillis())
-          throw new Exception(s"No YARN application is found with tag $appTagLowerCase in " +
-            livyConf.getTimeAsMs(LivyConf.YARN_APP_LOOKUP_TIMEOUT)/1000 + " seconds. " +
-            "Please check your cluster status, it is may be very busy.")
-        } else {
-          Clock.sleep(pollInterval.toMillis)
-          getAppIdFromTag(appTagLowerCase, pollInterval, deadline)
-        }
-    }
+  def updateYarnDiagnostics(diag: IndexedSeq[String]): Unit = {
+    yarnDiagnostics = diag
   }
 
-  private def getYarnDiagnostics(appReport: ApplicationReport): IndexedSeq[String] = {
-    Option(appReport.getDiagnostics)
-      .filter(_.nonEmpty)
-      .map[IndexedSeq[String]](_.split("\n"))
-      .getOrElse(IndexedSeq.empty)
-  }
-
-  private def isRunning: Boolean = {
+  private[utils] def isRunning: Boolean = {
     state != SparkApp.State.FAILED && state != SparkApp.State.FINISHED &&
       state != SparkApp.State.KILLED
   }
@@ -226,86 +171,4 @@ class SparkYarnApp private[utils] (
     }
   }
 
-  // Exposed for unit test.
-  // TODO Instead of spawning a thread for every session, create a centralized thread and
-  // batch YARN queries.
-  private[utils] val yarnAppMonitorThread = Utils.startDaemonThread(s"yarnAppMonitorThread-$this") {
-    try {
-      // Wait for spark-submit to finish submitting the app to YARN.
-      process.foreach { p =>
-        val exitCode = p.waitFor()
-        if (exitCode != 0) {
-          throw new Exception(s"spark-submit exited with code $exitCode}.\n" +
-            s"${process.get.inputLines.mkString("\n")}")
-        }
-      }
-
-      // If appId is not known, query YARN by appTag to get it.
-      val appId = try {
-        appIdOption.map(ConverterUtils.toApplicationId).getOrElse {
-          val pollInterval = getYarnPollInterval(livyConf)
-          val deadline = getYarnTagToAppIdTimeout(livyConf).fromNow
-          getAppIdFromTag(appTag, pollInterval, deadline)
-        }
-      } catch {
-        case e: Exception =>
-          appIdPromise.failure(e)
-          throw e
-      }
-      appIdPromise.success(appId)
-
-      Thread.currentThread().setName(s"yarnAppMonitorThread-$appId")
-      listener.foreach(_.appIdKnown(appId.toString))
-
-      val pollInterval = SparkYarnApp.getYarnPollInterval(livyConf)
-      var appInfo = AppInfo()
-      while (isRunning) {
-        try {
-          Clock.sleep(pollInterval.toMillis)
-
-          // Refresh application state
-          val appReport = yarnClient.getApplicationReport(appId)
-          yarnDiagnostics = getYarnDiagnostics(appReport)
-          changeState(mapYarnState(
-            appReport.getApplicationId,
-            appReport.getYarnApplicationState,
-            appReport.getFinalApplicationStatus))
-
-          val latestAppInfo = {
-            val attempt =
-              yarnClient.getApplicationAttemptReport(appReport.getCurrentApplicationAttemptId)
-            val driverLogUrl =
-              Try(yarnClient.getContainerReport(attempt.getAMContainerId).getLogUrl)
-                .toOption
-            AppInfo(driverLogUrl, Option(appReport.getTrackingUrl))
-          }
-
-          if (appInfo != latestAppInfo) {
-            listener.foreach(_.infoChanged(latestAppInfo))
-            appInfo = latestAppInfo
-          }
-        } catch {
-          // This exception might be thrown during app is starting up. It's transient.
-          case e: ApplicationAttemptNotFoundException =>
-          // Workaround YARN-4411: No enum constant FINAL_SAVING from getApplicationAttemptReport()
-          case e: IllegalArgumentException =>
-            if (e.getMessage.contains("FINAL_SAVING")) {
-              debug("Encountered YARN-4411.")
-            } else {
-              throw e
-            }
-        }
-      }
-
-      debug(s"$appId $state ${yarnDiagnostics.mkString(" ")}")
-    } catch {
-      case e: InterruptedException =>
-        yarnDiagnostics = ArrayBuffer("Session stopped by user.")
-        changeState(SparkApp.State.KILLED)
-      case e: Throwable =>
-        error(s"Error whiling refreshing YARN state: $e")
-        yarnDiagnostics = ArrayBuffer(e.toString, e.getStackTrace().mkString(" "))
-        changeState(SparkApp.State.FAILED)
-    }
-  }
 }

--- a/server/src/main/scala/org/apache/livy/utils/YarnInterface.scala
+++ b/server/src/main/scala/org/apache/livy/utils/YarnInterface.scala
@@ -1,0 +1,457 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.utils
+
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.collection.mutable.{Map => MutableMap}
+import scala.concurrent.blocking
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.util.{Failure, Success, Try}
+
+import org.apache.hadoop.yarn.api.records.{ApplicationId, ApplicationReport, ContainerReport}
+import org.apache.hadoop.yarn.client.api.YarnClient
+import org.apache.hadoop.yarn.conf.YarnConfiguration
+
+import org.apache.livy.{LivyConf, Logging, Utils}
+
+/**
+  * An interface to handle all interactions with Yarn.
+  */
+class YarnInterface(livyConf: LivyConf, yarnClient: YarnClient) extends Logging {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  import YarnInterface.appType
+
+  private val TIMEOUT_EXIT_CODE = -1
+
+  val sessionLeakageCheckTimeout = livyConf.getTimeAsMs(LivyConf.YARN_APP_LEAKAGE_CHECK_TIMEOUT)
+
+  val sessionLeakageCheckInterval = livyConf.getTimeAsMs(LivyConf.YARN_APP_LEAKAGE_CHECK_INTERVAL)
+
+  val yarnPollInterval = (livyConf.getTimeAsMs(LivyConf.YARN_POLL_INTERVAL) milliseconds)
+
+  val yarnTagToAppIdTimeout = livyConf.getTimeAsMs(LivyConf.YARN_APP_LOOKUP_TIMEOUT) milliseconds
+
+  private var yarnApplicationReports = Map.empty[ApplicationReport, ContainerReport]
+
+  private var appTagToAppIdMap = Map.empty[String, Seq[ApplicationId]]
+
+  val isRunning: AtomicBoolean = new AtomicBoolean(true)
+
+  val lock = new Object
+
+  val appReportUpdater = Utils.startDaemonThread(s"yarnAppMonitorThread-$this") {
+    Try {
+      while (isRunning.get) {
+
+        debug(s"cleaning yarnApplicationReports. Currently it is ${
+          yarnApplicationReports.map { case (appReport, _) =>
+            appReport.getApplicationId
+          }.toSeq.sorted.mkString(",")
+        }")
+
+        val yarnApps = blocking(yarnClient.getApplications(appType).asScala)
+        debug(s"new yarn apps = ${
+          yarnApps.map(appReport =>
+            appReport.getApplicationId
+          ).sorted.mkString(",")
+        }")
+
+        val updatedAppTagToAppIdMap = MutableMap.empty[String, Seq[ApplicationId]]
+        val newYarnApplicationReports = yarnApps.map { appReport =>
+          appReport.getApplicationTags.asScala.map(_.toLowerCase).map { tag =>
+            val appIdsForTag = updatedAppTagToAppIdMap.get(tag).getOrElse(Seq[ApplicationId]())
+            if (!appIdsForTag.contains(appReport.getApplicationId)) {
+              updatedAppTagToAppIdMap.update(tag, appIdsForTag :+ appReport.getApplicationId)
+            }
+          }
+          val containerReport = Try {
+            appReport.getCurrentApplicationAttemptId
+          }.toOption.flatMap { attemptId =>
+            Try(yarnClient.getApplicationAttemptReport(attemptId)).toOption
+          }.flatMap { attempt =>
+            Try(attempt.getAMContainerId).toOption
+          }.flatMap { containerId =>
+            Try(yarnClient.getContainerReport(containerId)).toOption
+          }
+          (appReport, containerReport.getOrElse(null))
+        }.toMap
+        blocking {
+          lock.synchronized {
+            yarnApplicationReports = newYarnApplicationReports
+            appTagToAppIdMap = updatedAppTagToAppIdMap.toMap // to immutable map
+          }
+        }
+        debug(s"yarnAppMonitorThread is going to sleep for $yarnPollInterval")
+        Clock.sleep(yarnPollInterval.toMillis)
+      }
+    } match {
+      case Success(_) =>
+        debug("Yarn App Monitor thread executed successfully! It is shutting down now!")
+      case Failure(ex) =>
+        warn("Unhandled Exception in Yarn App Monitor:${ex.getMessage}!")
+        warn(ex.getStackTrace.mkString("\n"))
+    }
+  }
+
+  def getApplicationReport(appId: ApplicationId): Option[ApplicationReport] = {
+    blocking {
+      lock.synchronized {
+        yarnApplicationReports.find { case (appReport, _) =>
+          appReport.getApplicationId == appId
+        }.map { case (appReport, _) =>
+          appReport
+        }
+      }
+    }
+  }
+
+  /**
+    * Find the corresponding YARN application id from an application tag.
+    *
+    * @param appTag The application tag tagged on the target application.
+    *               If the tag is not unique, it returns the first application it found.
+    *               It will be converted to lower case to match YARN's behaviour.
+    * @return ApplicationId or the failure.
+    */
+  def getAppIdFromTag(
+                       appTag: String,
+                       process: Option[LineBufferedProcess]
+                     ): ApplicationId = {
+
+    val appTagLowerCase = appTag.toLowerCase()
+    val deadline = yarnTagToAppIdTimeout.fromNow
+    debug(s"Going to find the application id for tag $appTag")
+
+    @tailrec
+    def go(appTagLowerCase: String, deadLine: Deadline): ApplicationId = {
+      debug(s"recursively finding appId for tag $appTagLowerCase. Deadline is $deadline")
+
+
+      val taggedApps = blocking {
+        lock.synchronized {
+          appTagToAppIdMap.get(appTagLowerCase)
+        }
+      }
+
+      debug(s"all apps with tag: $appTagLowerCase = ${taggedApps.mkString(",")}")
+
+      taggedApps match {
+        case Some(Seq(applicationId)) =>
+          info(s"Found $applicationId for tag $appTagLowerCase.")
+          applicationId
+        case _ =>
+          debug(s"didn't find the any app with tag $appTagLowerCase... Trying again")
+          if (deadline.isOverdue) {
+            process.foreach(_.destroy())
+            leakedAppTags.put(appTag, System.currentTimeMillis())
+            val timeOut = yarnTagToAppIdTimeout / 1000
+            val errorMsg =
+              s"""No YARN application was found with tag $appTag in $timeOut seconds.
+                 |Please make sure you submitted your application correctly.
+                 |Also check your cluster status, it is may be very busy.""".stripMargin
+            throw new Exception(errorMsg)
+          } else {
+            debug(s"going to sleep for ${yarnPollInterval.toMillis} ms... before retry")
+            Clock.sleep(yarnPollInterval.toMillis)
+            go(appTagLowerCase, deadline)
+          }
+      }
+    }
+
+    go(appTagLowerCase, deadline)
+  }
+
+  @tailrec
+  private def waitFor(process: LineBufferedProcess, deadline: Deadline): Int = {
+
+    debug(s"waiting for process $process to exit within deadline $deadline")
+    if (!deadline.isOverdue()) {
+      Try {
+        process.exitValue()
+      } match {
+        case Success(exitValue) =>
+          info(s"process $process exited with exit  code $exitValue")
+          exitValue
+        case Failure(ex) =>
+          debug(s"process $process did not exit!... trying one more time...: ${ex.getMessage}")
+          Clock.sleep(yarnPollInterval.toMillis)
+          waitFor(process, deadline)
+      }
+    } else {
+      info(s"process $process did not exit withing the deadline ($deadline)... Giving up!")
+
+      TIMEOUT_EXIT_CODE
+    }
+  }
+
+  def onExit(process: LineBufferedProcess,
+             onSuccess: Int => Unit,
+             onFailure: Throwable => Unit): Future[Int] = {
+    val exitCodeFuture = Future {
+      val deadline = yarnTagToAppIdTimeout.fromNow
+      debug(s"Going to wait for process $process to exit")
+      waitFor(process, deadline)
+    }
+
+    exitCodeFuture.onComplete {
+      case Success(exitCode) if exitCode == 0 =>
+        info(s"process $process exit successfully")
+        onSuccess(exitCode)
+      case Success(exitCode) =>
+        info(s"process $process exit with exit code $exitCode")
+        val exception = new Exception("Failed to submit the job to YARN.")
+        onFailure(exception)
+      case Failure(ex) =>
+        info(s"process $process FAILED :${ex.getMessage}")
+        onFailure(ex)
+    }
+
+    exitCodeFuture
+  }
+
+  def killApplication(appId: ApplicationId): Unit = yarnClient.killApplication(appId)
+
+  private val leakedAppTags = new java.util.concurrent.ConcurrentHashMap[String, Long]()
+  private val leakedAppsGCThread = new Thread() {
+    override def run(): Unit = {
+      while (true) {
+        if (!leakedAppTags.isEmpty) {
+          // kill the app if found it and remove it if exceeding a threashold
+          val iter = leakedAppTags.entrySet().iterator()
+          var isRemoved = false
+          val now = System.currentTimeMillis()
+          val apps = yarnClient.getApplications(appType).asScala
+          while (iter.hasNext) {
+            val entry = iter.next()
+            apps.find(_.getApplicationTags.contains(entry.getKey))
+              .foreach { applicationReport: ApplicationReport =>
+                info(s"Kill leaked app ${applicationReport.getApplicationId}")
+                killApplication(applicationReport.getApplicationId)
+                iter.remove()
+                isRemoved = true
+              }
+            if (!isRemoved) {
+              if ((entry.getValue - now) > sessionLeakageCheckTimeout) {
+                iter.remove()
+                info(s"Remove leaked yarn app tag ${entry.getKey}")
+              }
+            }
+          }
+        }
+        Clock.sleep(sessionLeakageCheckInterval)
+      }
+    }
+  }
+  leakedAppsGCThread.setDaemon(true)
+  leakedAppsGCThread.setName("LeakedAppsGCThread")
+  leakedAppsGCThread.start()
+
+  def kill(app: SparkYarnApp): Unit = synchronized {
+    info(s"Going to kill app with tag ${app.appTag} and id ${app.appIdOption}")
+    if (app.isRunning) {
+      try {
+        info(s"App with tag ${app.appTag} and id ${app.appIdOption} is running. Go kill it...")
+        val killYarnAppFuture = app.appId.map { appIdToKill =>
+          Try {
+            blocking {
+              info(s"Calling kill on $app with tag ${app.appTag} and id ${app.appIdOption}..")
+              killApplication(appIdToKill)
+              info(s"Called kill on $app with tag ${app.appTag} and id ${app.appIdOption}!")
+              true
+            }
+          } match {
+            case Success(_) =>
+              true
+            case Failure(ex) =>
+              warn(s"Failed to kill app with appTag = ${app.appTag} appId = ${app.appId}.")
+              warn(ex.getStackTrace.mkString("\n"))
+              false
+          }
+        }
+
+        @tailrec
+        def checkState: Boolean = {
+          if (!app.isRunning) {
+            true
+          } else {
+            Clock.sleep(yarnPollInterval.toMillis)
+            checkState
+          }
+        }
+
+        val appNotRunningFuture = Future[Boolean] {
+          checkState
+        }
+
+        Future.firstCompletedOf(Seq(appNotRunningFuture, killYarnAppFuture)).onComplete {
+          case Success(successCode) => info(s"Successfully killed app? $successCode")
+          case Failure(ex) => warn(s"Failed to kill the application: ${ex.getMessage}")
+        }
+
+      }
+      catch {
+        // We cannot kill the YARN app without the app id.
+        // There's a chance the YARN app hasn't been submitted during a livy-server failure.
+        // We don't want a stuck session that can't be deleted. Emit a warning and move on.
+        case _: TimeoutException | _: InterruptedException =>
+          error("Deleting a session while its YARN application is not found.")
+        // app.yarnAppMonitorThread.interrupt()
+      }
+      finally {
+        app.process.foreach(_.destroy())
+      }
+      //    } else if (app.yarnAppMonitorThread.isAlive) {
+      //      debug("Interrupting yarnAppMonitorThread...!!!")
+      //      app.yarnAppMonitorThread.interrupt()
+    }
+  }
+
+  /**
+    * Check the status of the give application on YARN periodically and updates information about it
+    * locally on this instance of Livy server.
+    *
+    * @param app
+    * The given `SparkYarnApp`
+    * @return
+    * returns a future that can be waited on
+    */
+  def checkStatus(app: SparkYarnApp): Future[Unit] = {
+    info(s"Checking status for app = $app tag ${app.appTag} and id ${app.appIdOption} ")
+    val process = app.process
+
+    val processExitCodeFuture = process.map { p =>
+      onExit(p, _ =>
+        debug(s"exist code for ${p} is ready"),
+        ex => {
+          warn(s"process $process failed: ${ex.getMessage}")
+          warn(process.get.inputLines.mkString("\n"))
+          app.changeState(SparkApp.State.FAILED)
+        }
+      )
+    }.getOrElse(Future.successful(0)) // return 0 if there is no process to get its exit code.
+
+    val appIdFuture = processExitCodeFuture.zip(app.appId).map {
+      case (0, appId) =>
+        Some(appId)
+      case _ =>
+        None
+    }
+
+    appIdFuture.onComplete {
+      case Success(Some(applicationId)) =>
+        app.listener.foreach(_.appIdKnown(applicationId.toString))
+      case Success(None) =>
+        warn(s"No application ID for to get appId for $process:$app")
+      case Failure(ex) =>
+        warn(s"Failed to get appId for $process:$app: ${ex.getMessage}")
+    }
+
+    appIdFuture.map {
+      case None =>
+        warn(s"Not going to check status of yarn application ${app.appTag}")
+      case Some(appId) =>
+        var appInfo = AppInfo()
+        do {
+          try {
+            Clock.sleep(yarnPollInterval.toMillis / 2)
+
+            // Refresh application state
+            val appReport = getApplicationReport(appId)
+            appReport.fold {
+              warn(s"No application report found for $appId")
+            } { appReport =>
+              app.updateYarnDiagnostics(getYarnDiagnostics(appReport))
+              app.changeState(app.mapYarnState(
+                appReport.getApplicationId,
+                appReport.getYarnApplicationState,
+                appReport.getFinalApplicationStatus))
+
+              val driverLogUrl = blocking {
+                lock.synchronized {
+//                  lock.wait
+                  yarnApplicationReports.get(appReport).flatMap { containerReport =>
+                    Try(containerReport.getLogUrl).toOption
+                  }
+                }
+              }
+              val latestAppInfo = AppInfo(driverLogUrl, Option(appReport.getTrackingUrl))
+              if (appInfo != latestAppInfo) {
+                app.listener.map{ appListener =>
+                  Try(appListener.infoChanged(latestAppInfo))
+                }
+                appInfo = latestAppInfo
+              }
+            }
+          } catch {
+            case ex: Throwable =>
+              warn(s"Error when checking status of $app: ${ex.getMessage}")
+              throw ex
+          }
+        } while (this.isRunning.get &&
+          (app.isRunning || appInfo.driverLogUrl == None || appInfo.sparkUiUrl == None))
+    }
+  }
+
+  def getStartTime(appId: ApplicationId): Long = {
+    yarnClient.getApplicationReport(appId).getStartTime
+  }
+
+  def getFinishTime(appId: ApplicationId): Long = {
+    yarnClient.getApplicationReport(appId).getFinishTime
+  }
+
+  private def toLogUrl(appId: Option[ApplicationId]): Option[String] = {
+    None
+  }
+
+  private def getYarnDiagnostics(appReport: ApplicationReport): IndexedSeq[String] = {
+    Option(appReport.getDiagnostics)
+      .filter(_.nonEmpty)
+      .map[IndexedSeq[String]]("YARN Diagnostics:" +: _.split("\n"))
+      .getOrElse(IndexedSeq.empty)
+  }
+
+  def shutdown: Unit = {
+    info("Shutting down the YARN interface...")
+    isRunning.set(false)
+    lock.synchronized {
+//      lock.notifyAll()
+    }
+  }
+}
+
+object YarnInterface {
+
+  val appType = Set("SPARK").asJava
+
+  // YarnClient is thread safe. Create once, share it across threads.
+  val yarnClient = {
+    val c = YarnClient.createYarnClient()
+    c.init(new YarnConfiguration())
+    c.start()
+    c
+  }
+}

--- a/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
@@ -14,45 +14,134 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.livy.utils
 
-import java.util.concurrent.CountDownLatch
+import java.io.{ByteArrayInputStream, InputStream}
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
-import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-import org.apache.hadoop.yarn.api.records._
-import org.apache.hadoop.yarn.api.records.YarnApplicationState._
 import org.apache.hadoop.yarn.client.api.YarnClient
 import org.apache.hadoop.yarn.util.ConverterUtils
-import org.mockito.Matchers.{any, anyString}
-import org.mockito.Mockito.{atLeast, doReturn, never, times, verify, when}
+import org.apache.http.{HttpEntity, HttpHost, HttpRequest, HttpResponse}
+import org.apache.http.client.HttpClient
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods.{compact, render}
+import org.mockito.Matchers.any
+import org.mockito.Mockito.{times, verify, when}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.scalatest.{FunSpec, FunSpecLike}
-import org.scalatest.Matchers._
 import org.scalatest.concurrent.Eventually.{eventually, interval, timeout}
 import org.scalatest.mock.MockitoSugar.mock
+import org.scalatest.FunSpec
+import org.scalatest.Matchers._
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 import org.apache.livy.utils.SparkApp._
 
+class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite {
 
-class SparkYarnAppSpec extends FunSpec with FunSpecLike with LivyBaseUnitTestSuite {
+  /**
+    * Creates an `InputStream` with the given parameters to mock an `HttpRespose`.
+    *
+    * @param id
+    * @param tag
+    * @param state
+    * @param finalStatus
+    * @param trackingUrl
+    * @param sparkUiUrl
+    * @return
+    */
+  private def jsonApp(id: String, tag: String, state: String, finalStatus: String,
+                      trackingUrl: String, sparkUiUrl: String, diagnostics: String): InputStream = {
+    val jsonResponse = render("apps" -> (
+      "app" ->
+        List(
+          // first object
+          ("allocatedMB" -> -1) ~
+            ("allocatedVCores" -> -1) ~
+            ("amContainerLogs" -> trackingUrl) ~
+            ("amHostHttpAddress" -> "rm_server:8042") ~
+            ("amNodeLabelExpression" -> "") ~
+            ("applicationTags" -> tag) ~
+            ("applicationType" -> "SPARK") ~
+            ("clusterId" -> 1501814742838L) ~
+            ("clusterUsagePercentage" -> 0.0) ~
+            ("diagnostics" -> diagnostics) ~
+            ("elapsedTime" -> 60179) ~
+            ("finalStatus" -> finalStatus) ~
+            ("finishedTime" -> 1503686236168L) ~
+            ("id" -> id) ~
+            ("logAggregationStatus" -> "TIME_OUT") ~
+            ("memorySeconds" -> 698448L) ~
+            ("name" -> "livy--test-app-1") ~
+            ("numAMContainerPreempted" -> 0) ~
+            ("numNonAMContainerPreempted" -> 0) ~
+            ("preemptedResourceMB" -> 0) ~
+            ("preemptedResourceVCores" -> 0) ~
+            ("priority" -> 0) ~
+            ("progress" -> 100.0) ~
+            ("queue" -> "default") ~
+            ("queueUsagePercentage" -> 0.0) ~
+            ("runningContainers" -> -1) ~
+            ("startedTime" -> 1503686175989L) ~
+            ("state" -> state) ~
+            ("trackingUI" -> "History") ~
+            ("trackingUrl" -> sparkUiUrl) ~
+            ("unmanagedApplication" -> false) ~
+            ("user" -> "livy") ~
+            ("vcoreSeconds" -> 26)
+          ,
+          ("allocatedMB" -> -1) ~
+            ("allocatedVCores" -> -1) ~
+            ("amContainerLogs" -> "http://rm_server:8080/spark/ui/url") ~
+            ("amHostHttpAddress" -> "rm_server:8042") ~
+            ("amNodeLabelExpression" -> "") ~
+            ("applicationTags" -> "an-app-tag-that-we-do-not-care-about") ~
+            ("applicationType" -> "SPARK") ~
+            ("clusterId" -> 1501814742838L) ~
+            ("clusterUsagePercentage" -> 0.0) ~
+            ("diagnostics" -> "fake-yarn-diagnostics") ~
+            ("elapsedTime" -> 60179) ~
+            ("finalStatus" -> "SUCCEEDED") ~
+            ("finishedTime" -> 1503686236168L) ~
+            ("id" -> "application_0000000000000_0000") ~
+            ("logAggregationStatus" -> "TIME_OUT") ~
+            ("memorySeconds" -> 698448L) ~
+            ("name" -> "livy--test-app-1") ~
+            ("numAMContainerPreempted" -> 0) ~
+            ("numNonAMContainerPreempted" -> 0) ~
+            ("preemptedResourceMB" -> 0) ~
+            ("preemptedResourceVCores" -> 0) ~
+            ("priority" -> 0) ~
+            ("progress" -> 100.0) ~
+            ("queue" -> "default") ~
+            ("queueUsagePercentage" -> 0.0) ~
+            ("runningContainers" -> -1) ~
+            ("startedTime" -> 1503686175989L) ~
+            ("state" -> "FINISHED") ~
+            ("trackingUI" -> "History") ~
+            ("trackingUrl" -> "http://rm_server:8080/tracking/url") ~
+            ("unmanagedApplication" -> false) ~
+            ("user" -> "livy") ~
+            ("vcoreSeconds" -> 26)
+        )
+      ))
 
-  private def mockSleep(ms: Long) = {
-    Thread.sleep(ms)
+    new ByteArrayInputStream(compact(jsonResponse).getBytes(StandardCharsets.UTF_8))
   }
 
   describe("SparkYarnApp") {
-    val TEST_TIMEOUT = timeout(50 seconds)
-    val RETRY_DELAY = interval(200 milliseconds)
-    val appId = ConverterUtils.toApplicationId("application_1467912463905_0021")
+    val TEST_TIMEOUT = timeout(10 seconds)
+    val RETRY_DELAY = interval(500 milliseconds)
+    val appIdString = "application_1467912463905_0021"
+    val appId = ConverterUtils.toApplicationId(appIdString)
     val appIdOption = Some(appId.toString)
     val appTag = "fakeTag"
-    val diagnostics = "diagnostics"
+    val diag = "diag"
     val driverLogUrl = "log://driver.log/url"
     val sparkUiUrl = "log://spark.ui/url"
     val livyConf = new LivyConf()
@@ -60,331 +149,401 @@ class SparkYarnAppSpec extends FunSpec with FunSpecLike with LivyBaseUnitTestSui
     livyConf.set(LivyConf.YARN_POLL_INTERVAL, "500ms")
 
     it("should poll YARN state and terminate") {
-      Clock.withSleepMethod(mockSleep) {
+      val mockAppListener = mock[SparkAppListener]
+      val mockYarnClient = mock[YarnClient]
+      val mockHttpClient = mock[HttpClient]
+      val mockHttpResponse = mock[HttpResponse]
+      val mockHttpEntity = mock[HttpEntity]
+      when(mockHttpClient.execute(any[HttpHost], any[HttpRequest])).thenReturn(mockHttpResponse)
+      when(mockHttpResponse.getEntity).thenReturn(mockHttpEntity)
 
-        val mockAppListener = mock[SparkAppListener]
-        val mockYarnClient = mock[YarnClient]
-        val mockAppReport = mock[ApplicationReport]
-        val mockAppReports = List[ApplicationReport](mockAppReport).asJava
-        val mockAttemptId = mock[ApplicationAttemptId]
-        val mockAttemptReport = mock[ApplicationAttemptReport]
-        val mockContainerId = mock[ContainerId]
-        val mockContainerReport = mock[ContainerReport]
+      val responses = List(
+        jsonApp(appIdString, appTag, "NEW", "UNDEFINED", driverLogUrl, sparkUiUrl, diag),
+        jsonApp(appIdString, appTag, "RUNNING", "UNDEFINED", driverLogUrl, sparkUiUrl, diag),
+        jsonApp(appIdString, appTag, "RUNNING", "UNDEFINED", driverLogUrl, sparkUiUrl, diag),
+        jsonApp(appIdString, appTag, "RUNNING", "UNDEFINED", driverLogUrl, sparkUiUrl, diag),
+        jsonApp(appIdString, appTag, "RUNNING", "UNDEFINED", driverLogUrl, sparkUiUrl, diag),
+        jsonApp(appIdString, appTag, "RUNNING", "UNDEFINED", driverLogUrl, sparkUiUrl, diag),
+        jsonApp(appIdString, appTag, "RUNNING", "UNDEFINED", driverLogUrl, sparkUiUrl, diag),
+        jsonApp(appIdString, appTag, "RUNNING", "UNDEFINED", driverLogUrl, sparkUiUrl, diag),
+        jsonApp(appIdString, appTag, "FINISHED", "SUCCEEDED", driverLogUrl, sparkUiUrl, diag)
+      )
 
-        val yarnInterface = new YarnInterface(livyConf, mockYarnClient)
+      when(mockHttpEntity.getContent).thenAnswer {
+        new Answer[InputStream] {
+          // will be incremented to 0 on the fist call to `incrementAndGet`
+          val count = new AtomicInteger(-1)
 
-        val app = new SparkYarnApp(
-          appTag,
-          appIdOption,
-          None,
-          Some(mockAppListener),
-          livyConf,
-          yarnInterface)
-
-        when(mockYarnClient.getApplications(any[java.util.Set[String]]()))
-          .thenReturn(mockAppReports)
-        when(mockAppReport.getApplicationId)
-          .thenReturn(appId)
-        when(mockAppReport.getName)
-          .thenReturn("Test-app")
-        when(mockAppReport.getApplicationTags)
-          .thenReturn(Set(appTag, "not used tag").asJava)
-        when(mockAppReport.getDiagnostics)
-          .thenReturn(diagnostics)
-        when(mockAppReport.getYarnApplicationState)
-          .thenReturn(YarnApplicationState.NEW)
-          .thenReturn(YarnApplicationState.NEW_SAVING)
-          .thenReturn(YarnApplicationState.SUBMITTED)
-          .thenReturn(YarnApplicationState.ACCEPTED)
-          .thenReturn(YarnApplicationState.RUNNING)
-          .thenReturn(YarnApplicationState.RUNNING)
-          .thenReturn(YarnApplicationState.RUNNING)
-          .thenReturn(YarnApplicationState.RUNNING)
-          .thenReturn(YarnApplicationState.FINISHED)
-
-        when(mockAppReport.getFinalApplicationStatus).thenAnswer(
-          new Answer[FinalApplicationStatus] {
-            override def answer(invocation: InvocationOnMock): FinalApplicationStatus = {
-              mockAppReport.getYarnApplicationState match {
-                case FINISHED =>
-                  FinalApplicationStatus.SUCCEEDED
-                case _ =>
-                  FinalApplicationStatus.UNDEFINED
-              }
-            }
-          })
-        when(mockAppReport.getCurrentApplicationAttemptId)
-          .thenReturn(mockAttemptId)
-        when(mockYarnClient.getApplicationAttemptReport(mockAttemptId))
-          .thenReturn(mockAttemptReport)
-        when(mockAttemptReport.getAMContainerId)
-          .thenReturn(mockContainerId)
-        when(mockYarnClient.getContainerReport(mockContainerId))
-          .thenReturn(mockContainerReport)
-        when(mockContainerReport.getLogUrl).thenReturn(driverLogUrl)
-
-        yarnInterface.checkStatus(app)
-        eventually(TEST_TIMEOUT, interval(100 millis)) {
-          app.state shouldBe (SparkApp.State.FINISHED)
+          override def answer(invocationOnMock: InvocationOnMock): InputStream = {
+            val index = count.incrementAndGet()
+            val inputStream = responses(Math.min(index, responses.size - 1))
+            inputStream.reset() // reset needed because we are reusing input streams
+            inputStream
+          }
         }
-        yarnInterface.shutdown
+      }
+      val yarnInterface = new YarnInterface(livyConf, mockYarnClient, mockHttpClient)
+
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        yarnInterface.isRunning.get shouldBe true
+      }
+
+      val app = new SparkYarnApp(
+        appTag,
+        appIdOption,
+        None,
+        Some(mockAppListener),
+        livyConf,
+        yarnInterface)
+
+      yarnInterface.checkStatus(app)
+
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        app.state shouldBe (SparkApp.State.FINISHED)
+      }
+
+      yarnInterface.shutdown
+
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        yarnInterface.isRunning.get shouldBe false
       }
     }
 
     it("should kill yarn app") {
-      Clock.withSleepMethod(mockSleep) {
-        val killLatch = new CountDownLatch(1)
-        val mockAppListener = mock[SparkAppListener]
-        val mockYarnClient = mock[YarnClient]
-        val mockAppReport = mock[ApplicationReport]
-        val mockAppReports = List[ApplicationReport](mockAppReport).asJava
-        val mockAttemptId = mock[ApplicationAttemptId]
-        val mockAttemptReport = mock[ApplicationAttemptReport]
-        val mockContainerId = mock[ContainerId]
-        val mockContainerReport = mock[ContainerReport]
+      val mockAppListener = mock[SparkAppListener]
+      val mockYarnClient = mock[YarnClient]
+      val mockHttpClient = mock[HttpClient]
+      val mockHttpResponse = mock[HttpResponse]
+      val mockHttpEntity = mock[HttpEntity]
+      when(mockHttpClient.execute(any[HttpHost], any[HttpRequest])).thenReturn(mockHttpResponse)
+      when(mockHttpResponse.getEntity).thenReturn(mockHttpEntity)
 
-        val yarnInterface = new YarnInterface(livyConf, mockYarnClient)
 
-        val app = new SparkYarnApp(
-          appTag,
-          appIdOption,
-          None,
-          Some(mockAppListener),
-          livyConf,
-          yarnInterface)
-
-        doReturn(mockAppReports).when(mockYarnClient).getApplications(any[java.util.Set[String]]())
-        doReturn(appId).when(mockAppReport).getApplicationId
-        doReturn("Test-app").when(mockAppReport).getName
-        doReturn(Set(appTag, "not used tag").asJava).when(mockAppReport).getApplicationTags
-        doReturn(diagnostics).when(mockAppReport).getDiagnostics
-        when(mockAppReport.getYarnApplicationState).thenAnswer(
-          new Answer[YarnApplicationState] {
-            override def answer(invocation: InvocationOnMock): YarnApplicationState = {
-              killLatch.getCount match {
-                case 0 =>
-                  YarnApplicationState.KILLED
-                case other =>
-                  YarnApplicationState.SUBMITTED
-              }
+      val appKilled = new AtomicBoolean(false)
+      when(mockHttpEntity.getContent).thenAnswer {
+        new Answer[InputStream] {
+          override def answer(invocation: InvocationOnMock): InputStream = {
+            val inputStream = if (!appKilled.get) {
+              jsonApp(appIdString, appTag, "RUNNING", "UNDEFINED", driverLogUrl, sparkUiUrl, diag)
+            } else {
+              jsonApp(appIdString, appTag, "KILLED", "KILLED", driverLogUrl, sparkUiUrl, diag)
             }
-          })
-
-        when(mockAppReport.getFinalApplicationStatus).thenAnswer(
-          new Answer[FinalApplicationStatus] {
-            override def answer(invocation: InvocationOnMock): FinalApplicationStatus = {
-              mockAppReport.getYarnApplicationState match {
-                case FINISHED =>
-                  FinalApplicationStatus.SUCCEEDED
-                case KILLED =>
-                  FinalApplicationStatus.KILLED
-                case FAILED =>
-                  FinalApplicationStatus.FAILED
-                case _ =>
-                  FinalApplicationStatus.UNDEFINED
-              }
-            }
-          })
-
-        when(mockYarnClient.killApplication(any[ApplicationId]())).thenAnswer(
-          new Answer[Unit] {
-            override def answer(invocation: InvocationOnMock): Unit = {
-              killLatch.countDown
-            }
+            inputStream.reset()
+            inputStream
           }
-        )
-
-        doReturn(mockAttemptId).when(mockAppReport).getCurrentApplicationAttemptId
-        doReturn(mockAttemptReport).when(mockYarnClient).getApplicationAttemptReport(mockAttemptId)
-        doReturn(mockContainerId).when(mockAttemptReport).getAMContainerId
-        doReturn(mockContainerReport).when(mockYarnClient).getContainerReport(mockContainerId)
-        doReturn(driverLogUrl).when(mockContainerReport).getLogUrl
-
-        yarnInterface.checkStatus(app)
-
-        eventually(TEST_TIMEOUT, RETRY_DELAY) {
-          app.state shouldBe (SparkApp.State.STARTING)
-          app.isRunning shouldBe true
         }
+      }
 
-        app.kill()
-        killLatch.await
+      val yarnInterface = new YarnInterface(livyConf, mockYarnClient, mockHttpClient)
 
-        eventually(TEST_TIMEOUT, RETRY_DELAY) {
-          app.state shouldBe (SparkApp.State.KILLED)
-          app.isRunning shouldBe false
-        }
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        yarnInterface.isRunning.get shouldBe true
+      }
 
-        app.process.foreach { p =>
-          verify(p).destroy()
-        }
-        verify(mockYarnClient).killApplication(appId)
+      val app = new SparkYarnApp(
+        appTag,
+        appIdOption,
+        None,
+        Some(mockAppListener),
+        livyConf,
+        yarnInterface)
 
-        assert(app.log().mkString.contains(diagnostics))
-        yarnInterface.shutdown
+      yarnInterface.checkStatus(app)
+
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        app.state shouldBe (SparkApp.State.RUNNING)
+      }
+      appKilled.set(true)
+      app.kill()
+
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        app.state shouldBe (SparkApp.State.KILLED)
+      }
+
+      verify(mockYarnClient).killApplication(appId)
+      assert(app.log().mkString.contains(diag))
+
+      yarnInterface.shutdown
+
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        yarnInterface.isRunning.get shouldBe false
       }
     }
 
     it("should return spark-submit log") {
-      Clock.withSleepMethod(mockSleep) {
-        val mockYarnClient = mock[YarnClient]
-        val yarnInterface = mock[YarnInterface]
-        val mockSparkSubmit = mock[LineBufferedProcess]
-        val sparkSubmitInfoLog = IndexedSeq("SPARK-SUBMIT", "LOG")
-        val sparkSubmitErrorLog = IndexedSeq("SPARK-SUBMIT", "error log")
-        val sparkSubmitLog = ("stdout: " +: sparkSubmitInfoLog) ++
-          ("\nstderr: " +: sparkSubmitErrorLog) :+ "\nYARN Diagnostics: "
-        when(mockSparkSubmit.inputLines).thenReturn(sparkSubmitInfoLog)
-        when(mockSparkSubmit.errorLines).thenReturn(sparkSubmitErrorLog)
-        val waitForCalledLatch = new CountDownLatch(1)
-        when(mockSparkSubmit.waitFor()).thenAnswer(new Answer[Int]() {
-          override def answer(invocation: InvocationOnMock): Int = {
-            waitForCalledLatch.countDown()
-            0
+      val mockYarnClient = mock[YarnClient]
+      val mockHttpClient = mock[HttpClient]
+      val mockHttpResponse = mock[HttpResponse]
+      val mockHttpEntity = mock[HttpEntity]
+      when(mockHttpClient.execute(any[HttpHost], any[HttpRequest])).thenReturn(mockHttpResponse)
+      when(mockHttpResponse.getEntity).thenReturn(mockHttpEntity)
+
+      when(mockHttpEntity.getContent).thenAnswer {
+        new Answer[InputStream] {
+          override def answer(invocationOnMock: InvocationOnMock): InputStream = {
+            val inputStream =
+              jsonApp(appIdString, appTag, "STARTING", "UNDEFINED", driverLogUrl, sparkUiUrl, "")
+            inputStream.reset()
+            inputStream
           }
-        })
+        }
+      }
+      val mockSparkSubmit = mock[LineBufferedProcess]
+      val sparkSubmitInfoLog = IndexedSeq("SPARK-SUBMIT", "LOG")
+      val sparkSubmitErrorLog = IndexedSeq("SPARK-SUBMIT", "error log")
+      val sparkSubmitLog = ("stdout: " +: sparkSubmitInfoLog) ++
+        ("\nstderr: " +: sparkSubmitErrorLog) :+ "\nYARN Diagnostics: "
+      when(mockSparkSubmit.inputLines).thenReturn(sparkSubmitInfoLog)
+      when(mockSparkSubmit.errorLines).thenReturn(sparkSubmitErrorLog)
+      val waitForCalledLatch = new CountDownLatch(1)
+      when(mockSparkSubmit.waitFor()).thenAnswer(new Answer[Int]() {
+        override def answer(invocation: InvocationOnMock): Int = {
+          waitForCalledLatch.countDown()
+          0
+        }
+      })
 
-        val mockAppReport = mock[ApplicationReport]
-        when(mockAppReport.getApplicationId).thenReturn(appId)
-        when(mockAppReport.getYarnApplicationState).thenReturn(YarnApplicationState.FINISHED)
-        when(mockAppReport.getDiagnostics).thenReturn(null)
-        when(mockYarnClient.getApplicationReport(appId)).thenReturn(mockAppReport)
+      val yarnInterface = new YarnInterface(livyConf, mockYarnClient, mockHttpClient)
 
-        val app = new SparkYarnApp(
-          appTag,
-          appIdOption,
-          Some(mockSparkSubmit),
-          None,
-          livyConf,
-          yarnInterface)
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        yarnInterface.isRunning.get shouldBe true
+      }
+
+      val app = new SparkYarnApp(
+        appTag,
+        appIdOption,
+        Some(mockSparkSubmit),
+        None,
+        livyConf,
+        yarnInterface)
+
+      yarnInterface.checkStatus(app)
+
+      waitForCalledLatch.await(TEST_TIMEOUT.value.millisPart, TimeUnit.MILLISECONDS)
+      assert(app.log() == sparkSubmitLog)
+      assert(app.log() == sparkSubmitLog, "Expect spark-submit log")
+
+      yarnInterface.shutdown
+
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        yarnInterface.isRunning.get shouldBe false
       }
     }
 
     it("can kill spark-submit while it's running") {
-      Clock.withSleepMethod(mockSleep) {
-        val livyConf = new LivyConf()
-        livyConf.set(LivyConf.YARN_APP_LOOKUP_TIMEOUT, "0")
 
-        val mockYarnClient = mock[YarnClient]
-        val mockYarnInterface = new YarnInterface(livyConf, mockYarnClient)
-        val mockSparkSubmit = mock[LineBufferedProcess]
+      val livyConf = new LivyConf()
+      livyConf.set(LivyConf.YARN_APP_LOOKUP_TIMEOUT, "0")
+      val mockYarnClient = mock[YarnClient]
+      val mockHttpClient = mock[HttpClient]
+      val mockHttpResponse = mock[HttpResponse]
+      val mockHttpEntity = mock[HttpEntity]
+      val mockSparkSubmit = mock[LineBufferedProcess]
 
-        val sparkSubmitRunningLatch = new CountDownLatch(1)
-        // Simulate a running spark-submit
-        when(mockSparkSubmit.waitFor()).thenAnswer(new Answer[Int]() {
-          override def answer(invocation: InvocationOnMock): Int = {
-            sparkSubmitRunningLatch.await()
-            0
+      when(mockHttpClient.execute(any[HttpHost], any[HttpRequest])).thenReturn(mockHttpResponse)
+      when(mockHttpResponse.getEntity).thenReturn(mockHttpEntity)
+
+      when(mockHttpEntity.getContent).thenAnswer {
+        new Answer[InputStream] {
+          override def answer(invocationOnMock: InvocationOnMock): InputStream = {
+            val inputStream =
+              jsonApp(appIdString, appTag, "STARTING", "UNDEFINED", driverLogUrl, sparkUiUrl, "")
+            inputStream.reset()
+            inputStream
           }
-        })
+        }
+      }
 
-        val app = new SparkYarnApp(
-          appTag,
-          appIdOption,
-          Some(mockSparkSubmit),
-          None,
-          livyConf,
-          mockYarnInterface)
-        app.kill()
-        verify(mockSparkSubmit, times(1)).destroy()
-        sparkSubmitRunningLatch.countDown()
+      val sparkSubmitRunningLatch = new CountDownLatch(1)
+      // Simulate a running spark-submit
+      when(mockSparkSubmit.waitFor()).thenAnswer(new Answer[Int]() {
+        override def answer(invocation: InvocationOnMock): Int = {
+          sparkSubmitRunningLatch.await(TEST_TIMEOUT.value.toMillis, TimeUnit.MILLISECONDS)
+          0
+        }
+      })
+
+      val yarnInterface = new YarnInterface(livyConf, mockYarnClient, mockHttpClient)
+
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        yarnInterface.isRunning.get shouldBe true
+      }
+
+      val app = new SparkYarnApp(
+        appTag,
+        appIdOption,
+        Some(mockSparkSubmit),
+        None,
+        livyConf,
+        yarnInterface
+      )
+      app.kill()
+      verify(mockSparkSubmit, times(1)).destroy()
+      sparkSubmitRunningLatch.countDown()
+
+      yarnInterface.shutdown
+
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        yarnInterface.isRunning.get shouldBe false
       }
     }
 
     it("should map YARN state to SparkApp.State correctly") {
-      val mockYarnInterface = mock[YarnInterface]
-      val app = new SparkYarnApp(appTag, appIdOption, None, None, livyConf, mockYarnInterface)
-      app.mapYarnState(appId, NEW, FinalApplicationStatus.UNDEFINED) shouldBe State.STARTING
-      app.mapYarnState(appId, NEW_SAVING, FinalApplicationStatus.UNDEFINED) shouldBe State.STARTING
-      app.mapYarnState(appId, SUBMITTED, FinalApplicationStatus.UNDEFINED) shouldBe State.STARTING
-      app.mapYarnState(appId, ACCEPTED, FinalApplicationStatus.UNDEFINED) shouldBe State.STARTING
-      app.mapYarnState(appId, RUNNING, FinalApplicationStatus.UNDEFINED) shouldBe State.RUNNING
-      app.mapYarnState(appId, FINISHED, FinalApplicationStatus.SUCCEEDED) shouldBe State.FINISHED
-      app.mapYarnState(appId, FINISHED, FinalApplicationStatus.FAILED) shouldBe State.FAILED
-      app.mapYarnState(appId, FINISHED, FinalApplicationStatus.KILLED) shouldBe State.KILLED
-      app.mapYarnState(appId, FINISHED, FinalApplicationStatus.UNDEFINED) shouldBe State.FAILED
-      app.mapYarnState(appId, FAILED, FinalApplicationStatus.UNDEFINED) shouldBe State.FAILED
-      app.mapYarnState(appId, KILLED, FinalApplicationStatus.UNDEFINED) shouldBe State.KILLED
+      val app = new SparkYarnApp(appTag, appIdOption, None, None, livyConf, null)
+      assert(app.mapYarnState(appIdString, "NEW", "UNDEFINED") == State.STARTING)
+      assert(app.mapYarnState(appIdString, "NEW_SAVING", "UNDEFINED") == State.STARTING)
+      assert(app.mapYarnState(appIdString, "SUBMITTED", "UNDEFINED") == State.STARTING)
+      assert(app.mapYarnState(appIdString, "ACCEPTED", "UNDEFINED") == State.STARTING)
+      assert(app.mapYarnState(appIdString, "RUNNING", "UNDEFINED") == State.RUNNING)
+      assert(
+        app.mapYarnState(appIdString, "FINISHED", "SUCCEEDED") == State.FINISHED)
+      assert(app.mapYarnState(appIdString, "FAILED", "FAILED") == State.FAILED)
+      assert(app.mapYarnState(appIdString, "KILLED", "KILLED") == State.KILLED)
+
+      // none of the (state , finalStatus) combination below should happen
+      assert(app.mapYarnState(appIdString, "FINISHED", "UNDEFINED") == State.FAILED)
+      assert(app.mapYarnState(appIdString, "FINISHED", "FAILED") == State.FAILED)
+      assert(app.mapYarnState(appIdString, "FINISHED", "KILLED") == State.FAILED)
+      assert(app.mapYarnState(appIdString, "FAILED", "UNDEFINED") == State.FAILED)
+      assert(app.mapYarnState(appIdString, "KILLED", "UNDEFINED") == State.FAILED)
+      assert(app.mapYarnState(appIdString, "FAILED", "SUCCEEDED") == State.FAILED)
+      assert(app.mapYarnState(appIdString, "KILLED", "SUCCEEDED") == State.FAILED)
     }
 
     it("should expose driver log url and Spark UI url") {
-      Clock.withSleepMethod(mockSleep) {
+      val mockYarnClient = mock[YarnClient]
+      val mockHttpClient = mock[HttpClient]
+      val mockHttpResponse = mock[HttpResponse]
+      val mockHttpEntity = mock[HttpEntity]
+      when(mockHttpClient.execute(any[HttpHost], any[HttpRequest])).thenReturn(mockHttpResponse)
+      when(mockHttpResponse.getEntity).thenReturn(mockHttpEntity)
 
-        val mockAppListener = mock[SparkAppListener]
-        val mockYarnClient = mock[YarnClient]
-        val mockAppReport = mock[ApplicationReport]
-        val mockAppReports = List[ApplicationReport](mockAppReport).asJava
-        val mockAttemptId = mock[ApplicationAttemptId]
-        val mockAttemptReport = mock[ApplicationAttemptReport]
-        val mockContainerId = mock[ContainerId]
-        val mockContainerReport = mock[ContainerReport]
+      @volatile var done = false
+      when(mockHttpEntity.getContent).thenAnswer {
+        new Answer[InputStream] {
 
-        val yarnInterface = new YarnInterface(livyConf, mockYarnClient)
-
-        val app = new SparkYarnApp(
-          appTag,
-          appIdOption,
-          None,
-          Some(mockAppListener),
-          livyConf,
-          yarnInterface)
-
-        doReturn(mockAppReports).when(mockYarnClient).getApplications(any[java.util.Set[String]])
-
-        mockYarnClient.getApplications(YarnInterface.appType) shouldBe mockAppReports
-
-        doReturn(appId)
-          .when(mockAppReport)
-          .getApplicationId
-        doReturn("Test-app")
-          .when(mockAppReport)
-          .getName
-        doReturn(Set(appTag, "not used tag").asJava).when(mockAppReport).getApplicationTags
-        doReturn(diagnostics).when(mockAppReport).getDiagnostics
-        doReturn(sparkUiUrl).when(mockAppReport).getTrackingUrl
-        doReturn(RUNNING).when(mockAppReport).getYarnApplicationState
-
-        doReturn(FinalApplicationStatus.UNDEFINED).when(mockAppReport).getFinalApplicationStatus
-        doReturn(mockAttemptId).when(mockAppReport).getCurrentApplicationAttemptId
-        doReturn(mockAttemptReport).when(mockYarnClient).getApplicationAttemptReport(mockAttemptId)
-        doReturn(mockContainerId).when(mockAttemptReport).getAMContainerId
-        doReturn(mockContainerReport).when(mockYarnClient).getContainerReport(mockContainerId)
-        doReturn(driverLogUrl).when(mockContainerReport).getLogUrl
-
-        @volatile var appIdStr: String = null
-        when(mockAppListener.appIdKnown(anyString)).thenAnswer(new Answer[Unit]() {
-          override def answer(invocation: InvocationOnMock): Unit = {
-            appIdStr = invocation.getArguments.head.asInstanceOf[String]
+          override def answer(invocationOnMock: InvocationOnMock): InputStream = {
+            val inputStream = if (!done) {
+              jsonApp(appIdString, appTag, "RUNNING", "UNDEFINED", driverLogUrl, sparkUiUrl, diag)
+            } else {
+              jsonApp(appIdString, appTag, "FINISHED", "FINISHED", driverLogUrl, sparkUiUrl, diag)
+            }
+            inputStream.reset()
+            inputStream
           }
-        })
-        @volatile var info: AppInfo = null
-        when(mockAppListener.infoChanged(any[AppInfo])).thenAnswer(new Answer[Unit]() {
-          override def answer(invocation: InvocationOnMock): Unit = {
-            info = invocation.getArguments.head.asInstanceOf[AppInfo]
+        }
+      }
+
+      val yarnInterface = new YarnInterface(livyConf, mockYarnClient, mockHttpClient)
+
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        yarnInterface.isRunning.get shouldBe true
+      }
+
+      val mockListener = mock[SparkAppListener]
+
+      val app = new SparkYarnApp(
+        appTag, appIdOption, None, Some(mockListener), livyConf, yarnInterface)
+      yarnInterface.checkStatus(app)
+
+      done = true
+
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        verify(mockListener).appIdKnown(appId.toString)
+        verify(mockListener).infoChanged(AppInfo(Some(driverLogUrl), Some(sparkUiUrl)))
+      }
+
+      yarnInterface.shutdown
+
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        yarnInterface.isRunning.get shouldBe false
+      }
+    }
+
+    // This test is irrelevant after refactoring YARN polling to use YARN's REST API
+    it("should not die on YARN-4411") {
+      val mockYarnClient = mock[YarnClient]
+      val mockHttpClient = mock[HttpClient]
+      val mockHttpResponse = mock[HttpResponse]
+      val mockHttpEntity = mock[HttpEntity]
+      when(mockHttpClient.execute(any[HttpHost], any[HttpRequest])).thenReturn(mockHttpResponse)
+      when(mockHttpResponse.getEntity).thenReturn(mockHttpEntity)
+      when(mockHttpClient.execute(any[HttpHost], any[HttpRequest])).thenReturn(mockHttpResponse)
+      when(mockHttpResponse.getEntity).thenReturn(mockHttpEntity)
+
+      when(mockHttpEntity.getContent).thenAnswer {
+        new Answer[InputStream] {
+
+          override def answer(invocationOnMock: InvocationOnMock): InputStream = {
+            throw new IllegalArgumentException("No enum constant " +
+              "org.apache.hadoop.yarn.api.records.YarnApplicationAttemptState.FINAL_SAVING")
           }
-        })
-
-        yarnInterface.checkStatus(app)
-
-        eventually(TEST_TIMEOUT, RETRY_DELAY) {
-          app.isRunning shouldBe true
         }
-
-        eventually(TEST_TIMEOUT, RETRY_DELAY) {
-          info shouldNot be(null)
-          appIdStr should be(appId.toString)
+      }
+      // Block test until getApplicationReport is called 10 times.
+      val pollCountDown = new CountDownLatch(10)
+      when(mockYarnClient.getApplicationReport(appId)).thenAnswer(new Answer[ApplicationReport] {
+        override def answer(invocation: InvocationOnMock): ApplicationReport = {
+          pollCountDown.countDown()
+          throw new IllegalArgumentException("No enum constant " +
+            "org.apache.hadoop.yarn.api.records.YarnApplicationAttemptState.FINAL_SAVING")
         }
+      })
 
-        verify(mockAppListener, atLeast(1)).infoChanged(any[AppInfo])
-        verify(mockAppListener).appIdKnown(anyString)
-        verify(mockAppReport, atLeast(1)).getTrackingUrl()
-        verify(mockContainerReport, atLeast(1)).getLogUrl()
-        verify(mockAppReport, atLeast(1)).getTrackingUrl()
-        verify(mockContainerReport, atLeast(1)).getLogUrl()
-        verify(mockYarnClient, never).getApplicationReport(appId)
+      val yarnInterface = new YarnInterface(livyConf, mockYarnClient, mockHttpClient)
 
-        yarnInterface.shutdown
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        yarnInterface.isRunning.get shouldBe true
+      }
 
+      val app = new SparkYarnApp(appTag, appIdOption, None, None, livyConf, yarnInterface)
+      pollCountDown.await(TEST_TIMEOUT.value.millisPart, TimeUnit.MILLISECONDS)
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        assert(app.state == SparkApp.State.STARTING)
+      }
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        app.state = SparkApp.State.FINISHED
+      }
+
+      yarnInterface.shutdown
+
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        yarnInterface.isRunning.get shouldBe false
+      }
+    }
+
+    // This test is irrelevant after refactoring YARN polling to use YARN's REST API
+    it("should not die on ApplicationAttemptNotFoundException") {
+      val mockYarnClient = mock[YarnClient]
+      val mockHttpClient = mock[HttpClient]
+      val mockHttpResponse = mock[HttpResponse]
+      val mockHttpEntity = mock[HttpEntity]
+      when(mockHttpClient.execute(any[HttpHost], any[HttpRequest])).thenReturn(mockHttpResponse)
+      when(mockHttpResponse.getEntity).thenReturn(mockHttpEntity)
+
+      when(mockHttpEntity.getContent).thenAnswer {
+        new Answer[InputStream] {
+          override def answer(invocationOnMock: InvocationOnMock): InputStream = {
+            // return an empty response, so the LIVY never finds the application on YARN
+            new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8))
+          }
+        }
+      }
+      val yarnInterface = new YarnInterface(livyConf, mockYarnClient, mockHttpClient)
+
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        yarnInterface.isRunning.get shouldBe true
+      }
+
+      val app = new SparkYarnApp(appTag, appIdOption, None, None, livyConf, yarnInterface)
+
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
+        assert(app.state == SparkApp.State.STARTING)
+      }
+
+      yarnInterface.shutdown
+
+      eventually(TEST_TIMEOUT, RETRY_DELAY) {
         yarnInterface.isRunning.get shouldBe false
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, Livy spawns one thread to for each Spark application to track the status of the application on YARN. The threads are called `yarnAppMonitorThread-xxxx` and make multiple calls to YARN using YARN's Java API to get the status of running applications or to kill applications. Spawning so many threads is a bottle neck and limits the number of Spark applications that can be submitted in a short span of time.

This pull request addresses the above issue in 2 ways:
1. It creates only one thread to poll YARN and get the status of all Spark applications.
1. It replaces the Java API with YARN REST API to eliminate multiple calls to YARN.

## How was this patch tested?

- The existing unit tests and integration test are updated to reflect the changes in the code.
- Every iteration of this PR is tested internally at PayPal at dev and production development. Some iterations have been running in productions for months.

## What is not in the scope of this pull request?
Based on the discussion and feedback on this pull request, and based on the feedback
- Calls to `yarnClient.kill` wont be replaced with REST API to kill YARN apps because:
  - The current kill REST API is experimental.
- Maven dependencies to YARN won't be removed because:
  - There is minimal benefit in removing all YARN dependencies. Livy still depends on Hadoop libraries.
  - If we remove YARN dependencies, we should find a different way to get the Name Node URL. One way to do that is to add new parameters in `livy.con, but that adds complexity and possibly confusion.

Task-url: https://issues.apache.org/jira/browse/LIVY-336