### PR TITLE
[LIVY-500] Add beeline client for dev

### DIFF
--- a/dev/beeline
+++ b/dev/beeline
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export LIVY_HOME=$(cd $(dirname $0)/.. && pwd)
+CLASS="org.apache.hive.beeline.BeeLine"
+
+LIVY_CONF_DIR=${LIVY_CONF_DIR:-"$LIVY_HOME/conf"}
+
+if [ -f "${LIVY_CONF_DIR}/livy-env.sh" ]; then
+  # Promote all variable declarations to environment (exported) variables
+  set -a
+  . "${LIVY_CONF_DIR}/livy-env.sh"
+  set +a
+fi
+
+# Find the java binary
+if [ -n "${JAVA_HOME}" ]; then
+  RUNNER="${JAVA_HOME}/bin/java"
+elif [ `command -v java` ]; then
+  RUNNER="java"
+else
+  echo "JAVA_HOME is not set" >&2
+  exit 1
+fi
+
+
+LIBDIR="$LIVY_HOME/thriftserver/client/target/jars"
+
+if [ ! -d "$LIBDIR" ]; then
+  echo "Could not find Livy jars directory." 1>&2
+  exit 1
+fi
+
+exec $RUNNER $BEELINE_JAVA_OPTS -cp $LIBDIR/*:$LIVY_CONF_DIR:$CLASSPATH $CLASS "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -1027,6 +1027,7 @@
       <id>thriftserver</id>
       <modules>
         <module>thriftserver/server</module>
+        <module>thriftserver/client</module> 
       </modules>
     </profile>
 

--- a/thriftserver/client/pom.xml
+++ b/thriftserver/client/pom.xml
@@ -22,8 +22,10 @@
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
     <version>0.6.0-incubating-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
+  <packaging>pom</packaging>
 
   <artifactId>livy-beeline</artifactId>
 
@@ -52,14 +54,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <outputDirectory>${project.build.directory}/jars</outputDirectory>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/thriftserver/client/pom.xml
+++ b/thriftserver/client/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>livy-main</artifactId>
+    <groupId>org.apache.livy</groupId>
+    <version>0.6.0-incubating-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>livy-beeline</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-jdbc</artifactId>
+      <version>${hive.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-beeline</artifactId>
+      <version>${hive.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <outputDirectory>${project.build.directory}/jars</outputDirectory>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR adds a new `thriftserver/client` module and a `beeline` script which are useful to have a client for the thriftserver during local testing. Both things are intended for dev usage only and are not shipped with the distribution.


## How was this patch tested?

manual test
