### PR TITLE
[LIVY-104][BUILD][WIP] Update default Scala version 2.11

### DIFF
--- a/integration-test/src/main/scala/org/apache/livy/test/framework/BaseIntegrationTestSuite.scala
+++ b/integration-test/src/main/scala/org/apache/livy/test/framework/BaseIntegrationTestSuite.scala
@@ -54,7 +54,7 @@ abstract class BaseIntegrationTestSuite extends FunSuite with Matchers with Befo
   }
 
   protected def restartLivy(): Unit = {
-    val f = future {
+    val f = Future {
       cluster.stopLivy()
       cluster.runLivy()
     }

--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,8 @@
     <py4j.version>0.9</py4j.version>
     <scala-2.10.version>2.10.4</scala-2.10.version>
     <scala-2.11.version>2.11.8</scala-2.11.version>
-    <scala.binary.version>2.10</scala.binary.version>
-    <scala.version>${scala-2.10.version}</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
+    <scala.version>${scala-2.11.version}</scala.version>
     <scalatest.version>2.2.4</scalatest.version>
     <scalatra.version>2.3.0</scalatra.version>
     <java.version>1.7</java.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update default Scala version to 2.11, since 2.10 is EOD now.

## How was this patch tested?

Existing test.