### PR TITLE
[LIVY-7] added autocompletion api and implementation for scala

### DIFF
--- a/core/src/main/scala/org/apache/livy/msgs.scala
+++ b/core/src/main/scala/org/apache/livy/msgs.scala
@@ -60,4 +60,8 @@ case class ExecuteReplyError(execution_count: Int,
 
 case class ExecuteResponse(id: Int, input: Seq[String], output: Seq[String])
 
+case class CompletionRequest(code: String, kind: Option[String], cursor: Int) extends Content
+
+case class CompletionResponse(candidates: List[String]) extends Content
+
 case class ShutdownRequest() extends Content

--- a/core/src/main/scala/org/apache/livy/msgs.scala
+++ b/core/src/main/scala/org/apache/livy/msgs.scala
@@ -60,7 +60,7 @@ case class ExecuteReplyError(execution_count: Int,
 
 case class ExecuteResponse(id: Int, input: Seq[String], output: Seq[String])
 
-case class CompletionRequest(code: String, kind: Option[String], cursor: Int) extends Content
+case class CompletionRequest(code: String, kind: String, cursor: Int) extends Content
 
 case class CompletionResponse(candidates: List[String]) extends Content
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -310,6 +310,37 @@ Cancel the specified statement in this session.
   </tr>
 </table>
 
+### POST /sessions/{sessionId}/completion
+
+Runs a statement in a session.
+
+#### Request Body
+
+<table class="table">
+  <tr><th>Name</th><th>Description</th><th>Type</th></tr>
+  <tr>
+    <td>code</td>
+    <td>The code for which completion proposals are requested</td>
+    <td>string</td>
+  </tr>
+  <tr>
+    <td>cursor</td>
+    <td>cursor position to get proposals</td>
+    <td>string</td>
+  </tr>
+</table>
+
+#### Response Body
+
+<table class="table">
+  <tr><th>Name</th><th>Description</th><th>Type</th></tr>
+  <tr>
+    <td>candidates</td>
+    <td>Code completions proposals</td>
+    <td>array[string]</td>
+  </tr>
+</table>
+
 ### GET /batches
 
 Returns all the active batch sessions.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -324,6 +324,11 @@ Runs a statement in a session.
     <td>string</td>
   </tr>
   <tr>
+    <td>kind</td>
+    <td>The kind of code to execute<sup><a href="#footnote2">[2]</a></sup></td>
+    <td><a href="#session-kind">code kind</a></td>
+  </tr>
+  <tr>
     <td>cursor</td>
     <td>cursor position to get proposals</td>
     <td>string</td>

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -78,7 +78,7 @@ Creates a new interactive Scala, Python, or R shell in the cluster.
   <tr><th>Name</th><th>Description</th><th>Type</th></tr>
   <tr>
     <td>kind</td>
-    <td>The session kind (required)</td>
+    <td>The session kind<sup><a href="#footnote1">[1]</a></sup></td>
     <td><a href="#session-kind">session kind</a></td>
   </tr>
   <tr>
@@ -152,6 +152,10 @@ Creates a new interactive Scala, Python, or R shell in the cluster.
     <td>int</td>
   </tr>
 </table>
+
+<a id="footnote1">1</a>: Starting with version 0.5.0-incubating this field is not required. To be
+compatible with previous versions users can still specify this with spark, pyspark or sparkr,
+implying that the submitted code snippet is the corresponding kind.
 
 #### Response Body
 
@@ -266,7 +270,16 @@ Runs a statement in a session.
     <td>The code to execute</td>
     <td>string</td>
   </tr>
+  <tr>
+    <td>kind</td>
+    <td>The kind of code to execute<sup><a href="#footnote2">[2]</a></sup></td>
+    <td><a href="#session-kind">code kind</a></td>
+  </tr>
 </table>
+
+<a id="footnote2">2</a>: If session kind is not specified or the submitted code is not the kind
+specified in session creation, this field should be filled with correct kind.
+Otherwise Livy will use kind specified in session creation as the default code kind.
 
 #### Response Body
 
@@ -610,11 +623,7 @@ A session represents an interactive shell.
   </tr>
   <tr>
     <td><a href="#pyspark">pyspark</a></td>
-    <td>Interactive Python 2 Spark session</td>
-  </tr>
-  <tr>
-    <td><a href="#pyspark3">pyspark3</a></td>
-    <td>Interactive Python 3 Spark session</td>
+    <td>Interactive Python Spark session</td>
   </tr>
   <tr>
     <td>sparkr</td>
@@ -622,22 +631,28 @@ A session represents an interactive shell.
   </tr>
 </table>
 
+Starting with version 0.5.0-incubating, each session can support all three Scala, Python and R
+interpreters. The ``kind`` field in session creation is no longer required, instead users should
+specify code kind (spark, pyspark or sparkr) during statement submission.
+
+To be compatible with previous versions, users can still specify ``kind`` in session creation,
+while ignoring ``kind`` in statement submission. Livy will then use this session
+``kind`` as default kind for all the submitted statements.
+
+If users want to submit code other than default ``kind`` specified in session creation, users
+need to specify code kind (spark, pyspark or sparkr) during statement submission.
+
 #### pyspark
+
 To change the Python executable the session uses, Livy reads the path from environment variable
 ``PYSPARK_PYTHON`` (Same as pyspark).
+
+Starting with version 0.5.0-incubating, session kind "pyspark3" is removed, instead users require
+to set ``PYSPARK_PYTHON`` to python3 executable.
 
 Like pyspark, if Livy is running in ``local`` mode, just set the environment variable.
 If the session is running in ``yarn-cluster`` mode, please set
 ``spark.yarn.appMasterEnv.PYSPARK_PYTHON`` in SparkConf so the environment variable is passed to
-the driver.
-
-#### pyspark3
-To change the Python executable the session uses, Livy reads the path from environment variable
-``PYSPARK3_PYTHON``.
-
-Like pyspark, if Livy is running in ``local`` mode, just set the environment variable.
-If the session is running in ``yarn-cluster`` mode, please set
-``spark.yarn.appMasterEnv.PYSPARK3_PYTHON`` in SparkConf so the environment variable is passed to
 the driver.
 
 ### Statement

--- a/integration-test/src/main/scala/org/apache/livy/test/framework/LivyRestClient.scala
+++ b/integration-test/src/main/scala/org/apache/livy/test/framework/LivyRestClient.scala
@@ -190,9 +190,9 @@ class LivyRestClient(val httpClient: AsyncHttpClient, val livyEndpoint: String) 
       }
     }
 
-    class Completion(code: String, cursor: Int) {
+    class Completion(code: String, kind: String, cursor: Int) {
       val completions = {
-        val requestBody = Map("code" -> code, "cursor" -> cursor)
+        val requestBody = Map("code" -> code, "cursor" -> cursor, "kind" -> kind)
         val r = httpClient.preparePost(s"$url/completion")
           .setBody(mapper.writeValueAsString(requestBody))
           .execute()
@@ -206,7 +206,7 @@ class LivyRestClient(val httpClient: AsyncHttpClient, val livyEndpoint: String) 
       final def result(): Seq[String] = completions
 
       def verifyContaining(expected: List[String]): Unit = {
-        result().toSet.exists(x => x == expected)
+        assert(result().toSet.forall(x => expected.contains(x)))
       }
 
       def verifyNone(): Unit = {
@@ -221,7 +221,8 @@ class LivyRestClient(val httpClient: AsyncHttpClient, val livyEndpoint: String) 
 
     def run(code: String): Statement = { new Statement(code) }
 
-    def complete(code: String, cursor: Int): Completion = { new Completion(code, cursor) }
+    def complete(code: String, kind: String, cursor: Int): Completion =
+      { new Completion(code, kind, cursor) }
 
     def runFatalStatement(code: String): Unit = {
       val requestBody = Map("code" -> code)

--- a/integration-test/src/main/scala/org/apache/livy/test/framework/LivyRestClient.scala
+++ b/integration-test/src/main/scala/org/apache/livy/test/framework/LivyRestClient.scala
@@ -212,17 +212,13 @@ class LivyRestClient(val httpClient: AsyncHttpClient, val livyEndpoint: String) 
       def verifyNone(): Unit = {
         assert(result() == List(), s"Expected no completion proposals but found $completions")
       }
-
-      private def matchStrings(actual: String, expected: String): Unit = {
-        val regex = Pattern.compile(expected, Pattern.DOTALL)
-        assert(regex.matcher(actual).matches(), s"$actual did not match regex $expected")
-      }
     }
 
     def run(code: String): Statement = { new Statement(code) }
 
-    def complete(code: String, kind: String, cursor: Int): Completion =
-      { new Completion(code, kind, cursor) }
+    def complete(code: String, kind: String, cursor: Int): Completion = {
+      new Completion(code, kind, cursor)
+    }
 
     def runFatalStatement(code: String): Unit = {
       val requestBody = Map("code" -> code)

--- a/integration-test/src/test/scala/org/apache/livy/test/InteractiveIT.scala
+++ b/integration-test/src/test/scala/org/apache/livy/test/InteractiveIT.scala
@@ -49,8 +49,8 @@ class InteractiveIT extends BaseIntegrationTestSuite {
         .verifyResult(".*false")
       s.run("""sys.props.exists(_._1.startsWith("spark.__livy__."))""").verifyResult(".*false")
       s.run("""val str = "str"""")
-      s.complete("str.", 4).verifyContaining(List("compare", "contains", "chars"))
-      s.complete("str2.", 5).verifyNone()
+      s.complete("str.", "scala", 4).verifyContaining(List("compare", "contains"))
+      s.complete("str2.", "scala", 5).verifyNone()
 
       // Make sure appInfo is reported correctly.
       val state = s.snapshot()

--- a/integration-test/src/test/scala/org/apache/livy/test/InteractiveIT.scala
+++ b/integration-test/src/test/scala/org/apache/livy/test/InteractiveIT.scala
@@ -48,6 +48,9 @@ class InteractiveIT extends BaseIntegrationTestSuite {
       s.run("""sc.getConf.getAll.exists(_._1.startsWith("spark.__livy__."))""")
         .verifyResult(".*false")
       s.run("""sys.props.exists(_._1.startsWith("spark.__livy__."))""").verifyResult(".*false")
+      s.run("""val str = "str"""")
+      s.complete("str.", 4).verifyContaining(List("compare", "contains", "chars"))
+      s.complete("str2.", 5).verifyNone()
 
       // Make sure appInfo is reported correctly.
       val state = s.snapshot()

--- a/repl/scala-2.10/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -133,6 +133,11 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
     sparkIMain.interpret(code)
   }
 
+  override protected def completeCandidates(code: String, cursor: Int) : Array[String] = {
+    val completer = new org.apache.spark.repl.SparkJLineCompletion(sparkIMain)
+    completer.completer().complete(code, cursor).candidates.toArray
+  }
+
   override protected[repl] def parseError(stdout: String): (String, Seq[String]) = {
     // An example of Scala 2.10 runtime exception error message:
     // java.lang.Exception: message

--- a/repl/scala-2.10/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -28,6 +28,7 @@ import scala.util.{Failure, Success, Try}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.repl.SparkIMain
+import org.apache.spark.repl.SparkJLineCompletion
 
 import org.apache.livy.rsc.driver.SparkEntries
 
@@ -134,7 +135,7 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
   }
 
   override protected def completeCandidates(code: String, cursor: Int) : Array[String] = {
-    val completer = new org.apache.spark.repl.SparkJLineCompletion(sparkIMain)
+    val completer = new SparkJLineCompletion(sparkIMain)
     completer.completer().complete(code, cursor).candidates.toArray
   }
 

--- a/repl/scala-2.11/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -117,6 +117,11 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
     sparkILoop.interpret(code)
   }
 
+  override protected def completeCandidates(code: String, cursor: Int) : Array[String] = {
+    val completer = new scala.tools.nsc.interpreter.JLineCompletion(sparkILoop.intp)
+    completer.completer().complete(code, cursor).candidates.toArray
+  }
+
   override protected def valueOfTerm(name: String): Option[Any] = {
     // IMain#valueOfTerm will always return None, so use other way instead.
     Option(sparkILoop.lastRequest.lineRep.call("$result"))

--- a/repl/scala-2.11/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -22,6 +22,7 @@ import java.net.URLClassLoader
 import java.nio.file.{Files, Paths}
 
 import scala.tools.nsc.Settings
+import scala.tools.nsc.interpreter.JLineCompletion
 import scala.tools.nsc.interpreter.JPrintWriter
 import scala.tools.nsc.interpreter.Results.Result
 import scala.util.control.NonFatal
@@ -118,7 +119,7 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
   }
 
   override protected def completeCandidates(code: String, cursor: Int) : Array[String] = {
-    val completer = new scala.tools.nsc.interpreter.JLineCompletion(sparkILoop.intp)
+    val completer = new JLineCompletion(sparkILoop.intp)
     completer.completer().complete(code, cursor).candidates.toArray
   }
 

--- a/repl/src/main/scala/org/apache/livy/repl/AbstractSparkInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/AbstractSparkInterpreter.scala
@@ -53,6 +53,8 @@ abstract class AbstractSparkInterpreter extends Interpreter with Logging {
 
   protected def interpret(code: String): Results.Result
 
+  protected def completeCandidates(code: String, cursor: Int) : Array[String] = Array()
+
   protected def valueOfTerm(name: String): Option[Any]
 
   protected def bind(name: String, tpe: String, value: Object, modifier: List[String]): Unit
@@ -108,6 +110,10 @@ abstract class AbstractSparkInterpreter extends Interpreter with Logging {
       executeLines(code.trim.split("\n").toList, Interpreter.ExecuteSuccess(JObject(
         (TEXT_PLAIN, JString(""))
       )))
+  }
+
+  override protected[repl] def complete(code: String, cursor: Int): Array[String] = {
+      completeCandidates(code, cursor)
   }
 
   private def executeMagic(magic: String, rest: String): Interpreter.ExecuteResponse = {

--- a/repl/src/main/scala/org/apache/livy/repl/Interpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/Interpreter.scala
@@ -17,6 +17,7 @@
 
 package org.apache.livy.repl
 
+import org.json4s.JArray
 import org.json4s.JObject
 
 object Interpreter {
@@ -28,6 +29,7 @@ object Interpreter {
                           traceback: Seq[String] = Seq()) extends ExecuteResponse
   case class ExecuteIncomplete() extends ExecuteResponse
   case class ExecuteAborted(message: String) extends ExecuteResponse
+
 }
 
 trait Interpreter {
@@ -45,6 +47,9 @@ trait Interpreter {
    * take some time to execute.
    */
   protected[repl] def execute(code: String): ExecuteResponse
+
+  protected[repl] def complete(code: String, cursor: Int): Array[String]
+    = Array()
 
   /** Shut down the interpreter. */
   def close(): Unit

--- a/repl/src/main/scala/org/apache/livy/repl/Interpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/Interpreter.scala
@@ -29,7 +29,6 @@ object Interpreter {
                           traceback: Seq[String] = Seq()) extends ExecuteResponse
   case class ExecuteIncomplete() extends ExecuteResponse
   case class ExecuteAborted(message: String) extends ExecuteResponse
-
 }
 
 trait Interpreter {

--- a/repl/src/main/scala/org/apache/livy/repl/ReplDriver.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/ReplDriver.scala
@@ -62,6 +62,10 @@ class ReplDriver(conf: SparkConf, livyConf: RSCConf)
     session.cancel(msg.id)
   }
 
+  def handle(ctx: ChannelHandlerContext, msg: BaseProtocol.ReplCompleteRequest): Array[String] = {
+    session.complete(msg.code, msg.codeType, msg.cursor)
+  }
+
   /**
    * Return statement results. Results are sorted by statement id.
    */

--- a/repl/src/main/scala/org/apache/livy/repl/Session.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/Session.scala
@@ -169,6 +169,18 @@ class Session(
     statementId
   }
 
+  def complete(code: String, codeType: String = null, cursor: Int): Array[String] = {
+    val tpe = if (codeType != null) {
+      Kind(codeType)
+    } else if (defaultInterpKind != Shared()) {
+      defaultInterpKind
+    } else {
+      throw new IllegalArgumentException(s"Code type should be specified if session kind is shared")
+    }
+    val interp = interpreter(tpe)
+    interp.complete(code, cursor)
+  }
+
   def cancel(statementId: Int): Unit = {
     val statementOpt = _statements.synchronized { _statements.get(statementId) }
     if (statementOpt.isEmpty) {

--- a/repl/src/main/scala/org/apache/livy/repl/Session.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/Session.scala
@@ -169,14 +169,8 @@ class Session(
     statementId
   }
 
-  def complete(code: String, codeType: String = null, cursor: Int): Array[String] = {
-    val tpe = if (codeType != null) {
-      Kind(codeType)
-    } else if (defaultInterpKind != Shared()) {
-      defaultInterpKind
-    } else {
-      throw new IllegalArgumentException(s"Code type should be specified if session kind is shared")
-    }
+  def complete(code: String, codeType: String, cursor: Int): Array[String] = {
+    val tpe = Kind(codeType)
     val interp = interpreter(tpe)
     interp.complete(code, cursor)
   }

--- a/repl/src/test/scala/org/apache/livy/repl/ScalaInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/ScalaInterpreterSpec.scala
@@ -209,7 +209,6 @@ class ScalaInterpreterSpec extends BaseInterpreterSpec {
       """"a".""".stripMargin
     val actual = interpreter.complete(code, code.length)
     actual should contain ("+")
-    actual should contain ("asInstanceOf")
     actual should contain ("charAt")
     actual should contain ("compareTo")
   }

--- a/repl/src/test/scala/org/apache/livy/repl/ScalaInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/ScalaInterpreterSpec.scala
@@ -203,4 +203,15 @@ class ScalaInterpreterSpec extends BaseInterpreterSpec {
           Interpreter.ExecuteSuccess(TEXT_PLAIN -> s"r: String =\n$stringWithComment"))
     }
   }
+
+  it should "return code completion candidates" in withInterpreter { interpreter =>
+    val code =
+      """"a".""".stripMargin
+    val actual = interpreter.complete(code, code.length)
+    actual should contain ("+")
+    actual should contain ("asInstanceOf")
+    actual should contain ("charAt")
+    actual should contain ("compareTo")
+  }
+
 }

--- a/rsc/src/main/java/org/apache/livy/rsc/BaseProtocol.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/BaseProtocol.java
@@ -202,6 +202,22 @@ public abstract class BaseProtocol extends RpcDispatcher {
     }
   }
 
+  public static class ReplCompleteRequest {
+    public final String code;
+    public final String codeType;
+    public final int cursor;
+
+    public ReplCompleteRequest(String code, String codeType, int cursor) {
+      this.code = code;
+      this.codeType = codeType;
+      this.cursor = cursor;
+    }
+
+    public ReplCompleteRequest() {
+      this(null, null, 0);
+    }
+  }
+
   protected static class ReplState {
 
     public final String state;

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
@@ -302,6 +302,12 @@ public class RSCClient implements LivyClient {
     return deferredCall(new BaseProtocol.GetReplJobResults(), ReplJobResults.class);
   }
 
+  public Future<String[]> completeReplCode(String code, String codeType, int cursor)
+      throws Exception {
+    return deferredCall(new BaseProtocol.ReplCompleteRequest(code, codeType, cursor),
+        String[].class);
+  }
+
   /**
    * @return Return the repl state. If this's not connected to a repl session, it will return null.
    */

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -505,7 +505,7 @@ class InteractiveSession(
     ensureRunning()
     recordActivity()
 
-    val proposals = client.get.completeReplCode(content.code, content.kind.orNull,
+    val proposals = client.get.completeReplCode(content.code, content.kind,
         content.cursor).get
     CompletionResponse(proposals.toList)
   }

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -501,6 +501,15 @@ class InteractiveSession(
     client.get.cancelReplCode(statementId)
   }
 
+  def completion(content: CompletionRequest): CompletionResponse = {
+    ensureRunning()
+    recordActivity()
+
+    val proposals = client.get.completeReplCode(content.code, content.kind.orNull,
+        content.cursor).get
+    CompletionResponse(proposals.toList)
+  }
+
   def runJob(job: Array[Byte], jobType: String): Long = {
     performOperation(job, jobType, true)
   }

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -28,7 +28,7 @@ import org.json4s.jackson.Json4sScalaModule
 import org.scalatra._
 import org.scalatra.servlet.FileUploadSupport
 
-import org.apache.livy.{ExecuteRequest, JobHandle, LivyConf, Logging}
+import org.apache.livy.{CompletionRequest, ExecuteRequest, JobHandle, LivyConf, Logging}
 import org.apache.livy.client.common.HttpMessages
 import org.apache.livy.client.common.HttpMessages._
 import org.apache.livy.server.{AccessManager, SessionServlet}
@@ -128,6 +128,13 @@ class InteractiveSessionServlet(
           "Location" -> url(getStatement,
             "id" -> session.id.toString,
             "statementId" -> statement.id.toString)))
+    }
+  }
+
+  jpost[CompletionRequest]("/:id/completion") { req =>
+    withModifyAccessSession { session =>
+      val compl = session.completion(req)
+      Ok(Map("candidates" -> compl.candidates))
     }
   }
 


### PR DESCRIPTION
I started an implementation of the very old feature request (LIVY-7) for code autocompletion.
This implementation works with scala 2.11 and scala 2.10.

I'd be happy if somebody could review and comment it.

As for the API: I chose a synchronous call because resolving the code options shouldn't be a very long process (and if it were it wouldn't make sense anyway).