### PR TITLE
[LIVY-429] preserve url fragment in spark.yarn.dist.archives

### DIFF
--- a/server/src/main/scala/org/apache/livy/sessions/Session.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/Session.scala
@@ -116,8 +116,11 @@ object Session {
     val defaultFS = livyConf.hadoopConf.get("fs.defaultFS").stripSuffix("/")
     val resolved =
       if (uri.getScheme() == null) {
-        require(uri.getPath().startsWith("/"), s"Path '${uri.getPath()}' is not absolute.")
-        new URI(defaultFS + uri.getPath())
+        val pathWithSegment =
+          if (uri.getFragment() != null) uri.getPath() + '#' + uri.getFragment() else uri.getPath()
+
+        require(pathWithSegment.startsWith("/"), s"Path '${uri.getPath()}' is not absolute.")
+        new URI(defaultFS + pathWithSegment)
       } else {
         uri
       }

--- a/server/src/test/scala/org/apache/livy/sessions/SessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/SessionSpec.scala
@@ -29,8 +29,8 @@ class SessionSpec extends FunSuite with LivyBaseUnitTestSuite {
     val conf = new LivyConf(false)
     conf.hadoopConf.set("fs.defaultFS", "dummy:///")
 
-    val uris = Seq("http://example.com/foo", "hdfs:/bar", "/baz")
-    val expected = Seq(uris(0), uris(1), "dummy:///baz")
+    val uris = Seq("http://example.com/foo", "hdfs:/bar", "/baz", "/foo#bar")
+    val expected = Seq(uris(0), uris(1), "dummy:///baz", "dummy:///foo#bar")
     assert(Session.resolveURIs(uris, conf) === expected)
 
     intercept[IllegalArgumentException] {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Preserve url fragment identifier in spark.yarn.dist.archives setting when there is no schema specified. Current code truncates url fragment, as a result Spark just copies archives to job local dir without extracting it.

## How was this patch tested?

Added case to existing unit test
