### PR TITLE
[LIVY-124] Allow jar/pyfile/file to be uploaded when creating a batch session

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/batch/CreateBatchRequest.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/CreateBatchRequest.scala
@@ -35,6 +35,7 @@ class CreateBatchRequest {
   var queue: Option[String] = None
   var name: Option[String] = None
   var conf: Map[String, String] = Map()
+  var delayed: Option[String] = None
 
   override def toString: String = {
     s"[proxyUser: $proxyUser, " +
@@ -51,6 +52,7 @@ class CreateBatchRequest {
       (if (numExecutors.isDefined) s"numExecutors: ${numExecutors.get}, " else "") +
       (if (queue.isDefined) s"queue: ${queue.get}, " else "") +
       (if (name.isDefined) s"name: ${name.get}, " else "") +
-      (if (conf.nonEmpty) s"conf: ${conf.mkString(",")}]" else "]")
+      (if (conf.nonEmpty) s"conf: ${conf.mkString(",")}]" else "]") +
+      (if (delayed.isDefined) s"suspend: ${delayed.get}, " else "")
   }
 }

--- a/server/src/test/scala/org/apache/livy/server/BaseSessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/BaseSessionServletSpec.scala
@@ -57,12 +57,14 @@ abstract class BaseSessionServletSpec[S <: Session, R <: RecoveryMetadata]
 
   /** Create a LivyConf with impersonation enabled and a superuser. */
   protected def createConf(): LivyConf = {
+    val tmpDir = sys.props("java.io.tmpdir")
     new LivyConf()
       .set(LivyConf.IMPERSONATION_ENABLED, true)
       .set(LivyConf.SUPERUSERS, ADMIN)
       .set(LivyConf.ACCESS_CONTROL_VIEW_USERS, VIEW_USER)
       .set(LivyConf.ACCESS_CONTROL_MODIFY_USERS, MODIFY_USER)
-      .set(LivyConf.LOCAL_FS_WHITELIST, sys.props("java.io.tmpdir"))
+      .set(LivyConf.LOCAL_FS_WHITELIST, tmpDir)
+      .set(LivyConf.SESSION_STAGING_DIR, tmpDir)
   }
 
   override def afterAll(): Unit = {

--- a/server/src/test/scala/org/apache/livy/server/batch/CreateBatchRequestSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/CreateBatchRequestSpec.scala
@@ -48,6 +48,7 @@ class CreateBatchRequestSpec extends FunSpec with LivyBaseUnitTestSuite {
       assert(req.queue === None)
       assert(req.name === None)
       assert(req.conf === Map())
+      assert(req.delayed === None)
     }
 
   }

--- a/server/src/test/scala/org/apache/livy/sessions/SessionManagerSpec.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/SessionManagerSpec.scala
@@ -22,7 +22,7 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.{Failure, Try}
 
-import org.mockito.Mockito.{doReturn, never, verify, when}
+import org.mockito.Mockito.{never, verify, when}
 import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.mock.MockitoSugar.mock
@@ -82,7 +82,7 @@ class SessionManagerSpec extends FunSpec with Matchers with LivyBaseUnitTestSuit
     def testSessionGC(session: Session, sm: SessionManager[_, _]): Unit = {
 
       def changeStateAndCheck(s: SessionState)(fn: SessionManager[_, _] => Unit): Unit = {
-        doReturn(s).when(session).state
+        when(session.state).thenReturn(s)
         Await.result(sm.collectGarbage(), Duration.Inf)
         fn(sm)
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/LIVY-124

Allow upload jar/python/other files only with Livy http connection for batch session.

1. Create batch session with delayed flag
2. Upload files with set-file, add-file, add-jar and/or and-pyfile
3. Start session with start (i.e. submit to spark)

## How was this patch tested?

- New unittest for batch session
- New unittest for batch servlet
- Tested manually against my spark cluster
