### PR TITLE
[LIVY-479] Enable livy.rsc.launcher.address configuration

### DIFF
--- a/rsc/src/main/java/org/apache/livy/rsc/ContextLauncher.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/ContextLauncher.java
@@ -97,7 +97,13 @@ class ContextLauncher {
       String replMode = conf.get("repl");
       boolean repl = replMode != null && replMode.equals("true");
 
-      conf.set(LAUNCHER_ADDRESS, factory.getServer().getAddress());
+      // In some scenarios the user may need to configure this endpoint setting explicitly.
+      String address = conf.get(LAUNCHER_ADDRESS);
+      // If not specified, use the RPC server address; otherwise use the specified address.
+      if (address == null) {
+        address = factory.getServer().getAddress();
+      }
+      conf.set(LAUNCHER_ADDRESS, address);
       conf.set(LAUNCHER_PORT, factory.getServer().getPort());
       conf.set(CLIENT_ID, clientId);
       conf.set(CLIENT_SECRET, secret);

--- a/rsc/src/main/java/org/apache/livy/rsc/ContextLauncher.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/ContextLauncher.java
@@ -100,7 +100,7 @@ class ContextLauncher {
       // In some scenarios the user may need to configure this endpoint setting explicitly.
       String address = conf.get(LAUNCHER_ADDRESS);
       // If not specified, use the RPC server address; otherwise use the specified address.
-      if (address == null) {
+      if (address == null || address.trim().isEmpty()) {
         address = factory.getServer().getAddress();
       }
       conf.set(LAUNCHER_ADDRESS, address);


### PR DESCRIPTION
## What changes were proposed in this pull request?
In current code we are setting livy.rsc.launcher.address to RPC server and ignoring whatever is specified in configs. However in some scenarios there is a need for the user to be able to explicitly configure it. For example, the IP address for an active Livy server might change over the time, so rather than using the fixed IP address, we need to specify this setting to a more generic host name. For this reason, we want to enable the capability of user side configurations.

Jira: https://issues.apache.org/jira/browse/LIVY-479

## How was this patch tested?
Manual tests by changing "livy.rsc.launcher.address" and verified the setting took effect