### PR TITLE
[LIVY-104] [Core] Update Livy build to Scala 2.11

### DIFF
--- a/integration-test/src/main/scala/org/apache/livy/test/framework/BaseIntegrationTestSuite.scala
+++ b/integration-test/src/main/scala/org/apache/livy/test/framework/BaseIntegrationTestSuite.scala
@@ -54,7 +54,7 @@ abstract class BaseIntegrationTestSuite extends FunSuite with Matchers with Befo
   }
 
   protected def restartLivy(): Unit = {
-    val f = future {
+    val f = Future {
       cluster.stopLivy()
       cluster.runLivy()
     }

--- a/integration-test/src/test/scala/org/apache/livy/test/InteractiveIT.scala
+++ b/integration-test/src/test/scala/org/apache/livy/test/InteractiveIT.scala
@@ -75,7 +75,7 @@ class InteractiveIT extends BaseIntegrationTestSuite {
       // This is important because if YARN app state is killed, Spark history is not archived.
       val appId = s.appId()
       s.stop()
-      eventually(timeout(15 seconds), interval(5 seconds)) {
+      eventually(timeout(5 seconds), interval(1 seconds)) {
         val appReport = cluster.yarnClient.getApplicationReport(appId)
         appReport.getYarnApplicationState() shouldEqual YarnApplicationState.FINISHED
       }

--- a/integration-test/src/test/scala/org/apache/livy/test/JobApiIT.scala
+++ b/integration-test/src/test/scala/org/apache/livy/test/JobApiIT.scala
@@ -168,10 +168,10 @@ class JobApiIT extends BaseIntegrationTestSuite with BeforeAndAfterAll with Logg
 
     val jobs = Seq(
       new ScalaEcho("abcde"),
-      new ScalaEcho(Seq(1, 2, 3, 4)),
+      new ScalaEcho(IndexedSeq(1, 2, 3, 4)),
       new ScalaEcho(Map(1 -> 2, 3 -> 4)),
       new ScalaEcho(ValueHolder("abcde")),
-      new ScalaEcho(ValueHolder(Seq(1, 2, 3, 4))),
+      new ScalaEcho(ValueHolder(IndexedSeq(1, 2, 3, 4))),
       new ScalaEcho(Some("abcde"))
     )
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,8 @@
     <py4j.version>0.9</py4j.version>
     <scala-2.10.version>2.10.4</scala-2.10.version>
     <scala-2.11.version>2.11.8</scala-2.11.version>
-    <scala.binary.version>2.10</scala.binary.version>
-    <scala.version>${scala-2.10.version}</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
+    <scala.version>${scala-2.11.version}</scala.version>
     <scalatest.version>2.2.4</scalatest.version>
     <scalatra.version>2.3.0</scalatra.version>
     <java.version>1.7</java.version>

--- a/server/src/main/scala/org/apache/livy/server/JsonServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/JsonServlet.scala
@@ -133,7 +133,7 @@ abstract class JsonServlet extends ScalatraServlet with ApiFormats with FutureSu
   }
 
   private def toJson(obj: Any): Any = {
-    if (obj != null && obj != ()) {
+    if (obj != null && obj != (())) {
       mapper.writeValueAsBytes(obj)
     } else {
       null


### PR DESCRIPTION
[LIVY-104](https://issues.apache.org/jira/browse/LIVY-104)

Livy currently builds using Scala 2.10 which has been EOL for a couple years. This update switches the build to use 2.11 instead.
This does not drop Livy support for Scala 2.10, it only updates the version used to build Livy itself.
We are holding off updating to Scala 2.12 since Livy still supports Spark 1.6, which doesn't support 2.12 and such an update would break UTs for 1.6, any update to 2.12 will have to wait until Spark 1.6 support is dropped.

This update also addresses any new deprecation warning raised in the update as well as updates various ITs to pass.

This locally passes both UTs and ITs build withe all supported versions of Spark.