### PR TITLE
[LIVY-458][Build] Upgrade jackson version to 2.9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <guava.version>15.0</guava.version>
     <httpclient.version>4.5.3</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>
-    <jackson.version>2.9.2</jackson.version>
+    <jackson.version>2.9.5</jackson.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <jetty.version>9.2.16.v20160414</jetty.version>
     <json4s.version>3.2.10</json4s.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to several security issues of jackson databind module (CVE-2018-5968, CVE-2017-17485, CVE-2018-7489), here propose to upgrade jackson version 2.9.5.

## How was this patch tested?

Existing UTs.
