### PR TITLE
[LIVY-531][BUILD] Update spark-2.3 default version to 2.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1031,13 +1031,13 @@
     <profile>
       <id>spark-2.3</id>
       <properties>
-        <spark.scala-2.11.version>2.3.1</spark.scala-2.11.version>
+        <spark.scala-2.11.version>2.3.2</spark.scala-2.11.version>
         <spark.version>${spark.scala-2.11.version}</spark.version>
         <netty.spark-2.11.version>4.1.17.Final</netty.spark-2.11.version>
         <spark.bin.download.url>
-          http://mirrors.advancedhosters.com/apache/spark/spark-2.3.1/spark-2.3.1-bin-hadoop2.7.tgz
+          http://mirrors.advancedhosters.com/apache/spark/spark-2.3.2/spark-2.3.2-bin-hadoop2.7.tgz
         </spark.bin.download.url>
-        <spark.bin.name>spark-2.3.1-bin-hadoop2.7</spark.bin.name>
+        <spark.bin.name>spark-2.3.2-bin-hadoop2.7</spark.bin.name>
       </properties>
     </profile>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to spark 2.3.2 is highly recommended version to upgrade for all 2.3.x users which contains many stability bug fixes.

## How was this patch tested?

Existing UTs.
