### PR TITLE
[LIVY-520] Add log when session is GC-ed

### DIFF
--- a/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
@@ -149,7 +149,10 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
       }
     }
 
-    Future.sequence(all().filter(expired).map(delete))
+    Future.sequence(all().filter(expired).map { s =>
+      info(s"Deleting $s because it was inactive for more than ${sessionTimeout / 1e6} ms.")
+      delete(s)
+    })
   }
 
   private def recover(): Seq[S] = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a session is inactive for a long time, it is GC-ed, ie. it is closed. Currently this operation is not logged, so it is not easy to understand why a session was closed.

The PR proposes to add a log in order to explain what happened.

## How was this patch tested?

manual tests
