### PR TITLE
LIVY-475 Support of Hadoop CredentialProvider API

### DIFF
--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -23,7 +23,9 @@
 # Specify the key password.
 # livy.key-password =
 
-# Hadoop Credential Provider Path to get "livy.keystore.password" and "livy.key-password"
+# Hadoop Credential Provider Path to get "livy.keystore.password" and "livy.key-password".
+# Credential Provider can be created using command as follow:
+# hadoop credential create "livy.keystore.password" -value "secret" -provider jceks://hdfs/path/to/livy.jceks
 # livy.hadoop.security.credential.provider.path =
 
 # What host address to start the server on. By default, Livy will bind to all network interfaces.

--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -23,6 +23,9 @@
 # Specify the key password.
 # livy.key-password =
 
+# Hadoop Credential Provider Path to get "livy.keystore.password" and "livy.key-password"
+# livy.hadoop.security.credential.provider.path =
+
 # What host address to start the server on. By default, Livy will bind to all network interfaces.
 # livy.server.host = 0.0.0.0
 

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -85,6 +85,8 @@ object LivyConf {
   val SSL_KEYSTORE_PASSWORD = Entry("livy.keystore.password", null)
   val SSL_KEY_PASSWORD = Entry("livy.key-password", null)
 
+  val HADOOP_CREDENTIAL_PROVIDER_PATH = Entry("livy.hadoop.security.credential.provider.path", null)
+
   val AUTH_TYPE = Entry("livy.server.auth.type", null)
   val AUTH_KERBEROS_PRINCIPAL = Entry("livy.server.auth.kerberos.principal", null)
   val AUTH_KERBEROS_KEYTAB = Entry("livy.server.auth.kerberos.keytab", null)

--- a/server/src/main/scala/org/apache/livy/server/WebServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/WebServer.scala
@@ -58,12 +58,12 @@ class WebServer(livyConf: LivyConf, var host: String, var port: Int) extends Log
 
       val keyStorePassword = Option(livyConf.get(LivyConf.SSL_KEYSTORE_PASSWORD))
         .orElse {
-          Option(hadoopConf.getPassword(LivyConf.SSL_KEYSTORE_PASSWORD.key).mkString)
+          Option(hadoopConf.getPassword(LivyConf.SSL_KEYSTORE_PASSWORD.key)).map(_.mkString)
         }
 
       val keyPassword = Option(livyConf.get(LivyConf.SSL_KEY_PASSWORD))
         .orElse {
-          Option(hadoopConf.getPassword(LivyConf.SSL_KEY_PASSWORD.key).mkString)
+          Option(hadoopConf.getPassword(LivyConf.SSL_KEY_PASSWORD.key)).map(_.mkString)
         }
 
       keyStorePassword

--- a/server/src/main/scala/org/apache/livy/server/WebServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/WebServer.scala
@@ -66,10 +66,8 @@ class WebServer(livyConf: LivyConf, var host: String, var port: Int) extends Log
           Option(hadoopConf.getPassword(LivyConf.SSL_KEY_PASSWORD.key)).map(_.mkString)
         }
 
-      keyStorePassword
-        .foreach(sslContextFactory.setKeyStorePassword)
-      keyPassword
-        .foreach(sslContextFactory.setKeyManagerPassword)
+      keyStorePassword.foreach(sslContextFactory.setKeyStorePassword)
+      keyPassword.foreach(sslContextFactory.setKeyManagerPassword)
 
       (new ServerConnector(server,
         new SslConnectionFactory(sslContextFactory, "http/1.1"),

--- a/server/src/main/scala/org/apache/livy/server/WebServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/WebServer.scala
@@ -54,17 +54,8 @@ class WebServer(livyConf: LivyConf, var host: String, var port: Int) extends Log
       var keyPassword = livyConf.get(LivyConf.SSL_KEY_PASSWORD)
 
       val credentialProviderPath = livyConf.get(LivyConf.HADOOP_CREDENTIAL_PROVIDER_PATH)
-      val credentialProviderSupported = {
-        // Only supported in Hadoop 2.6.0+
-        try {
-          classOf[Configuration].getMethod("getPassword", classOf[String])
-          true
-        } catch {
-          case e: NoSuchMethodException => false
-        }
-      }
 
-      if (credentialProviderPath != null && credentialProviderSupported) {
+      if (credentialProviderPath != null) {
         val hadoopConf = new Configuration()
         hadoopConf.set("hadoop.security.credential.provider.path", credentialProviderPath)
 


### PR DESCRIPTION
In this PR I've added following option to livy.conf:
```
# Hadoop Credential Provider Path to get "livy.keystore.password" and "livy.key-password"
# livy.hadoop.security.credential.provider.path =
```
to allow to specify path to Hadoop Credential Provider, which than used in `WebServer.scala` to set Keystore password and Key password to JKS that used to enable SSL encryption.

Also before trying to use Hadoop CredentialProvider API I'm checking if it available (as it was not available in Hadoop < 2.6) using the same [method that used in Oozie](https://github.com/apache/oozie/commit/6a731f9926158da38d1e3b518671ada95a544fe8#diff-800f95e605f21c5aaf5edef13039c9b9R124).

To use this, you will need to generate Credential Provider containing "livy.keystore.password" and/or "livy.key-password" in the common way:
```bash
hadoop credential create "livy.keystore.password" -value "keystore_secret" -provider jceks://hdfs@nn1.example.com/my/path/livy_creds.jceks
hadoop credential create "livy.key-password" -value "key_secret" -provider jceks://hdfs@nn1.example.com/my/path/livy_creds.jceks
```