### PR TITLE
[LIVY-471][Server] Adding new API set to support resource uploading

### DIFF
--- a/integration-test/src/main/scala/org/apache/livy/test/framework/MiniCluster.scala
+++ b/integration-test/src/main/scala/org/apache/livy/test/framework/MiniCluster.scala
@@ -294,9 +294,6 @@ class MiniCluster(config: Map[String, String]) extends Cluster with MiniClusterU
     val procDir = mkdir(simpleName)
     val procTmp = mkdir("tmp", parent = procDir)
 
-    // Before starting anything, clean up previous running sessions.
-    sys.process.Process(s"pkill -f $simpleName") !
-
     val java = sys.props("java.home") + "/bin/java"
     val cmd =
       Seq(

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -151,6 +151,8 @@ object LivyConf {
   val SESSION_STATE_RETAIN_TIME = Entry("livy.server.session.state-retain.sec", "600s")
   // Max creating session in livyServer
   val SESSION_MAX_CREATION = Entry("livy.server.session.max-creation", 100)
+  // Livy directory to cache the upload resources.
+  val RESOURCE_DIR = Entry("livy.server.resource-dir", sys.props("java.io.tmpdir"))
 
   val SPARK_MASTER = "spark.master"
   val SPARK_DEPLOY_MODE = "spark.submit.deployMode"

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -27,6 +27,7 @@ import scala.util.Try
 
 import org.scalatra._
 import org.scalatra.servlet.FileUploadSupport
+
 import org.apache.livy.{LivyConf, Logging}
 import org.apache.livy.rsc.RSCClientFactory
 import org.apache.livy.server.batch.BatchSession

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -17,12 +17,16 @@
 
 package org.apache.livy.server
 
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import javax.servlet.http.HttpServletRequest
 
-import org.scalatra._
 import scala.concurrent._
 import scala.concurrent.duration._
+import scala.util.Try
 
+import org.scalatra._
+import org.scalatra.servlet.FileUploadSupport
 import org.apache.livy.{LivyConf, Logging}
 import org.apache.livy.rsc.RSCClientFactory
 import org.apache.livy.server.batch.BatchSession
@@ -47,7 +51,11 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
   with MethodOverride
   with UrlGeneratorSupport
   with GZipSupport
-{
+  with FileUploadSupport {
+
+  private val requestedIds = Collections.newSetFromMap(
+    new ConcurrentHashMap[Int, java.lang.Boolean]())
+
   /**
    * Creates a new session based on the current request. The implementation is responsible for
    * parsing the body of the request.
@@ -119,13 +127,60 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
     }
   }
 
-  def tooManySessions(): Boolean = {
-    val totalChildProceses = RSCClientFactory.childProcesses().get() +
-      BatchSession.childProcesses.get()
-    totalChildProceses >= livyConf.getInt(LivyConf.SESSION_MAX_CREATION)
+  post("/") {
+    createSession()
   }
 
-  post("/") {
+  get("/id") {
+    val newId = sessionManager.nextId()
+    requestedIds.add(newId)
+    newId
+  }
+
+  post("/:id/resources") {
+    val sessionId = params("id").toInt
+    if (!hasModifyAccess(null, request)) {
+      Forbidden()
+    } else if (!requestedIds.contains(sessionId)) {
+      BadRequest("Rejected, please request new session id first!")
+    } else {
+      fileParams.foreach { case (_, f) =>
+        sessionManager.saveResource(sessionId, f.name, f.getInputStream)
+      }
+    }
+  }
+
+  post("/:id") {
+    val sessionId = params("id").toInt
+    if (!requestedIds.contains(sessionId)) {
+      BadRequest("Rejected, please request new session id first")
+    } else {
+      createSession()
+      // Remove the cached session id which is actually used.
+      requestedIds.remove(sessionId)
+    }
+  }
+
+  error {
+    case e: IllegalArgumentException => BadRequest(e.getMessage)
+    case e: IllegalStateException => BadRequest(e.getMessage)
+  }
+
+  def tooManySessions(): Boolean = {
+    val totalChildProcesses = RSCClientFactory.childProcesses().get() +
+      BatchSession.childProcesses.get()
+    totalChildProcesses >= livyConf.getInt(LivyConf.SESSION_MAX_CREATION)
+  }
+
+  private def getRequestPathInfo(request: HttpServletRequest): String = {
+    if (request.getPathInfo != null && request.getPathInfo != "/") {
+      request.getPathInfo
+    } else {
+      ""
+    }
+  }
+
+  protected def createSession(): Any = {
     if (tooManySessions) {
       BadRequest("Rejected, too many sessions are being created!")
     } else {
@@ -139,16 +194,13 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
     }
   }
 
-  private def getRequestPathInfo(request: HttpServletRequest): String = {
-    if (request.getPathInfo != null && request.getPathInfo != "/") {
-      request.getPathInfo
-    } else {
-      ""
-    }
-  }
-
-  error {
-    case e: IllegalArgumentException => BadRequest(e.getMessage)
+  protected def getSessionIdFromReq(req: HttpServletRequest): Option[Int] = {
+    Try {
+      val pathInfo = getRequestPathInfo(req)
+      val stripped = pathInfo.stripSuffix("/")
+      val idx = stripped.lastIndexOf("/")
+      if (idx != -1) stripped.substring(idx + 1).toInt else "".toInt
+    }.toOption
   }
 
   /**

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -156,9 +156,10 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
     if (!requestedIds.contains(sessionId)) {
       BadRequest("Rejected, please request new session id first")
     } else {
-      createSession()
+      val ret = createSession()
       // Remove the cached session id which is actually used.
       requestedIds.remove(sessionId)
+      ret
     }
   }
 

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
@@ -37,14 +37,19 @@ class BatchSessionServlet(
     sessionStore: SessionStore,
     livyConf: LivyConf,
     accessManager: AccessManager)
-  extends SessionServlet(sessionManager, livyConf, accessManager)
-{
+  extends SessionServlet(sessionManager, livyConf, accessManager) {
 
   override protected def createSession(req: HttpServletRequest): BatchSession = {
     val createRequest = bodyAs[CreateBatchRequest](req)
     val proxyUser = checkImpersonation(createRequest.proxyUser, req)
     BatchSession.create(
-      sessionManager.nextId(), createRequest, livyConf, remoteUser(req), proxyUser, sessionStore)
+      getSessionIdFromReq(req).getOrElse(sessionManager.nextId()),
+      createRequest,
+      livyConf,
+      remoteUser(req),
+      proxyUser,
+      sessionManager,
+      sessionStore)
   }
 
   override protected[batch] def clientSessionView(

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -69,14 +69,17 @@ object InteractiveSession extends Logging {
       proxyUser: Option[String],
       livyConf: LivyConf,
       request: CreateInteractiveRequest,
+      sessionManager: SessionManager[_, _],
       sessionStore: SessionStore,
       mockApp: Option[SparkApp] = None,
       mockClient: Option[RSCClient] = None): InteractiveSession = {
     val appTag = s"livy-session-$id-${Random.alphanumeric.take(8).mkString}"
+    val retrieveResFunc = Some(sessionManager.retrieveResource(id, _: String))
 
     val client = mockClient.orElse {
-      val conf = SparkApp.prepareSparkConf(appTag, livyConf, prepareConf(
-        request.conf, request.jars, request.files, request.archives, request.pyFiles, livyConf))
+      val conf = SparkApp.prepareSparkConf(appTag, livyConf,
+        prepareConf(request.conf, request.jars, request.files, request.archives,
+          request.pyFiles, livyConf, retrieveResFunc))
 
       val builderProperties = prepareBuilderProp(conf, request.kind, livyConf)
 

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -26,7 +26,6 @@ import scala.concurrent.duration._
 
 import org.json4s.jackson.Json4sScalaModule
 import org.scalatra._
-import org.scalatra.servlet.FileUploadSupport
 
 import org.apache.livy.{CompletionRequest, ExecuteRequest, JobHandle, LivyConf, Logging}
 import org.apache.livy.client.common.HttpMessages
@@ -44,7 +43,6 @@ class InteractiveSessionServlet(
     accessManager: AccessManager)
   extends SessionServlet(sessionManager, livyConf, accessManager)
   with SessionHeartbeatNotifier[InteractiveSession, InteractiveRecoveryMetadata]
-  with FileUploadSupport
 {
 
   mapper.registerModule(new SessionKindModule())
@@ -54,11 +52,12 @@ class InteractiveSessionServlet(
     val createRequest = bodyAs[CreateInteractiveRequest](req)
     val proxyUser = checkImpersonation(createRequest.proxyUser, req)
     InteractiveSession.create(
-      sessionManager.nextId(),
+      getSessionIdFromReq(req).getOrElse(sessionManager.nextId()),
       remoteUser(req),
       proxyUser,
       livyConf,
       createRequest,
+      sessionManager,
       sessionStore)
   }
 

--- a/server/src/main/scala/org/apache/livy/sessions/ResourceManager.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/ResourceManager.scala
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.sessions
+
+import java.io.{File, FileOutputStream, InputStream}
+import java.util.UUID
+
+import scala.util.control.NonFatal
+
+import com.google.common.annotations.VisibleForTesting
+import org.apache.commons.io.{FileUtils, IOUtils}
+
+import org.apache.livy.{LivyConf, Logging}
+
+final class ResourceManager(livyConf: LivyConf) extends Logging {
+
+  @VisibleForTesting
+  private[livy] val baseDir = new File(
+    s"${livyConf.get(LivyConf.RESOURCE_DIR)}/livy-resources-${UUID.randomUUID().toString}")
+  if (!baseDir.mkdir()) {
+    throw new IllegalStateException(s"Fail to create base dir $baseDir")
+  }
+
+  private val whitelistLocalDir = livyConf.configToSeq(LivyConf.LOCAL_FS_WHITELIST) ++
+    Seq(baseDir.getAbsolutePath)
+  livyConf.set(LivyConf.LOCAL_FS_WHITELIST, whitelistLocalDir.mkString(","))
+
+  /**
+   * Register session with Id into ResourceManager.
+   */
+  def registerSession(sessionId: Int): Unit = {
+    val folder = sessionFolder(sessionId)
+    if (!folder.mkdir()) {
+      throw new IllegalStateException(s"Fail to create session folder $folder")
+    }
+    info(s"Session $sessionId registered in ResourceManager")
+  }
+
+  /**
+   * Save resource associated with session id and name into file.
+   */
+  def saveResource(sessionId: Int, name: String, is: InputStream): Unit = {
+    val folder = sessionFolder(sessionId)
+    if (!folder.exists() || !folder.isDirectory) {
+      throw new IllegalStateException("Session folder is not existed, or is not a directory")
+    }
+
+    val resource = new File(folder, name)
+    if (resource.exists()) {
+      warn(s"Resource ${resource.getAbsolutePath} is already existed, will ignore duplicated " +
+        s"resource $name")
+      return
+    }
+
+    val tmpFile = new File(folder, name + UUID.randomUUID().toString)
+    var fos: FileOutputStream = null
+    try {
+      fos = new FileOutputStream(tmpFile)
+      IOUtils.copy(is, fos)
+    } catch {
+      case NonFatal(e) =>
+        warn(s"Fail to write source to local file", e)
+    } finally {
+      if (fos != null) {
+        fos.close()
+        fos = null
+      }
+    }
+
+    val resourceFile = new File(folder, name)
+    tmpFile.renameTo(resourceFile)
+    info(s"Resource $name added to the ResourcesManager as ${resourceFile.getAbsolutePath}")
+  }
+
+  /**
+   * Get resource based on session id and name.
+   */
+  def retrieveResource(sessionId: Int, name: String): Option[String] = {
+    val folder = sessionFolder(sessionId)
+    val resource = new File(folder, name)
+    if (resource.exists() && resource.canRead) {
+      info(s"Resource $name for session $sessionId is retrieved at ${resource.getAbsolutePath}")
+      Some(resource.getAbsolutePath)
+    } else {
+      info(s"Resource $name for session $sessionId is not found")
+      None
+    }
+  }
+
+  /**
+   * Unregister the session with id specified.
+   */
+  def unregisterSession(sessionId: Int): Unit = {
+    val folder = sessionFolder(sessionId)
+    if (!folder.exists()) {
+      return
+    }
+
+    folder.listFiles().foreach { f => f.delete() }
+    folder.delete()
+    info(s"Session $sessionId unregistered in ResourcesManager")
+  }
+
+  /**
+   * Clean all the cached resource files when LivyServer is stopped.
+   */
+  def clean(): Unit = {
+    FileUtils.deleteDirectory(baseDir)
+  }
+
+  private def sessionFolder(sessionId: Int): File = {
+    new File(baseDir, sessionId.toString)
+  }
+}

--- a/server/src/test/scala/org/apache/livy/sessions/ResourceManagerSpec.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/ResourceManagerSpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.sessions
+
+import java.io.{File, FileInputStream, FileOutputStream}
+import java.nio.file.Files
+
+import org.apache.commons.io.IOUtils
+import org.scalatest.FunSuite
+
+import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
+
+class ResourceManagerSpec extends FunSuite with LivyBaseUnitTestSuite {
+
+  test("register and unregister sessions") {
+    val sessionId = 1
+    val conf = new LivyConf(false)
+    val resourceManager = new ResourceManager(conf)
+
+    val baseDir = resourceManager.baseDir
+    assert(baseDir.exists())
+    assert(baseDir.isDirectory)
+    assert(conf.get(LivyConf.LOCAL_FS_WHITELIST).contains(baseDir.getAbsolutePath))
+
+    resourceManager.registerSession(sessionId)
+    val sessionDir = new File(baseDir, sessionId.toString)
+    assert(sessionDir.exists())
+    assert(sessionDir.isDirectory)
+
+    resourceManager.unregisterSession(sessionId)
+    assert(!sessionDir.exists())
+  }
+
+  test("save and retrieve resources") {
+    val sessionId = 1
+    val conf = new LivyConf(false)
+    val resourceManager = new ResourceManager(conf)
+
+    resourceManager.registerSession(sessionId)
+
+    val tmpFile = Files.createTempFile("tmp", "jar").toFile
+    var os: FileOutputStream = null
+    try {
+      os = new FileOutputStream(tmpFile)
+      IOUtils.write("test", os)
+    } finally {
+      if (os != null) {
+        os.close()
+        os = null
+      }
+    }
+
+    var is: FileInputStream = null
+    try {
+      is = new FileInputStream(tmpFile)
+      resourceManager.saveResource(sessionId, tmpFile.getName, is)
+      val res = resourceManager.retrieveResource(sessionId, tmpFile.getName)
+      assert(res.isDefined)
+      val resPath = s"${resourceManager.baseDir.getAbsolutePath.stripSuffix("/")}" +
+        s"/$sessionId/${tmpFile.getName}"
+      assert(res.get == resPath)
+      assert(resourceManager.retrieveResource(sessionId, "random") == None)
+    } finally {
+      if (is != null) {
+        is.close()
+        is == null
+      }
+    }
+
+    resourceManager.unregisterSession(sessionId)
+  }
+
+  test("save resources without registering session") {
+    val conf = new LivyConf(false)
+    val resourceManager = new ResourceManager(conf)
+
+    val tmpFile = Files.createTempFile("tmp", ".jar").toFile
+    var is: FileInputStream = null
+    try {
+      is = new FileInputStream(tmpFile)
+      intercept[IllegalStateException](resourceManager.saveResource(1, tmpFile.getName, is))
+    } finally {
+      if (is != null) {
+        is.close()
+        is = null
+      }
+    }
+  }
+
+  test("clean the resources manager") {
+    val conf = new LivyConf(false)
+    val resourceManager = new ResourceManager(conf)
+
+    resourceManager.registerSession(1)
+    resourceManager.registerSession(2)
+    resourceManager.registerSession(3)
+
+    val tmpJar = Files.createTempFile("tmpJar", ".jar").toFile
+    val tmpJarIs = new FileInputStream(tmpJar)
+    val tmpFile = Files.createTempFile("tmpFile", "").toFile
+    val tmpFileIs = new FileInputStream(tmpFile)
+    val tmpPy = Files.createTempFile("tmpPy", ".py").toFile
+    val tmpPyIs = new FileInputStream(tmpPy)
+
+    resourceManager.saveResource(1, tmpJar.getName, tmpJarIs)
+    resourceManager.saveResource(2, tmpFile.getName, tmpFileIs)
+    resourceManager.saveResource(3, tmpPy.getName, tmpPyIs)
+
+    tmpJarIs.close()
+    tmpFileIs.close()
+    tmpPyIs.close()
+
+    resourceManager.clean()
+    assert(!resourceManager.baseDir.exists())
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding a new API set to support resource uploading in session creation.

1. GET `[sessions|batches]/id` to request new session id.
2. POST `[sessions|batches]/id/resource` to upload resources. This step can be passed if we don't need to upload resources.
3. POST `[sessions|batches]/id` to create new session with specified id. the POST request format is the same as old API.

This PR adding a local `ResourcesManager` to manager all uploaded resources. Resources are properly managed and deleted after session finished.

This is still WIP, needs to debug and add new tests.

## How was this patch tested?

new UT.
