### PR TITLE
[LIVY-508][Server] Support custom auth filter for livy server

### DIFF
--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -148,3 +148,16 @@
 # A list of users with comma separated has the permission to view other user's infomation, like
 # submitted session state, statement results.
 # livy.server.access-control.view-users =
+#
+# Authentication support for Livy server
+# Livy has a built-in SPnego authentication support for HTTP requests  with below configurations.
+# livy.server.auth.type = kerberos
+# livy.server.auth.kerberos.principal = <spnego principal>
+# livy.server.auth.kerberos.keytab = <spnego keytab>
+# livy.server.auth.kerberos.name-rules = DEFAULT
+#
+# If user wants to use custom authentication filter, configurations are:
+# livy.server.auth.type = <custom>
+# livy.server.auth.<custom>.class = <class of custom auth filter>
+# livy.server.auth.<custom>.param.<foo1> = <bar1>
+# livy.server.auth.<custom>.param.<foo2> = <bar2>

--- a/server/src/main/scala/org/apache/livy/server/LivyServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/LivyServer.scala
@@ -23,6 +23,7 @@ import java.util.concurrent._
 import java.util.EnumSet
 import javax.servlet._
 
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
@@ -259,11 +260,25 @@ class LivyServer extends Logging {
         server.context.addFilter(holder, "/*", EnumSet.allOf(classOf[DispatcherType]))
         info(s"SPNEGO auth enabled (principal = $principal)")
 
-     case null =>
+      case null =>
         // Nothing to do.
 
-      case other =>
-        throw new IllegalArgumentException(s"Invalid auth type: $other")
+      case e =>
+        val authClassConf = s"livy.server.auth.$e.class"
+        val authClass = livyConf.get(authClassConf)
+        require(authClass != null, s"$e auth requires $authClassConf to be provided")
+
+        val holder = new FilterHolder()
+        holder.setClassName(authClass)
+
+        val prefix = s"livy.server.auth.$e.param."
+        livyConf.asScala.filter { kv =>
+          kv.getKey.length > prefix.length && kv.getKey.startsWith(prefix)
+        }.foreach { kv =>
+          holder.setInitParameter(kv.getKey.substring(prefix.length), kv.getValue)
+        }
+        server.context.addFilter(holder, "/*", EnumSet.allOf(classOf[DispatcherType]))
+        info(s"$e auth enabled")
     }
 
     if (livyConf.getBoolean(CSRF_PROTECTION)) {

--- a/server/src/main/scala/org/apache/livy/server/LivyServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/LivyServer.scala
@@ -263,22 +263,22 @@ class LivyServer extends Logging {
       case null =>
         // Nothing to do.
 
-      case e =>
-        val authClassConf = s"livy.server.auth.$e.class"
+      case customType =>
+        val authClassConf = s"livy.server.auth.$customType.class"
         val authClass = livyConf.get(authClassConf)
-        require(authClass != null, s"$e auth requires $authClassConf to be provided")
+        require(authClass != null, s"$customType auth requires $authClassConf to be provided")
 
         val holder = new FilterHolder()
         holder.setClassName(authClass)
 
-        val prefix = s"livy.server.auth.$e.param."
+        val prefix = s"livy.server.auth.$customType.param."
         livyConf.asScala.filter { kv =>
           kv.getKey.length > prefix.length && kv.getKey.startsWith(prefix)
         }.foreach { kv =>
           holder.setInitParameter(kv.getKey.substring(prefix.length), kv.getValue)
         }
         server.context.addFilter(holder, "/*", EnumSet.allOf(classOf[DispatcherType]))
-        info(s"$e auth enabled")
+        info(s"$customType auth enabled")
     }
 
     if (livyConf.getBoolean(CSRF_PROTECTION)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Users may have the requirement to add their own auth filter to the Livy server other than Kerberos, so here propose to add this support.

## How was this patch tested?

Verified locally in the cluster.
