### PR TITLE
[LIVY-448] Assembly format is duplicated in pom.xml and assembly.xml

### DIFF
--- a/assembly/assembly.xml
+++ b/assembly/assembly.xml
@@ -19,7 +19,7 @@
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
   <id>livy-server</id>
   <formats>
-    <format>zip</format>
+    <format>${assembly.format}</format>
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -77,9 +77,6 @@
               <descriptors>
                 <descriptor>assembly.xml</descriptor>
               </descriptors>
-              <formats>
-                <format>${assembly.format}</format>
-              </formats>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?
The assembly format for Livy is specified twice:
1 in `assembly/pom.xml`:
```xml
              <formats>
                <format>${assembly.format}</format>
              </formats>
```
2 in `assembly/assembly.xml`
```
              <formats>
                <format>zip</format>
              </formats>
```
But only one is enough. Also in `assembly/assembly.xml`, the format is hard coded as zip, but is should be based 

## How was this patch tested?
All the unit tests and ITs pass as usual. Moreover, I tested that  `targz` profile builds a tar.gz archive and the default profile builds a zip archive.

For example,
this builds the zip archive:
```
mvn -am -pl assembly package
```
And this builds the tar.gz artifact:
```
mvn -Ptargz -am -pl assembly package
```

Task-url: https://issues.apache.org/jira/browse/LIVY-448
