### PR TITLE
[LIVY-416] Upgrade the version of Jackson from 2.4.4 to 2.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,9 +82,10 @@
     <hadoop.scope>compile</hadoop.scope>
     <spark.version>1.6.2</spark.version>
     <commons-codec.version>1.9</commons-codec.version>
+    <guava.version>15.0</guava.version>
     <httpclient.version>4.5.3</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>
-    <jackson.version>2.4.4</jackson.version>
+    <jackson.version>2.9.2</jackson.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <jetty.version>9.2.16.v20160414</jetty.version>
     <json4s.version>3.2.10</json4s.version>
@@ -307,6 +308,12 @@
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>${commons-codec.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${guava.version}</version>
       </dependency>
 
       <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -75,6 +75,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
     </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/LIVY-416

`com.fasterxml.jackson.core.JsonGenerationException` is sometimes thrown. The full stack trace is show on [JsonGenerationException.txt](https://github.com/apache/incubator-livy/files/1482566/JsonGenerationException.txt).

This is because of the Jackson's bug (https://github.com/FasterXML/jackson-core/issues/307) which was fixed at Jackson 2.7.7.

To fix this issue, the version of Jackson should be updated from 2.4.4 to the latest one (2.9.2).

In addition, `com.google.guava:guava:15.0` was added to the dependencies because it was removed from the dependencies of `com.fasterxml.jackson.module:jackson-module-scala_{2.10,2.11}:2.9.2`.

* [com.fasterxml.jackson.module:jackson-module-scala_2.10:2.4.4](https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-scala_2.10/2.4.4)
* [com.fasterxml.jackson.module:jackson-module-scala_2.11:2.4.4](https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-scala_2.11/2.4.4)
* [com.fasterxml.jackson.module:jackson-module-scala_2.10:2.9.2](https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-scala_2.10/2.9.2)
* [com.fasterxml.jackson.module:jackson-module-scala_2.11:2.9.2](https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-scala_2.11/2.9.2)

## How was this patch tested?
By executing `mvn clean package`.