### PR TITLE
[LIVY-535] Fix non-atomic session creation

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -127,16 +127,18 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
   }
 
   post("/") {
-    if (tooManySessions) {
-      BadRequest(ResponseMessage("Rejected, too many sessions are being created!"))
-    } else {
-      val session = sessionManager.register(createSession(request))
-      // Because it may take some time to establish the session, update the last activity
-      // time before returning the session info to the client.
-      session.recordActivity()
-      Created(clientSessionView(session, request),
-        headers = Map("Location" ->
-          (getRequestPathInfo(request) + url(getSession, "id" -> session.id.toString))))
+    synchronized {
+      if (tooManySessions) {
+        BadRequest(ResponseMessage("Rejected, too many sessions are being created!"))
+      } else {
+        val session = sessionManager.register(createSession(request))
+        // Because it may take some time to establish the session, update the last activity
+        // time before returning the session info to the client.
+        session.recordActivity()
+        Created(clientSessionView(session, request),
+          headers = Map("Location" ->
+            (getRequestPathInfo(request) + url(getSession, "id" -> session.id.toString))))
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

All steps, that include check for too many sessions and creating new
session, should be atomic operation to avoid concurrent access of
several threads to different part of this code in the same time.

https://issues.apache.org/jira/browse/LIVY-535

## How was this patch tested?
If was tested manually on local virtual cluster with this different values of config option `livy.server.session.max-creation`: 1, 2 and 3

Then I run the following command to make sure that only allowed number of sessions were created in the same time and others were rejected:
`for i in {1..5}; do curl -X POST --data '{"file": "/tmp/spark-examples-2.jar", "className": "org.apache.spark.examples.SparkPi"}' -H "Content-Type: application/json" http://localhost:8999/batches; done`