### PR TITLE
[LIVY-537] Add hiveconf for setting the num of executors in thrift sessions

### DIFF
--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
@@ -594,6 +594,8 @@ object LivyThriftSessionManager extends Logging {
               createInteractiveRequest.executorMemory = Some(value)
             case "set:hiveconf:livy.session.executorCores" =>
               createInteractiveRequest.executorCores = convertConfValueToInt(key, value)
+            case "set:hiveconf:livy.session.numExecutors" =>
+              createInteractiveRequest.numExecutors = convertConfValueToInt(key, value)
             case "set:hiveconf:livy.session.queue" =>
               createInteractiveRequest.queue = Some(value)
             case "set:hiveconf:livy.session.name" =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

We missed to add a parameter to set the number of executors when creating a session through the thrift API. See https://issues.apache.org/jira/browse/LIVY-537.

## How was this patch tested?

Manual tests.
