### PR TITLE
[LIVY-477][BUILD] Upgrade Scala version to 2.11.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <py4j.version>0.9</py4j.version>
     <scala-2.10.version>2.10.4</scala-2.10.version>
-    <scala-2.11.version>2.11.8</scala-2.11.version>
+    <scala-2.11.version>2.11.12</scala-2.11.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scala.version>${scala-2.11.version}</scala.version>
     <scalatest.version>2.2.4</scalatest.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Scala version below 2.11.12 has CVE (https://scala-lang.org/news/security-update-nov17.html), and Spark will also upgrade its supported version to 2.11.12. 

So here upgrading Livy's Scala version also.

## How was this patch tested?

Existing tests.
