### PR TITLE
fix bug -- looks like I can not submit a local jar

### DIFF
--- a/server/src/main/scala/org/apache/livy/sessions/Session.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/Session.scala
@@ -127,7 +127,7 @@ object Session {
 
     if (resolved.getScheme() == "file") {
       // Make sure the location is whitelisted before allowing local files to be added.
-      require(livyConf.localFsWhitelist.find(resolved.getPath().startsWith).isDefined,
+      require(livyConf.localFsWhitelist.exists(resolved.getPath().startsWith).isDefined,
         s"Local path ${uri.getPath()} cannot be added to user sessions.")
     }
 


### PR DESCRIPTION
## Fix the bug : It looks like I can not submit a local jar in batch job rest api. with error message, Local path ...cannot be added to user sessions.

https://groups.google.com/a/cloudera.org/forum/#!topic/livy-user/mm-XEhANDHU
(Please fill in changes proposed in this fix)
Iinclude a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

## The patch is tested manually.

Please review https://livy.incubator.apache.org/community/ before opening a pull request.