### PR TITLE
[LIVY-408][RSC] Update Netty version to 4.0.37.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
     <kryo.version>2.22</kryo.version>
     <metrics.version>3.1.0</metrics.version>
     <mockito.version>1.9.5</mockito.version>
-    <netty.version>4.0.29.Final</netty.version>
+    <netty.version>4.0.37.Final</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <py4j.version>0.9</py4j.version>
     <scala-2.10.version>2.10.4</scala-2.10.version>


### PR DESCRIPTION
Netty version below 4.0.37.Final has some potential security issue (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4970), it is fixed in this version. So propose to upgrade Netty to avoid such issue.