### PR TITLE
[LIVY-539] Fix incorrect default value in livy-client.conf.template

### DIFF
--- a/conf/livy-client.conf.template
+++ b/conf/livy-client.conf.template
@@ -73,7 +73,7 @@
 # Address for the RSC driver to connect back with it's connection info.
 # livy.rsc.launcher.address =
 # Port Range on which RPC will launch . Port range in inclusive of start and end port .
-# livy.rsc.launcher.port.range = 10000~10110
+# livy.rsc.launcher.port.range = 10000~10010
 
 # How long will the RSC wait for a connection for a Livy server before shutting itself down.
 # livy.rsc.server.idle-timeout = 10m


### PR DESCRIPTION
## What changes were proposed in this pull request?
JIRA LINK: https://issues.apache.org/jira/browse/LIVY-539

The template for `livy-client.conf` implies that the default value of `livy.rsc.launcher.port.range` is `10000~10110`, but this is in fact incorrect - the real default value is `10000~10010`, as you can [see here](https://github.com/apache/incubator-livy/blob/master/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java#L54). This is really confusing, especially since:
  * 10110 is wrong on the Spark side, the default configuration there won't open that many ports
  * 10010 and 10110 look very similar to the human eye so it can take a long time to notice the discrepancy

This PR modifies the default conf template to reflect the real default value.

## How was this patch tested?

No testing applicable, it's a configuration template fix.
