### PR TITLE
Fix travis builds

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -23,6 +23,7 @@ logs/*
 **/derby.log
 **/metastore_db/**
 **/.eggs/**
+**/.pytest_cache/**
 **/Gemfile.lock
 **/jquery-2.1.1.min.js
 docs/**/*.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,4 +80,4 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 
 after_failure:
-  - for log in `find * -name "*.log" -o -name "stderr" -o -name "stdout"`; do echo "=========$log========="; cat $log; done
+  - for log in `find * -name "*.log" -o -name "stderr" -o -name "stdout" -o -name "rat.txt"`; do echo "=========$log========="; cat $log; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,9 +62,9 @@ before_install:
   - sudo apt-get -y install libkrb5-dev
   - sudo apt-get -y remove python-setuptools
   - sudo pip2 install --upgrade pip "setuptools < 36"
-  - sudo pip3 install --upgrade pip "setuptools < 36"
+  - sudo python3 -m pip install --upgrade pip "setuptools < 36"
   - sudo pip2 install codecov cloudpickle
-  - sudo pip3 install cloudpickle
+  - sudo python3 -m pip install cloudpickle
 
 install:
   - mvn $MVN_FLAG install -Dskip -DskipTests -DskipITs -Dmaven.javadoc.skip=true -B -V


### PR DESCRIPTION
Each individual commit has a more detailed description of what's being changed and why.

## What changes were proposed in this pull request?

At the moment, Travis builds don't work:

* https://travis-ci.org/mineo/incubator-livy/builds/359324523 - the `sudo pip3 install --upgrade pip "setuptools < 36"` command fails with `sudo: pip3: command not found`.
* fixing that, the `failing the org.apache.rat:apache-rat-plugin:0.12:check` maven goal fails because it sees `.pytest_cache` folders that it doesn't know about (https://github.com/pytest-dev/pytest/issues/3286, failure in https://travis-ci.org/mineo/incubator-livy/jobs/359326261, check the raw log).

This pull request works around the pip3 failures by just using pip as a callable module (possible since Python 3.4) and adding `.pytest_cache` to raw-excludes, as well as showing the contents of `rat.txt` files in the `after_failure` step. I concede that the pip change is more of a workaround, but I don't know how else to fix it and unblock testing.

## How was this patch tested?

Running the tests on travis.

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
