### PR TITLE
[LIVY-414][SERVER] Support setting env variables during session creation

### DIFF
--- a/api/src/main/java/org/apache/livy/LivyClientFactory.java
+++ b/api/src/main/java/org/apache/livy/LivyClientFactory.java
@@ -18,6 +18,7 @@
 package org.apache.livy;
 
 import java.net.URI;
+import java.util.Map;
 import java.util.Properties;
 
 import org.apache.livy.annotations.Private;
@@ -39,6 +40,6 @@ public interface LivyClientFactory {
    *
    * @param uri URI pointing at the livy backend to use.
    */
-  LivyClient createClient(URI uri, Properties config);
+  LivyClient createClient(URI uri, Properties config, Map<String, String> env);
 
 }

--- a/api/src/test/java/org/apache/livy/TestClientFactory.java
+++ b/api/src/test/java/org/apache/livy/TestClientFactory.java
@@ -19,16 +19,17 @@ package org.apache.livy;
 
 import java.io.File;
 import java.net.URI;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Future;
 
 public class TestClientFactory implements LivyClientFactory {
 
   @Override
-  public LivyClient createClient(URI uri, Properties config) {
+  public LivyClient createClient(URI uri, Properties config, Map<String, String> env) {
     switch (uri.getPath()) {
       case "match":
-        return new Client(config);
+        return new Client(config, env);
 
       case "error":
         throw new IllegalStateException("error");
@@ -41,9 +42,11 @@ public class TestClientFactory implements LivyClientFactory {
   public static class Client implements LivyClient {
 
     public final Properties config;
+    public final Map<String, String> env;
 
-    private Client(Properties config) {
+    private Client(Properties config, Map<String, String> env) {
       this.config = config;
+      this.env = env;
     }
 
     @Override

--- a/api/src/test/java/org/apache/livy/TestLivyClientBuilder.java
+++ b/api/src/test/java/org/apache/livy/TestLivyClientBuilder.java
@@ -18,6 +18,7 @@
 package org.apache.livy;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.Properties;
 
 import org.junit.Test;
@@ -36,6 +37,8 @@ public class TestLivyClientBuilder {
         .setURI(new URI("match"))
         .setConf("prop1", "prop1")
         .setConf("prop2", "prop2")
+        .setEnv("env1", "env1")
+        .setAllEnvs(Collections.singletonMap("env2", "env2"))
         .setAll(props)
         .build();
 
@@ -43,6 +46,8 @@ public class TestLivyClientBuilder {
     assertEquals("_prop1_", client.config.getProperty("prop1"));
     assertEquals("prop2", client.config.getProperty("prop2"));
     assertEquals("prop3", client.config.getProperty("prop3"));
+    assertEquals("env1", client.env.get("env1"));
+    assertEquals("env2", client.env.get("env2"));
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/client-common/src/main/java/org/apache/livy/client/common/HttpMessages.java
+++ b/client-common/src/main/java/org/apache/livy/client/common/HttpMessages.java
@@ -39,13 +39,15 @@ public class HttpMessages {
   public static class CreateClientRequest implements ClientMessage {
 
     public final Map<String, String> conf;
+    public final Map<String, String> env;
 
-    public CreateClientRequest(Map<String, String> conf) {
+    public CreateClientRequest(Map<String, String> conf, Map<String, String> env) {
       this.conf = conf;
+      this.env = env;
     }
 
     private CreateClientRequest() {
-      this(null);
+      this(null, null);
     }
 
   }

--- a/client-http/src/main/java/org/apache/livy/client/http/HttpClient.java
+++ b/client-http/src/main/java/org/apache/livy/client/http/HttpClient.java
@@ -50,7 +50,7 @@ class HttpClient implements LivyClient {
 
   private boolean stopped;
 
-  HttpClient(URI uri, HttpConf httpConf) {
+  HttpClient(URI uri, HttpConf httpConf, Map<String, String> sessionEnv) {
     this.config = httpConf;
     this.stopped = false;
 
@@ -74,7 +74,7 @@ class HttpClient implements LivyClient {
           sessionConf.put(e.getKey(), e.getValue());
         }
 
-        ClientMessage create = new CreateClientRequest(sessionConf);
+        ClientMessage create = new CreateClientRequest(sessionConf, sessionEnv);
         this.conn = new LivyConnection(uri, httpConf);
         this.sessionId = conn.post(create, SessionInfo.class, "/").id;
       }

--- a/python-api/src/main/python/livy/client.py
+++ b/python-api/src/main/python/livy/client.py
@@ -45,6 +45,9 @@ class HttpClient(object):
     conf_dict : dict, optional
         The key-value pairs in the conf_dict will be loaded to the config
         Default is None
+    env_dict : dict, optional
+        The key-value pairs in the env_dict will be loaded as environment variables
+        Default is None
 
     Examples
     --------
@@ -66,11 +69,12 @@ class HttpClient(object):
     _CONFIG_SECTION = 'env'
     _LIVY_CLIENT_CONF_DIR = "LIVY_CLIENT_CONF_DIR"
 
-    def __init__(self, url, load_defaults=True, conf_dict=None):
+    def __init__(self, url, load_defaults=True, conf_dict=None, env_dict=None):
         uri = urlparse(url)
         self._config = ConfigParser()
         self._load_config(load_defaults, conf_dict)
         self._job_type = 'pyspark'
+        self._env = {} if env_dict is None else env_dict
         match = re.match(r'(.*)/sessions/([0-9]+)', uri.path)
         if match:
             base = ParseResult(scheme=uri.scheme, netloc=uri.netloc,
@@ -85,7 +89,7 @@ class HttpClient(object):
             session_conf_dict = dict(self._config.items(self._CONFIG_SECTION))
             self._conn = _LivyConnection(uri, self._config)
             self._session_id = self._create_new_session(
-                session_conf_dict).json()['id']
+                session_conf_dict, self._env).json()['id']
         self._executor = ThreadPoolExecutor(max_workers=1)
         self._stopped = False
         self.lock = threading.Lock()
@@ -382,8 +386,8 @@ class HttpClient(object):
             open(path, encoding='utf-8').read()
         self._config.readfp(StringIO(data))
 
-    def _create_new_session(self, session_conf_dict):
-        data = {'kind': 'pyspark', 'conf': session_conf_dict}
+    def _create_new_session(self, session_conf_dict, session_env_dict):
+        data = {'kind': 'pyspark', 'conf': session_conf_dict, 'env': session_env_dict}
         response = self._conn.send_request('POST', "/",
             headers=self._conn._JSON_HEADERS, data=data)
         return response

--- a/python-api/src/main/python/livy/client.py
+++ b/python-api/src/main/python/livy/client.py
@@ -46,8 +46,8 @@ class HttpClient(object):
         The key-value pairs in the conf_dict will be loaded to the config
         Default is None
     env_dict : dict, optional
-        The key-value pairs in the env_dict will be loaded as environment variables
-        Default is None
+        The key-value pairs in the env_dict will be loaded as environment
+        variables. Default is None
 
     Examples
     --------
@@ -387,7 +387,8 @@ class HttpClient(object):
         self._config.readfp(StringIO(data))
 
     def _create_new_session(self, session_conf_dict, session_env_dict):
-        data = {'kind': 'pyspark', 'conf': session_conf_dict, 'env': session_env_dict}
+        data = {'kind': 'pyspark', 'conf': session_conf_dict,
+                'env': session_env_dict}
         response = self._conn.send_request('POST', "/",
             headers=self._conn._JSON_HEADERS, data=data)
         return response

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCClientFactory.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCClientFactory.java
@@ -19,6 +19,7 @@ package org.apache.livy.rsc;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -53,7 +54,7 @@ public final class RSCClientFactory implements LivyClientFactory {
    * Otherwise, a new Spark context will be started with the given configuration.
    */
   @Override
-  public LivyClient createClient(URI uri, Properties config) {
+  public LivyClient createClient(URI uri, Properties config, Map<String, String> env) {
     if (!"rsc".equals(uri.getScheme())) {
       return null;
     }
@@ -69,7 +70,7 @@ public final class RSCClientFactory implements LivyClientFactory {
       } else {
         needsServer = true;
         ref(lconf);
-        DriverProcessInfo processInfo = ContextLauncher.create(this, lconf);
+        DriverProcessInfo processInfo = ContextLauncher.create(this, lconf, env);
         info = processInfo.getContextInfo();
         driverProcess = processInfo.getDriverProcess();
       }

--- a/rsc/src/test/java/org/apache/livy/rsc/TestSparkClient.java
+++ b/rsc/src/test/java/org/apache/livy/rsc/TestSparkClient.java
@@ -452,6 +452,17 @@ public class TestSparkClient {
     runBypassTest(true);
   }
 
+  @Test
+  public void testEnvs() throws Exception {
+    runTest(false, new TestFunction() {
+      @Override
+      void call(LivyClient client) throws Exception {
+        JobHandle<String> handle = client.submit(new EnvCheck("key1"));
+        assertEquals("value1", handle.get(TIMEOUT, TimeUnit.SECONDS));
+      }
+    }, Collections.singletonMap("key1", "value1"));
+  }
+
   private void runBypassTest(final boolean sync) throws Exception {
     runTest(true, new TestFunction() {
       @Override
@@ -517,12 +528,20 @@ public class TestSparkClient {
   }
 
   private void runTest(boolean local, TestFunction test) throws Exception {
+    runTest(local, test, Collections.<String, String>emptyMap());
+  }
+
+  private void runTest(
+      boolean local,
+      TestFunction test,
+      Map<String, String> env) throws Exception {
     Properties conf = createConf(local);
     LivyClient client = null;
     try {
       test.config(conf);
       client = new LivyClientBuilder(false).setURI(new URI("rsc:/"))
         .setAll(conf)
+        .setAllEnvs(env)
         .build();
 
       // Wait for the context to be up before running the test.

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
@@ -71,6 +71,7 @@ object BatchSession extends Logging {
 
       val builder = new SparkProcessBuilder(livyConf)
       builder.conf(conf)
+      request.env.foreach(kv => builder.env(kv._1, kv._2))
 
       proxyUser.foreach(builder.proxyUser)
       request.className.foreach(builder.className)

--- a/server/src/main/scala/org/apache/livy/server/batch/CreateBatchRequest.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/CreateBatchRequest.scala
@@ -35,6 +35,7 @@ class CreateBatchRequest {
   var queue: Option[String] = None
   var name: Option[String] = None
   var conf: Map[String, String] = Map()
+  var env: Map[String, String] = Map()
 
   override def toString: String = {
     s"[proxyUser: $proxyUser, " +
@@ -51,6 +52,7 @@ class CreateBatchRequest {
       (if (numExecutors.isDefined) s"numExecutors: ${numExecutors.get}, " else "") +
       (if (queue.isDefined) s"queue: ${queue.get}, " else "") +
       (if (name.isDefined) s"name: ${name.get}, " else "") +
-      (if (conf.nonEmpty) s"conf: ${conf.mkString(",")}]" else "]")
+      (if (conf.nonEmpty) s"conf: ${conf.mkString(",")}]" else "]") +
+      (if (env.nonEmpty) s"env: ${env.mkString(",")}]" else "]")
   }
 }

--- a/server/src/main/scala/org/apache/livy/server/interactive/CreateInteractiveRequest.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/CreateInteractiveRequest.scala
@@ -34,6 +34,7 @@ class CreateInteractiveRequest {
   var queue: Option[String] = None
   var name: Option[String] = None
   var conf: Map[String, String] = Map()
+  var env: Map[String, String] = Map()
   var heartbeatTimeoutInSecond: Int = 0
 
   override def toString: String = {
@@ -50,6 +51,7 @@ class CreateInteractiveRequest {
       (if (queue.isDefined) s"queue: ${queue.get}, " else "") +
       (if (name.isDefined) s"name: ${name.get}, " else "") +
       (if (conf.nonEmpty) s"conf: ${conf.mkString(",")}, " else "") +
+      (if (env.nonEmpty) s"env: ${env.mkString(",")}, " else "") +
       s"heartbeatTimeoutInSecond: $heartbeatTimeoutInSecond]"
   }
 }

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -101,6 +101,7 @@ object InteractiveSession extends Logging {
         .setAll(builderProperties.asJava)
         .setConf("livy.client.session-id", id.toString)
         .setConf(RSCConf.Entry.DRIVER_CLASS.key(), "org.apache.livy.repl.ReplDriver")
+        .setAllEnvs(request.env.asJava)
         .setConf(RSCConf.Entry.PROXY_USER.key(), proxyUser.orNull)
         .setURI(new URI("rsc:/"))
 

--- a/test-lib/src/main/java/org/apache/livy/test/jobs/EnvCheck.java
+++ b/test-lib/src/main/java/org/apache/livy/test/jobs/EnvCheck.java
@@ -15,27 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.livy.client.http;
+package org.apache.livy.test.jobs;
 
-import java.net.URI;
-import java.util.Map;
-import java.util.Properties;
+import org.apache.livy.Job;
+import org.apache.livy.JobContext;
 
-import org.apache.livy.LivyClient;
-import org.apache.livy.LivyClientFactory;
+public class EnvCheck implements Job<String> {
 
-/**
- * Factory for HTTP Livy clients.
- */
-public final class HttpClientFactory implements LivyClientFactory {
+  private final String envKey;
 
-  @Override
-  public LivyClient createClient(URI uri, Properties config, Map<String, String> env) {
-    if (!"http".equals(uri.getScheme()) && !"https".equals(uri.getScheme())) {
-      return null;
-    }
-
-    return new HttpClient(uri, new HttpConf(config), env);
+  public EnvCheck(String key) {
+    this.envKey = key;
   }
 
+  @Override
+  public String call(JobContext jc) {
+    return System.getenv(envKey);
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the current Livy, we don't support setting environment variables per session, Livy server by default will honor env variables set in spark-env.sh during SparkSubmit process launches. This is not flexible enough if we want to set different env variables per session. So here propose to support this feature.

## How was this patch tested?

new UTs.
