### PR TITLE
[LIVY-450] Override config options by environment variables.

### DIFF
--- a/client-common/src/main/java/org/apache/livy/client/common/ClientConf.java
+++ b/client-common/src/main/java/org/apache/livy/client/common/ClientConf.java
@@ -38,6 +38,9 @@ public abstract class ClientConf<T extends ClientConf>
 
   protected Logger LOG = LoggerFactory.getLogger(getClass());
 
+  /** Option to configure the list of options that can be overridden by environment variables. */
+  static final String LIVY_CONF_ENV_WHITELIST_PROPERTY = "livy.conf.env.whitelist";
+
   public static interface ConfEntry {
 
     /**
@@ -70,6 +73,9 @@ public abstract class ClientConf<T extends ClientConf>
 
   protected final ConcurrentMap<String, String> config;
 
+  /** Used to keep a set of whitelisted options that can be overridden by environment variables. */
+  private Set<String> whitelistEnvOptions;
+
   /** Used to retrieve configuration value from environment variable. */
   private EnvironmentService environmentService;
 
@@ -84,13 +90,34 @@ public abstract class ClientConf<T extends ClientConf>
     }
   }
 
+  /**
+   * Split whitelist config option by commas, trim spaces and create new set of whitelisted options.
+   */
+  private void initWhitelistEnvOptions() {
+    String whitelist = config.get(LIVY_CONF_ENV_WHITELIST_PROPERTY);
+    if (whitelist == null) {
+      whitelistEnvOptions = new HashSet<>();
+    } else {
+      whitelistEnvOptions = new HashSet<String>(Arrays.asList(whitelist.split("\\s*,\\s*")));
+    }
+  }
+
   public String get(String key) {
-    // Environment variable overrides the correspondent configuration option if it was set before.
+    String val;
+
+    // lazy initialization
+    if (whitelistEnvOptions == null) {
+      initWhitelistEnvOptions();
+    }
+    // Environment variable overrides the correspondent configuration option if it was set before
+    // and this option was found in whitelist.
     // For example, option "livy.spark.master" will be overridden by LIVY_SPARK_MASTER environment
     // variable.
-    String val = environmentService.getVariable(key.toUpperCase().replaceAll("[.-]", "_"));
-    if (val != null) {
-      return val;
+    if (!key.equals(LIVY_CONF_ENV_WHITELIST_PROPERTY) && whitelistEnvOptions.contains(key)) {
+      val = environmentService.getVariable(key.toUpperCase().replaceAll("[.-]", "_"));
+      if (val != null) {
+        return val;
+      }
     }
 
     val = config.get(key);

--- a/client-common/src/test/java/org/apache/livy/client/common/TestClientConf.java
+++ b/client-common/src/test/java/org/apache/livy/client/common/TestClientConf.java
@@ -148,6 +148,27 @@ public class TestClientConf {
     assertEquals("new-val", conf.get("new-key"));
   }
 
+  @Test
+  public void testEnvVarsConfiguration() {
+    TestConf conf = new TestConf(null);
+    MockEnvironmentService environmentService = new MockEnvironmentService();
+    conf.setEnvironmentService(environmentService);
+
+    String configOption = "livy.spark.master";
+    String envOption = "LIVY_SPARK_MASTER";
+
+    // configuration option was not set
+    assertNull(conf.get(configOption));
+
+    // set configuration option in normal way
+    conf.set(configOption, "local");
+    assertEquals("local", conf.get(configOption));
+
+    // set environment variable which overrides the configuration option
+    environmentService.setVariable(envOption, "yarn");
+    assertEquals("yarn", conf.get(configOption));
+  }
+
   private static class TestConf extends ClientConf<TestConf> {
 
     static enum Entry implements ConfEntry {
@@ -224,6 +245,18 @@ public class TestClientConf {
 
       @Override
       public String deprecationMessage() { return deprecationMessage; }
+    }
+  }
+
+  protected class MockEnvironmentService implements ClientConf.EnvironmentService {
+    Map<String, String> env = new HashMap<>();
+
+    public void setVariable(String name, String value) {
+      env.put(name, value);
+    }
+
+    public String getVariable(String name) {
+      return env.get(name);
     }
   }
 

--- a/client-common/src/test/java/org/apache/livy/client/common/TestClientConf.java
+++ b/client-common/src/test/java/org/apache/livy/client/common/TestClientConf.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.junit.Test;
+
+import static org.apache.livy.client.common.ClientConf.LIVY_CONF_ENV_WHITELIST_PROPERTY;
 import static org.junit.Assert.*;
 
 public class TestClientConf {
@@ -149,7 +151,7 @@ public class TestClientConf {
   }
 
   @Test
-  public void testEnvVarsConfiguration() {
+  public void testNotAllowedEnvVarsConfiguration() {
     TestConf conf = new TestConf(null);
     MockEnvironmentService environmentService = new MockEnvironmentService();
     conf.setEnvironmentService(environmentService);
@@ -166,6 +168,31 @@ public class TestClientConf {
 
     // set environment variable which overrides the configuration option
     environmentService.setVariable(envOption, "yarn");
+    // it still has to return value from config file option, not from environment variable
+    assertEquals("local", conf.get(configOption));
+    }
+
+  @Test
+  public void testAllowedEnvVarsConfiguration() {
+    MockEnvironmentService environmentService = new MockEnvironmentService();
+
+    String configOption = "livy.spark.master";
+    String envOption = "LIVY_SPARK_MASTER";
+
+    // create new config object with whitelist config option which contains a list of allowed config
+    // options as environment variables
+    Properties properties = new Properties();
+    properties.setProperty(LIVY_CONF_ENV_WHITELIST_PROPERTY, "key1, " + configOption);
+    TestConf conf = new TestConf(properties);
+    conf.setEnvironmentService(environmentService);
+
+    // set configuration option in normal way
+    conf.set(configOption, "local");
+    assertEquals("local", conf.get(configOption));
+
+    // set environment variable which overrides the configuration option
+    environmentService.setVariable(envOption, "yarn");
+    // it has to return value from environment variable, not from config file option
     assertEquals("yarn", conf.get(configOption));
   }
 

--- a/client-common/src/test/java/org/apache/livy/client/common/TestClientConf.java
+++ b/client-common/src/test/java/org/apache/livy/client/common/TestClientConf.java
@@ -24,8 +24,9 @@ import java.util.Properties;
 
 import org.junit.Test;
 
-import static org.apache.livy.client.common.ClientConf.LIVY_CONF_ENV_WHITELIST_PROPERTY;
 import static org.junit.Assert.*;
+
+import static org.apache.livy.client.common.ClientConf.LIVY_CONF_ENV_WHITELIST_PROPERTY;
 
 public class TestClientConf {
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a possibility to override all config options by environment variables. 
For example:
`LIVY_SPARK_MASTER` automatically overrides `livy.spark.master` and `LIVY_SPARK_DEPLOY_MODE` overrides `livy.spark.deploy-mode`.

It can be useful in case of using the same Docker image of Livy in different scenarios that requires different configuration options.

https://issues.apache.org/jira/browse/LIVY-450

## How was this patch tested?

- Added corresponding unit test
- Tested manually on virtual Spark2/Livy cluster