### PR TITLE
LIVY-418. Respect spark.pyspark.python for PythonInterpreter

### DIFF
--- a/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
@@ -44,7 +44,8 @@ import org.apache.livy.sessions._
 object PythonInterpreter extends Logging {
 
   def apply(conf: SparkConf, sparkEntries: SparkEntries): Interpreter = {
-    val pythonExec = sys.env.get("PYSPARK_PYTHON")
+    val pythonExec = conf.getOption("spark.pyspark.python")
+      .orElse(sys.env.get("PYSPARK_PYTHON"))
       .orElse(sys.props.get("pyspark.python")) // This java property is only used for internal UT.
       .getOrElse("python")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`spark.pyspark.python` is introduced in spark 2.1, livy also need to update its code for choosing python version 

## How was this patch tested?

Manually verified. 


