### PR TITLE
[LIVY-435] Allow floating point numbers to be used for the driver and executor core counts

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/batch/CreateBatchRequest.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/CreateBatchRequest.scala
@@ -27,9 +27,9 @@ class CreateBatchRequest {
   var pyFiles: List[String] = List()
   var files: List[String] = List()
   var driverMemory: Option[String] = None
-  var driverCores: Option[Int] = None
+  var driverCores: Option[Double] = None
   var executorMemory: Option[String] = None
-  var executorCores: Option[Int] = None
+  var executorCores: Option[Double] = None
   var numExecutors: Option[Int] = None
   var archives: List[String] = List()
   var queue: Option[String] = None

--- a/server/src/main/scala/org/apache/livy/server/interactive/CreateInteractiveRequest.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/CreateInteractiveRequest.scala
@@ -26,9 +26,9 @@ class CreateInteractiveRequest {
   var pyFiles: List[String] = List()
   var files: List[String] = List()
   var driverMemory: Option[String] = None
-  var driverCores: Option[Int] = None
+  var driverCores: Option[Double] = None
   var executorMemory: Option[String] = None
-  var executorCores: Option[Int] = None
+  var executorCores: Option[Double] = None
   var numExecutors: Option[Int] = None
   var archives: List[String] = List()
   var queue: Option[String] = None

--- a/server/src/main/scala/org/apache/livy/utils/SparkProcessBuilder.scala
+++ b/server/src/main/scala/org/apache/livy/utils/SparkProcessBuilder.scala
@@ -92,7 +92,7 @@ class SparkProcessBuilder(livyConf: LivyConf) extends Logging {
     this
   }
 
-  def driverCores(driverCores: Int): SparkProcessBuilder = {
+  def driverCores(driverCores: Double): SparkProcessBuilder = {
     this.driverCores(driverCores.toString)
   }
 
@@ -104,7 +104,7 @@ class SparkProcessBuilder(livyConf: LivyConf) extends Logging {
     conf("spark.driver.cores", driverCores)
   }
 
-  def executorCores(executorCores: Int): SparkProcessBuilder = {
+  def executorCores(executorCores: Double): SparkProcessBuilder = {
     this.executorCores(executorCores.toString)
   }
 

--- a/server/src/test/scala/org/apache/livy/server/batch/CreateBatchRequestSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/CreateBatchRequestSpec.scala
@@ -50,6 +50,20 @@ class CreateBatchRequestSpec extends FunSpec with LivyBaseUnitTestSuite {
       assert(req.conf === Map())
     }
 
+    it("should support integer cores") {
+      val json = """{ "driverCores" : 1, "executorCores": 2 }"""
+      val req = mapper.readValue(json, classOf[CreateBatchRequest])
+      assert(req.driverCores === 1)
+      assert(req.executorCores === 2)
+    }
+
+    it("should support float cores") {
+      val json = """{ "driverCores" : 0.1, "executorCores": 0.2 }"""
+      val req = mapper.readValue(json, classOf[CreateBatchRequest])
+      assert(req.driverCores === 0.1)
+      assert(req.executorCores === 0.2)
+    }
+
   }
 
 }

--- a/server/src/test/scala/org/apache/livy/server/batch/CreateBatchRequestSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/CreateBatchRequestSpec.scala
@@ -53,15 +53,26 @@ class CreateBatchRequestSpec extends FunSpec with LivyBaseUnitTestSuite {
     it("should support integer cores") {
       val json = """{ "driverCores" : 1, "executorCores": 2 }"""
       val req = mapper.readValue(json, classOf[CreateBatchRequest])
-      assert(req.driverCores === 1)
-      assert(req.executorCores === 2)
+      assert(req.driverCores.get === 1)
+      assert(req.executorCores.get === 2)
     }
 
     it("should support float cores") {
       val json = """{ "driverCores" : 0.1, "executorCores": 0.2 }"""
       val req = mapper.readValue(json, classOf[CreateBatchRequest])
-      assert(req.driverCores === 0.1)
-      assert(req.executorCores === 0.2)
+      assert(req.driverCores.get === 0.1)
+      assert(req.executorCores.get === 0.2)
+    }
+
+    it("should not support string cores") {
+      val json = """{ "driverCores" : "asdf", "executorCores": "0.2" }"""
+      val req = mapper.readValue(json, classOf[CreateBatchRequest])
+      intercept[ClassCastException] {
+        req.driverCores.get
+      }
+      intercept[ClassCastException] {
+        req.executorCores.get
+      }
     }
 
   }

--- a/server/src/test/scala/org/apache/livy/server/interactive/CreateInteractiveRequestSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/CreateInteractiveRequestSpec.scala
@@ -53,15 +53,26 @@ class CreateInteractiveRequestSpec extends FunSpec with LivyBaseUnitTestSuite {
     it("should support integer cores") {
       val json = """{ "driverCores" : 1, "executorCores": 2 }"""
       val req = mapper.readValue(json, classOf[CreateInteractiveRequest])
-      assert(req.driverCores === 1)
-      assert(req.executorCores === 2)
+      assert(req.driverCores.get === 1)
+      assert(req.executorCores.get === 2)
     }
 
     it("should support float cores") {
       val json = """{ "driverCores" : 0.1, "executorCores": 0.2 }"""
       val req = mapper.readValue(json, classOf[CreateInteractiveRequest])
-      assert(req.driverCores === 0.1)
-      assert(req.executorCores === 0.2)
+      assert(req.driverCores.get === 0.1)
+      assert(req.executorCores.get === 0.2)
+    }
+
+    it("should not support string cores") {
+      val json = """{ "driverCores" : "asdf", "executorCores": "0.2" }"""
+      val req = mapper.readValue(json, classOf[CreateInteractiveRequest])
+      intercept[ClassCastException] {
+        req.driverCores.get
+      }
+      intercept[ClassCastException] {
+        req.executorCores.get
+      }
     }
 
   }

--- a/server/src/test/scala/org/apache/livy/server/interactive/CreateInteractiveRequestSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/CreateInteractiveRequestSpec.scala
@@ -50,6 +50,20 @@ class CreateInteractiveRequestSpec extends FunSpec with LivyBaseUnitTestSuite {
       assert(req.conf === Map())
     }
 
+    it("should support integer cores") {
+      val json = """{ "driverCores" : 1, "executorCores": 2 }"""
+      val req = mapper.readValue(json, classOf[CreateInteractiveRequest])
+      assert(req.driverCores === 1)
+      assert(req.executorCores === 2)
+    }
+
+    it("should support float cores") {
+      val json = """{ "driverCores" : 0.1, "executorCores": 0.2 }"""
+      val req = mapper.readValue(json, classOf[CreateInteractiveRequest])
+      assert(req.driverCores === 0.1)
+      assert(req.executorCores === 0.2)
+    }
+
   }
 
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LIVY-435 is the ticket.

I added unit tests for the improved struct parsing but SparkProcessBuilder has no tests currently so I wasn't sure how to add them (if needed, the changes there are relatively minor).