### PR TITLE
[LIVY-460][Server] Remove misleading log prefix

### DIFF
--- a/server/src/main/scala/org/apache/livy/utils/LineBufferedStream.scala
+++ b/server/src/main/scala/org/apache/livy/utils/LineBufferedStream.scala
@@ -38,7 +38,7 @@ class LineBufferedStream(inputStream: InputStream, logSize: Int) extends Logging
     override def run() = {
       val lines = Source.fromInputStream(inputStream).getLines()
       for (line <- lines) {
-        info(s"stdout: $line")
+        info(line)
         _lock.lock()
         try {
           _lines.add(line)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removing misleading log prefix "stdout: " for the captured stdout/stderr of spark-submit process

## How was this patch tested?

N/A
