### PR TITLE
[LIVY-529][DOCS] Fix supported Python version from 2.6+ to 2.7+ in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,20 +29,20 @@ To build Livy, you will need:
 Debian/Ubuntu:
   * mvn (from ``maven`` package or maven3 tarball)
   * openjdk-8-jdk (or Oracle JDK 8)
-  * Python 2.6+
+  * Python 2.7+
   * R 3.x
 
 Redhat/CentOS:
   * mvn (from ``maven`` package or maven3 tarball)
   * java-1.8.0-openjdk (or Oracle JDK 8)
-  * Python 2.6+
+  * Python 2.7+
   * R 3.x
 
 MacOS:
   * Xcode command line tools
   * Oracle's JDK 1.8
   * Maven (Homebrew)
-  * Python 2.6+
+  * Python 2.7+
   * R 3.x
 
 Required python packages for building Livy:


### PR DESCRIPTION
## What changes were proposed in this pull request?

As of Spark 2.2, Python 2.6 is officially dropped(https://issues.apache.org/jira/browse/SPARK-12661).

Since Livy support Spark 2.2+, looks this limitation is inheritted.

Currently, Livy doc (https://github.com/apache/incubator-livy/blob/master/README.md) notes Python 2.6+ is required.

It looks this should be changed to 2.7+

## How was this patch tested?

N/A
