### PR TITLE
[LIVY-411][REPL] Fix session cannot start issue when python or r package is missing

### DIFF
--- a/integration-test/src/test/scala/org/apache/livy/test/JobApiIT.scala
+++ b/integration-test/src/test/scala/org/apache/livy/test/JobApiIT.scala
@@ -279,7 +279,7 @@ class JobApiIT extends BaseIntegrationTestSuite with BeforeAndAfterAll with Logg
   }
 
   private def waitFor[T](future: JFuture[T]): T = {
-    future.get(30, TimeUnit.SECONDS)
+    future.get(60, TimeUnit.SECONDS)
   }
 
   private def sessionList(): SessionList = {

--- a/integration-test/src/test/spark2/scala/Spark2JobApiIT.scala
+++ b/integration-test/src/test/spark2/scala/Spark2JobApiIT.scala
@@ -91,7 +91,7 @@ class Spark2JobApiIT extends BaseIntegrationTestSuite with BeforeAndAfterAll wit
   }
 
   private def waitFor[T](future: JFuture[T]): T = {
-    future.get(30, TimeUnit.SECONDS)
+    future.get(60, TimeUnit.SECONDS)
   }
 
   private def sessionList(): SessionList = {

--- a/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
@@ -79,7 +79,7 @@ object PythonInterpreter extends Logging {
           val pyLibPath = Seq(sparkHome, "python", "lib").mkString(File.separator)
           val pyArchivesFile = new File(pyLibPath, "pyspark.zip")
           require(pyArchivesFile.exists(),
-            "pyspark.zip not found; cannot run pyspark application in YARN mode.")
+            "pyspark.zip not found; cannot start pyspark interpreter.")
 
           val py4jFile = Files.newDirectoryStream(Paths.get(pyLibPath), "py4j-*-src.zip")
             .iterator()
@@ -87,7 +87,7 @@ object PythonInterpreter extends Logging {
             .toFile
 
           require(py4jFile.exists(),
-            "py4j-*-src.zip not found; cannot run pyspark application in YARN mode.")
+            "py4j-*-src.zip not found; cannot start pyspark interpreter.")
           Seq(pyArchivesFile.getAbsolutePath, py4jFile.getAbsolutePath)
         }.getOrElse(Seq())
       }

--- a/repl/src/main/scala/org/apache/livy/repl/ReplDriver.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/ReplDriver.scala
@@ -93,24 +93,24 @@ class ReplDriver(conf: SparkConf, livyConf: RSCConf)
 
   override protected def createWrapper(msg: BaseProtocol.BypassJobRequest): BypassJobWrapper = {
     Kind(msg.jobType) match {
-      case PySpark() =>
+      case PySpark() if session.interpreter(PySpark()).isDefined =>
         new BypassJobWrapper(this, msg.id,
           new BypassPySparkJob(msg.serializedJob,
-            session.interpreter(PySpark()).asInstanceOf[PythonInterpreter]))
+            session.interpreter(PySpark()).get.asInstanceOf[PythonInterpreter]))
       case _ => super.createWrapper(msg)
     }
   }
 
   override protected def addFile(path: String): Unit = {
-    if (!ClientConf.TEST_MODE) {
-      session.interpreter(PySpark()).asInstanceOf[PythonInterpreter].addFile(path)
+    if (!ClientConf.TEST_MODE && session.interpreter(PySpark()).isDefined) {
+      session.interpreter(PySpark()).get.asInstanceOf[PythonInterpreter].addFile(path)
     }
     super.addFile(path)
   }
 
   override protected def addJarOrPyFile(path: String): Unit = {
-    if (!ClientConf.TEST_MODE) {
-      session.interpreter(PySpark()).asInstanceOf[PythonInterpreter].addPyFile(this, conf, path)
+    if (!ClientConf.TEST_MODE && session.interpreter(PySpark()).isDefined) {
+      session.interpreter(PySpark()).get.asInstanceOf[PythonInterpreter].addPyFile(this, conf, path)
     }
     super.addJarOrPyFile(path)
   }

--- a/repl/src/main/scala/org/apache/livy/repl/ReplDriver.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/ReplDriver.scala
@@ -102,15 +102,16 @@ class ReplDriver(conf: SparkConf, livyConf: RSCConf)
   }
 
   override protected def addFile(path: String): Unit = {
-    if (!ClientConf.TEST_MODE && session.interpreter(PySpark()).isDefined) {
-      session.interpreter(PySpark()).get.asInstanceOf[PythonInterpreter].addFile(path)
+    if (!ClientConf.TEST_MODE) {
+      session.interpreter(PySpark()).foreach { _.asInstanceOf[PythonInterpreter].addFile(path) }
     }
     super.addFile(path)
   }
 
   override protected def addJarOrPyFile(path: String): Unit = {
-    if (!ClientConf.TEST_MODE && session.interpreter(PySpark()).isDefined) {
-      session.interpreter(PySpark()).get.asInstanceOf[PythonInterpreter].addPyFile(this, conf, path)
+    if (!ClientConf.TEST_MODE) {
+      session.interpreter(PySpark())
+        .foreach { _.asInstanceOf[PythonInterpreter].addPyFile(this, conf, path) }
     }
     super.addJarOrPyFile(path)
   }

--- a/scala-api/src/test/scala/org/apache/livy/scalaapi/ScalaClientTest.scala
+++ b/scala-api/src/test/scala/org/apache/livy/scalaapi/ScalaClientTest.scala
@@ -50,8 +50,11 @@ class ScalaClientTest extends FunSuite
 
   after {
     if (client != null) {
-      client.stop(true)
-      client = null
+      try {
+        client.stop(true)
+      } finally {
+        client = null
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/LIVY-411

In Livy 0.5.0, we supported multiple languages in one session, but it requires that all the packages should be available before session creation, such as R package and Python package, otherwise session will be failed to create. However, in some cases python or R package may be missing in Spark distro, this will make Livy fail to creation interactive session.

To fix this issue, we should not force such restriction on session creation, but delay the check until related interpreter is used. If such packaging is missing, we should make the related execution failure and return user the cause of issue, but don't affect other correctly started interpreters.


## How was this patch tested?

Existing test and manually verification on local cluster.
