### PR TITLE
[LIVY-406][FOLLOWUP][SERVER] Fix LIVY-406 UT failure in branch 0.4 and apply to Master branch for consistency

### DIFF
--- a/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
@@ -261,7 +261,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite {
         when(mockAppReport.getApplicationTags).thenReturn(Set(appTag.toLowerCase).asJava)
         when(mockAppReport.getApplicationId).thenReturn(appId)
         when(mockAppReport.getFinalApplicationStatus).thenReturn(FinalApplicationStatus.SUCCEEDED)
-        when(mockAppReport.getYarnApplicationState).thenReturn(RUNNING)
+        when(mockAppReport.getYarnApplicationState).thenReturn(YarnApplicationState.FINISHED)
         when(mockYarnClient.getApplicationReport(appId)).thenReturn(mockAppReport)
         when(mockYarnClient.getApplications(Set("SPARK").asJava))
           .thenReturn(List(mockAppReport).asJava)


### PR DESCRIPTION
Because we changed the AppState logic in #39 , so the UT which passed in master branch will be failed in branch 0.4, here to fix this issue.

Also apply this PR to master branch for the consistency, it should also be worked in master branch.