### PR TITLE
[LIVY-414] Support environment variables for interactive and batch sessions

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -147,6 +147,11 @@ Creates a new interactive Scala, Python, or R shell in the cluster.
     <td>Map of key=val</td>
   </tr>
   <tr>
+    <td>env</td>
+    <td>Environment variables to set before creating Spark client</td>
+    <td>Map of key=val</td>
+  </tr>
+  <tr>
     <td>heartbeatTimeoutInSecond</td>
     <td>Timeout in second to which session be orphaned</td>
     <td>int</td>
@@ -471,6 +476,11 @@ Returns all the active batch sessions.
   <tr>
     <td>conf</td>
     <td>Spark configuration properties</td>
+    <td>Map of key=val</td>
+  </tr>
+  <tr>
+    <td>env</td>
+    <td>Environment variables to set before running `spark-submit`</td>
     <td>Map of key=val</td>
   </tr>
 </table>

--- a/rsc/src/main/java/org/apache/livy/rsc/ContextLauncher.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/ContextLauncher.java
@@ -17,12 +17,10 @@
 
 package org.apache.livy.rsc;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
@@ -31,6 +29,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -217,7 +216,21 @@ class ContextLauncher {
       };
       return new ChildProcess(conf, promise, child, confFile);
     } else {
-      final SparkLauncher launcher = new SparkLauncher();
+      String envConfigPrefix = RSCConf.Entry.SPARK_ENV + ".";
+      Map<String, String> env = new HashMap<>();
+      for(Map.Entry<String, String> entry : conf) {
+        if(entry.getKey().startsWith(envConfigPrefix)) {
+          env.put(entry.getKey().replace(envConfigPrefix, ""), entry.getValue());
+        }
+      }
+      final SparkLauncher launcher = new SparkLauncher(env);
+
+      // Spark 1.x does not support specifying deploy mode in conf and needs special handling.
+      String deployMode = conf.get(SPARK_DEPLOY_MODE);
+      if (deployMode != null) {
+        launcher.setDeployMode(deployMode);
+      }
+
       launcher.setSparkHome(System.getenv(SPARK_HOME_ENV));
       launcher.setAppResource(SparkLauncher.NO_RESOURCE);
       launcher.setPropertiesFile(confFile.getAbsolutePath());

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
@@ -81,7 +81,9 @@ public class RSCConf extends ClientConf<RSCConf> {
     RETAINED_SHARE_VARIABLES("retained.share-variables", 100),
 
     // Number of result rows to get for SQL Interpreters.
-    SQL_NUM_ROWS("sql.num-rows", 1000);
+    SQL_NUM_ROWS("sql.num-rows", 1000),
+
+    SPARK_ENV("spark.env", null);
 
     private final String key;
     private final Object dflt;

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
@@ -82,13 +82,14 @@ object BatchSession extends Logging {
       request.numExecutors.foreach(builder.numExecutors)
       request.queue.foreach(builder.queue)
       request.name.foreach(builder.name)
+      request.env.foreach{case (k, v) => builder.env(k, v)}
 
       sessionStore.save(BatchSession.RECOVERY_SESSION_TYPE, s.recoveryMetadata)
 
       builder.redirectOutput(Redirect.PIPE)
       builder.redirectErrorStream(true)
 
-      val file = resolveURIs(Seq(request.file), livyConf)(0)
+      val file = resolveURIs(Seq(request.file), livyConf).head
       val sparkSubmit = builder.start(Some(file), request.args)
 
       Utils.startDaemonThread(s"batch-session-process-$id") {

--- a/server/src/main/scala/org/apache/livy/server/batch/CreateBatchRequest.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/CreateBatchRequest.scala
@@ -35,6 +35,7 @@ class CreateBatchRequest {
   var queue: Option[String] = None
   var name: Option[String] = None
   var conf: Map[String, String] = Map()
+  var env: Map[String, String] = Map()
 
   override def toString: String = {
     s"[proxyUser: $proxyUser, " +
@@ -51,6 +52,7 @@ class CreateBatchRequest {
       (if (numExecutors.isDefined) s"numExecutors: ${numExecutors.get}, " else "") +
       (if (queue.isDefined) s"queue: ${queue.get}, " else "") +
       (if (name.isDefined) s"name: ${name.get}, " else "") +
-      (if (conf.nonEmpty) s"conf: ${conf.mkString(",")}]" else "]")
+      (if (conf.nonEmpty) s"conf: ${conf.mkString(",")}, " else "") +
+      (if (env.nonEmpty) s"conf: ${env.mkString(",")}]" else "]")
   }
 }

--- a/server/src/main/scala/org/apache/livy/server/interactive/CreateInteractiveRequest.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/CreateInteractiveRequest.scala
@@ -35,6 +35,7 @@ class CreateInteractiveRequest {
   var name: Option[String] = None
   var conf: Map[String, String] = Map()
   var heartbeatTimeoutInSecond: Int = 0
+  var env: Map[String, String] = Map()
 
   override def toString: String = {
     s"[kind: $kind, proxyUser: $proxyUser, " +
@@ -50,6 +51,7 @@ class CreateInteractiveRequest {
       (if (queue.isDefined) s"queue: ${queue.get}, " else "") +
       (if (name.isDefined) s"name: ${name.get}, " else "") +
       (if (conf.nonEmpty) s"conf: ${conf.mkString(",")}, " else "") +
+      (if (env.nonEmpty) s"conf: ${env.mkString(",")}]" else "") +
       s"heartbeatTimeoutInSecond: $heartbeatTimeoutInSecond]"
   }
 }

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -98,12 +98,20 @@ object InteractiveSession extends Logging {
 
       builderProperties.getOrElseUpdate("spark.app.name", s"livy-session-$id")
 
+      val envConfigPrefix = RSCConf.Entry.SPARK_ENV + "."
+      val livyClientEnv = mutable.Map[String, String]()
+      request.env.foreach { case (key, opt) =>
+          livyClientEnv.put(envConfigPrefix + key, opt)
+      }
+
+
       info(s"Creating Interactive session $id: [owner: $owner, request: $request]")
       val builder = new LivyClientBuilder()
         .setAll(builderProperties.asJava)
         .setConf("livy.client.session-id", id.toString)
         .setConf(RSCConf.Entry.DRIVER_CLASS.key(), "org.apache.livy.repl.ReplDriver")
         .setConf(RSCConf.Entry.PROXY_USER.key(), impersonatedUser.orNull)
+        .setAll(livyClientEnv.asJava)
         .setURI(new URI("rsc:/"))
 
       Option(builder.build().asInstanceOf[RSCClient])


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LIVY-414

## What changes were proposed in this pull request?
* Add support for setting environment variables for batch sessions
* Interactive sessions can use `spark.driver.extraClasspath`
* Batch sessions sometimes need to modify `SPARK_CLASSPATH` to pickup delegation tokens
    * TODO - Add link to blog
* Should also be able to setup `SPARK_HOME` on each request to choose between different Spark versions like Spark 1 and Spark 2.
    * https://docs.hortonworks.com/HDPDocuments/HDP2/HDP-2.6.4/bk_spark-component-guide/content/spark2-livy.html
* Exposes new config `env` for batch request

## How was this patch tested?
* New unittest to ensure that `SparkProcessBuilder` gets environment variables before launching `spark-submit`
* New unittest to ensure that `SparkLauncher` gets environment variables before creating session
* Batch sessions tested against Spark cluster