### PR TITLE
[LIVY-19][REPL] Add SQL interpreter for Livy interactive session

### DIFF
--- a/core/src/main/scala/org/apache/livy/Logging.scala
+++ b/core/src/main/scala/org/apache/livy/Logging.scala
@@ -44,6 +44,10 @@ trait Logging {
     logger.warn(message.toString)
   }
 
+  def warn(message: => Any, t: Throwable): Unit = {
+    logger.warn(message.toString, t)
+  }
+
   def error(message: => Any, t: Throwable): Unit = {
     logger.error(message.toString, t)
   }

--- a/core/src/main/scala/org/apache/livy/sessions/Kind.scala
+++ b/core/src/main/scala/org/apache/livy/sessions/Kind.scala
@@ -33,6 +33,8 @@ object SparkR extends Kind("sparkr")
 
 object Shared extends Kind("shared")
 
+object SQL extends Kind("sql")
+
 object Kind {
 
   def apply(kind: String): Kind = kind match {
@@ -40,6 +42,7 @@ object Kind {
     case "pyspark" | "python" => PySpark
     case "sparkr" | "r" => SparkR
     case "shared" => Shared
+    case "sql" => SQL
     case other => throw new IllegalArgumentException(s"Invalid kind: $other")
   }
 }

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -666,12 +666,12 @@ A session represents an interactive shell.
     <td>Interactive R Spark session</td>
   </tr>
   <tr>
-    <td>SQL</td>
+    <td>sql</td>
     <td>Interactive SQL Spark session</td>
   </tr>
   </table>
 
-Starting with version 0.5.0-incubating, each session can support all three Scala, Python and R
+Starting with version 0.5.0-incubating, each session can support all four Scala, Python and R
 interpreters with newly added SQL interpreter. The ``kind`` field in session creation 
 is no longer required, instead users should specify code kind (spark, pyspark, sparkr or sql) 
 during statement submission.
@@ -681,7 +681,7 @@ while ignoring ``kind`` in statement submission. Livy will then use this session
 ``kind`` as default kind for all the submitted statements.
 
 If users want to submit code other than default ``kind`` specified in session creation, users
-need to specify code kind (spark, pyspark, sparkr or SQL) during statement submission.
+need to specify code kind (spark, pyspark, sparkr or sql) during statement submission.
 
 #### pyspark
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -665,18 +665,23 @@ A session represents an interactive shell.
     <td>sparkr</td>
     <td>Interactive R Spark session</td>
   </tr>
-</table>
+  <tr>
+    <td>SQL</td>
+    <td>Interactive SQL Spark session</td>
+  </tr>
+  </table>
 
 Starting with version 0.5.0-incubating, each session can support all three Scala, Python and R
-interpreters. The ``kind`` field in session creation is no longer required, instead users should
-specify code kind (spark, pyspark or sparkr) during statement submission.
+interpreters with newly added SQL interpreter. The ``kind`` field in session creation 
+is no longer required, instead users should specify code kind (spark, pyspark, sparkr or sql) 
+during statement submission.
 
 To be compatible with previous versions, users can still specify ``kind`` in session creation,
 while ignoring ``kind`` in statement submission. Livy will then use this session
 ``kind`` as default kind for all the submitted statements.
 
 If users want to submit code other than default ``kind`` specified in session creation, users
-need to specify code kind (spark, pyspark or sparkr) during statement submission.
+need to specify code kind (spark, pyspark, sparkr or SQL) during statement submission.
 
 #### pyspark
 

--- a/pom.xml
+++ b/pom.xml
@@ -1105,6 +1105,7 @@
       <properties>
         <spark.version>2.0.1</spark.version>
         <py4j.version>0.10.3</py4j.version>
+        <json4s.version>3.2.11</json4s.version>
         <spark.bin.download.url>
           https://d3kbcqa49mib13.cloudfront.net/spark-2.0.1-bin-hadoop2.7.tgz
         </spark.bin.download.url>
@@ -1122,6 +1123,7 @@
       <properties>
         <spark.version>2.1.0</spark.version>
         <py4j.version>0.10.4</py4j.version>
+        <json4s.version>3.2.11</json4s.version>
         <spark.bin.download.url>
           https://d3kbcqa49mib13.cloudfront.net/spark-2.1.0-bin-hadoop2.7.tgz
         </spark.bin.download.url>
@@ -1140,6 +1142,7 @@
         <spark.version>2.2.0</spark.version>
         <java.version>1.8</java.version>
         <py4j.version>0.10.4</py4j.version>
+        <json4s.version>3.2.11</json4s.version>
         <spark.bin.download.url>
           https://d3kbcqa49mib13.cloudfront.net/spark-2.2.0-bin-hadoop2.7.tgz
         </spark.bin.download.url>

--- a/repl/src/main/scala/org/apache/livy/repl/SQLInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/SQLInterpreter.scala
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.repl
+
+import java.lang.reflect.InvocationTargetException
+
+import scala.util.control.NonFatal
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.Row
+import org.json4s._
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+
+import org.apache.livy.Logging
+import org.apache.livy.rsc.driver.SparkEntries
+
+/**
+ * A SQL interpreter which only accepts SQL query, execute the query and return the result. The
+ * format of result is JSON format:
+ *  {
+ *    application/json: {
+ *        "schema": {
+ *          "type": "struct",
+ *          "fields": [
+ *            {
+ *              "name": "column_name",
+ *              "type": "column_type",
+ *              "nullable": true|false,
+ *              "metadata": {}
+ *            },
+ *            ...
+ *          ]
+ *        },
+ *        "data":[
+ *          [column_a, column_b, ...],
+ *          [column_a, column_b, ...],
+ *          ...
+ *        ]
+ *      }
+ *    }
+ *  }
+ *
+ * The size of ouput data is controlled by "spark.livy.sql.max-result", default maximum output
+ * rows is 1000.
+ */
+class SQLInterpreter(
+    sparkConf: SparkConf,
+    sparkEntries: SparkEntries) extends Interpreter with Logging {
+
+  private implicit def formats = DefaultFormats
+
+  private var spark: AnyRef = null
+
+  private val maxResult = sparkConf.getInt("spark.livy.sql.max-result", 1000)
+
+  override def kind: String = "sql"
+
+  override def start(): Unit = {
+    require(!sparkEntries.sc().sc.isStopped)
+
+    val sparkVersion = sparkConf.getInt("spark.livy.spark_major_version", 1)
+    if (sparkVersion == 1) {
+      spark = Option(sparkEntries.hivectx()).getOrElse(sparkEntries.sqlctx())
+    } else {
+      spark = sparkEntries.sparkSession()
+    }
+  }
+
+  override protected[repl] def execute(code: String): Interpreter.ExecuteResponse = {
+    try {
+      val result = spark.getClass.getMethod("sql", classOf[String]).invoke(spark, code)
+
+      // Get the schema info
+      val schema = result.getClass.getMethod("schema").invoke(result)
+      val jsonString = schema.getClass.getMethod("json").invoke(schema).asInstanceOf[String]
+      val jSchema = parse(jsonString)
+
+      // Get the row data
+      val rows = result.getClass.getMethod("take", classOf[Int])
+        .invoke(result, maxResult: java.lang.Integer)
+        .asInstanceOf[Array[Row]]
+          .map(_.toSeq)
+      val jRows = Extraction.decompose(rows)
+
+      Interpreter.ExecuteSuccess(
+        APPLICATION_JSON -> (("schema" -> jSchema) ~ ("data" -> jRows)))
+    } catch {
+      case e: InvocationTargetException =>
+        warn(s"Fail to execute query $code", e.getTargetException)
+        val cause = e.getTargetException
+        Interpreter.ExecuteError("Error", cause.getMessage, cause.getStackTrace.map(_.toString))
+
+      case NonFatal(f) =>
+        warn(s"Fail to execute query $code", f)
+        Interpreter.ExecuteError("Error", f.getMessage, f.getStackTrace.map(_.toString))
+    }
+  }
+
+  override def close(): Unit = { }
+}

--- a/repl/src/main/scala/org/apache/livy/repl/SQLInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/SQLInterpreter.scala
@@ -28,6 +28,7 @@ import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
 
 import org.apache.livy.Logging
+import org.apache.livy.rsc.RSCConf
 import org.apache.livy.rsc.driver.SparkEntries
 
 /**
@@ -61,13 +62,14 @@ import org.apache.livy.rsc.driver.SparkEntries
  */
 class SQLInterpreter(
     sparkConf: SparkConf,
+    rscConf: RSCConf,
     sparkEntries: SparkEntries) extends Interpreter with Logging {
 
   private implicit def formats = DefaultFormats
 
   private var spark: AnyRef = null
 
-  private val maxResult = sparkConf.getInt("spark.livy.sql.max-result", 1000)
+  private val maxResult = rscConf.getInt(RSCConf.Entry.SQL_NUM_ROWS)
 
   override def kind: String = "sql"
 

--- a/repl/src/main/scala/org/apache/livy/repl/Session.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/Session.scala
@@ -105,7 +105,7 @@ class Session(
             throw new IllegalStateException("SparkInterpreter should not be lazily created.")
           case PySpark => PythonInterpreter(sparkConf, entries)
           case SparkR => SparkRInterpreter(sparkConf, entries)
-          case SQL => new SQLInterpreter(sparkConf, entries)
+          case SQL => new SQLInterpreter(sparkConf, livyConf, entries)
         }
         interp.start()
         interpGroup(kind) = interp

--- a/repl/src/main/scala/org/apache/livy/repl/Session.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/Session.scala
@@ -105,6 +105,7 @@ class Session(
             throw new IllegalStateException("SparkInterpreter should not be lazily created.")
           case PySpark => PythonInterpreter(sparkConf, entries)
           case SparkR => SparkRInterpreter(sparkConf, entries)
+          case SQL => new SQLInterpreter(sparkConf, entries)
         }
         interp.start()
         interpGroup(kind) = interp
@@ -331,24 +332,25 @@ class Session(
 
   private def setJobGroup(codeType: Kind, statementId: Int): String = {
     val jobGroup = statementIdToJobGroup(statementId)
-    val cmd = codeType match {
-      case Spark =>
+    val (cmd, tpe) = codeType match {
+      case Spark | SQL =>
         // A dummy value to avoid automatic value binding in scala REPL.
-        s"""val _livyJobGroup$jobGroup = sc.setJobGroup("$jobGroup",""" +
-          s""""Job group for statement $jobGroup")"""
+        (s"""val _livyJobGroup$jobGroup = sc.setJobGroup("$jobGroup",""" +
+          s""""Job group for statement $jobGroup")""",
+         Spark)
       case PySpark =>
-        s"""sc.setJobGroup("$jobGroup", "Job group for statement $jobGroup")"""
+        (s"""sc.setJobGroup("$jobGroup", "Job group for statement $jobGroup")""", PySpark)
       case SparkR =>
         sc.getConf.get("spark.livy.spark_major_version", "1") match {
           case "1" =>
-            s"""setJobGroup(sc, "$jobGroup", "Job group for statement $jobGroup", """ +
-              "FALSE)"
+            (s"""setJobGroup(sc, "$jobGroup", "Job group for statement $jobGroup", FALSE)""",
+             SparkR)
           case "2" =>
-            s"""setJobGroup("$jobGroup", "Job group for statement $jobGroup", FALSE)"""
+            (s"""setJobGroup("$jobGroup", "Job group for statement $jobGroup", FALSE)""", SparkR)
         }
     }
     // Set the job group
-    executeCode(interpreter(codeType), statementId, cmd)
+    executeCode(interpreter(tpe), statementId, cmd)
   }
 
   private def statementIdToJobGroup(statementId: Int): String = {

--- a/repl/src/test/scala/org/apache/livy/repl/SQLInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/SQLInterpreterSpec.scala
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.repl
+
+import scala.util.Try
+
+import org.apache.spark.SparkConf
+import org.json4s.{DefaultFormats, JValue}
+import org.json4s.JsonAST.JArray
+import org.json4s.JsonDSL._
+
+import org.apache.livy.rsc.driver.SparkEntries
+
+case class People(name: String, age: Int)
+
+class SQLInterpreterSpec extends BaseInterpreterSpec {
+
+  implicit val formats = DefaultFormats
+
+  private var sparkEntries: SparkEntries = _
+
+  override def createInterpreter(): Interpreter = {
+    val conf = new SparkConf()
+    if (sparkEntries == null) {
+      sparkEntries = new SparkEntries(conf)
+    }
+    new SQLInterpreter(conf, sparkEntries)
+  }
+
+  it should "execute sql queries" in withInterpreter { interpreter =>
+    val rdd = sparkEntries.sc().parallelize(Seq(People("Jerry", 20), People("Michael", 21)))
+    val df = sparkEntries.sqlctx().createDataFrame(rdd)
+    df.registerTempTable("people")
+
+    // Test normal behavior
+    val resp1 = interpreter.execute(
+      """
+        |SELECT * FROM people
+      """.stripMargin)
+
+    // In Spark 1.6, 2.0, 2.2 the "nullable" field of column "age" is false. In spark 2.1, this
+    // field is true.
+    val expectedResult = (nullable: Boolean) => {
+      Interpreter.ExecuteSuccess(
+        APPLICATION_JSON -> (("schema" ->
+          (("type" -> "struct") ~
+            ("fields" -> List(
+              ("name" -> "name") ~ ("type" -> "string") ~ ("nullable" -> true) ~
+                ("metadata" -> List()),
+              ("name" -> "age") ~ ("type" -> "integer") ~ ("nullable" -> nullable) ~
+                ("metadata" -> List())
+            )))) ~
+          ("data" -> List(
+            List[JValue]("Jerry", 20),
+            List[JValue]("Michael", 21)
+          )))
+      )
+    }
+
+    val result = Try { resp1 should equal(expectedResult(false))}
+      .orElse(Try { resp1 should equal(expectedResult(true)) })
+    if (result.isFailure) {
+      fail(s"$resp1 doesn't equal to expected result")
+    }
+
+    // Test empty result
+     val resp2 = interpreter.execute(
+      """
+        |SELECT name FROM people WHERE age > 22
+      """.stripMargin)
+    resp2 should equal(Interpreter.ExecuteSuccess(
+      APPLICATION_JSON -> (("schema" ->
+        (("type" -> "struct") ~
+          ("fields" -> List(
+            ("name" -> "name") ~ ("type" -> "string") ~ ("nullable" -> true) ~
+              ("metadata" -> List())
+          )))) ~
+        ("data" -> JArray(List())))
+    ))
+  }
+
+  it should "throw exception for illegal query" in withInterpreter { interpreter =>
+    val resp = interpreter.execute(
+      """
+        |SELECT * FROM peopl1
+      """.stripMargin)
+
+    assert(resp.isInstanceOf[Interpreter.ExecuteError])
+  }
+
+  it should "fail if submitting multiple queries" in withInterpreter { interpreter =>
+    val resp = interpreter.execute(
+      """
+        |SELECT name FROM people;
+        |SELECT age FROM people
+      """.stripMargin)
+
+    assert(resp.isInstanceOf[Interpreter.ExecuteError])
+  }
+}

--- a/repl/src/test/scala/org/apache/livy/repl/SQLInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/SQLInterpreterSpec.scala
@@ -97,10 +97,13 @@ class SQLInterpreterSpec extends BaseInterpreterSpec {
   it should "throw exception for illegal query" in withInterpreter { interpreter =>
     val resp = interpreter.execute(
       """
-        |SELECT * FROM peopl1
+        |SELECT * FROM people1
       """.stripMargin)
 
     assert(resp.isInstanceOf[Interpreter.ExecuteError])
+    val error = resp.asInstanceOf[Interpreter.ExecuteError]
+    error.ename should be ("Error")
+    assert(error.evalue.contains("not found"))
   }
 
   it should "fail if submitting multiple queries" in withInterpreter { interpreter =>
@@ -111,5 +114,6 @@ class SQLInterpreterSpec extends BaseInterpreterSpec {
       """.stripMargin)
 
     assert(resp.isInstanceOf[Interpreter.ExecuteError])
+    resp.asInstanceOf[Interpreter.ExecuteError].ename should be ("Error")
   }
 }

--- a/repl/src/test/scala/org/apache/livy/repl/SQLInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/SQLInterpreterSpec.scala
@@ -24,6 +24,7 @@ import org.json4s.{DefaultFormats, JValue}
 import org.json4s.JsonAST.JArray
 import org.json4s.JsonDSL._
 
+import org.apache.livy.rsc.RSCConf
 import org.apache.livy.rsc.driver.SparkEntries
 
 case class People(name: String, age: Int)
@@ -39,7 +40,7 @@ class SQLInterpreterSpec extends BaseInterpreterSpec {
     if (sparkEntries == null) {
       sparkEntries = new SparkEntries(conf)
     }
-    new SQLInterpreter(conf, sparkEntries)
+    new SQLInterpreter(conf, new RSCConf(), sparkEntries)
   }
 
   it should "execute sql queries" in withInterpreter { interpreter =>

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
@@ -52,7 +52,7 @@ public class RSCConf extends ClientConf<RSCConf> {
     // Address for the RSC driver to connect back with it's connection info.
     LAUNCHER_ADDRESS("launcher.address", null),
     LAUNCHER_PORT_RANGE("launcher.port.range", "10000~10010"),
-    // Setting up of this propety by user has no benefit. It is currently being used
+    // Setting up of this property by user has no benefit. It is currently being used
     // to pass  port information from ContextLauncher to RSCDriver
     LAUNCHER_PORT("launcher.port", -1),
     // How long will the RSC wait for a connection for a Livy server before shutting itself down.

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
@@ -78,7 +78,10 @@ public class RSCConf extends ClientConf<RSCConf> {
     JOB_CANCEL_TIMEOUT("job-cancel.timeout", "30s"),
 
     RETAINED_STATEMENTS("retained-statements", 100),
-    RETAINED_SHARE_VARIABLES("retained.share-variables", 100);
+    RETAINED_SHARE_VARIABLES("retained.share-variables", 100),
+
+    // Number of result rows to get for SQL Interpreters.
+    SQL_NUM_ROWS("sql.num-rows", 1000);
 
     private final String key;
     private final Object dflt;


### PR DESCRIPTION
## What changes were proposed in this pull request?

With the requirement to support executing SQL query in Livy interactive session. Here propose to add this new interpreter for SQL specific usage. 

This interpreter will honor a new code kind "SQL", and pass query to SparkSession/SQLContext to get executed. The returned format is json format with schema included, each type is properly mapped a related json type.

## How was this patch tested?

Add new UTs and ITs.
