### PR TITLE
Try to process statements of single session concurrentlly (especially for sql kind)

### DIFF
--- a/repl/src/main/scala/org/apache/livy/repl/ReplDriver.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/ReplDriver.scala
@@ -76,7 +76,7 @@ class ReplDriver(conf: SparkConf, livyConf: RSCConf)
       assert(msg.from != null)
       assert(msg.size != null)
       if (msg.from == -1) {
-        Array(new Statement(-1, session.getBufferState, StatementState.Rejected, null))
+        Array(new Statement(-1, session.getBufferState(), StatementState.Rejected, null))
       } else if (msg.size == 1) {
         session.statements.get(msg.from).toArray
       } else {

--- a/repl/src/main/scala/org/apache/livy/repl/Session.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/Session.scala
@@ -58,7 +58,7 @@ class Session(
   import Session._
 
   private val interpreterExecutor = ExecutionContext.fromExecutorService(
-    Executors.newSingleThreadExecutor())
+    Executors.newFixedThreadPool(livyConf.getInt(RSCConf.Entry.SESSION_INTERPRETER_THREADS)))
 
   private val cancelExecutor = ExecutionContext.fromExecutorService(
     Executors.newSingleThreadExecutor())
@@ -161,7 +161,7 @@ class Session(
     _statements.synchronized { _statements(statementId) = statement }
 
     Future {
-      setJobGroup(tpe, statementId)
+      this.synchronized { setJobGroup(tpe, statementId) }
       statement.compareAndTransit(StatementState.Waiting, StatementState.Running)
 
       if (statement.state.get() == StatementState.Running) {

--- a/repl/src/main/scala/org/apache/livy/repl/Session.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/Session.scala
@@ -68,9 +68,11 @@ class Session(
   // Number of statements kept in driver's memory
   private val numRetainedStatements = livyConf.getInt(RSCConf.Entry.RETAINED_STATEMENTS)
 
-  private val resultRetainedTimeout = livyConf.getTimeAsMs(RSCConf.Entry.STAETMENT_RESULT_RETAINED_TIMEOUT)
+  private val resultRetainedTimeout =
+    livyConf.getTimeAsMs(RSCConf.Entry.STAETMENT_RESULT_RETAINED_TIMEOUT)
 
-  private val resultDiscardTimeout = livyConf.getTimeAsMs(RSCConf.Entry.STATEMENT_RESULT_DISCRAD_TIMEOUT)
+  private val resultDiscardTimeout =
+    livyConf.getTimeAsMs(RSCConf.Entry.STATEMENT_RESULT_DISCRAD_TIMEOUT)
 
   private val _statements = mutable.HashMap[Int, Statement]()
 
@@ -158,7 +160,8 @@ class Session(
       } else if (defaultInterpKind != Shared) {
         defaultInterpKind
       } else {
-        throw new IllegalArgumentException(s"Code type should be specified if session kind is shared")
+        throw new IllegalArgumentException(
+          s"Code type should be specified if session kind is shared")
       }
 
       val statementId = newStatementId.getAndIncrement()
@@ -375,7 +378,8 @@ class Session(
     debug(s"statement No.${id} ${msg}")
     val (running, o) = _statements.values.partition(_.state.get() == StatementState.Running)
     debug(s"Buffer Size: ${numRetainedStatements}\tUsed Size: ${_statements.size}\t" +
-      s"Finished: ${_waitingRemove.size} Running: ${running.size} Waiting: ${o.size-_waitingRemove.size}")
+      s"Finished: ${_waitingRemove.size} Running: ${running.size} " +
+      s"Waiting: ${o.size-_waitingRemove.size}")
   }
 
   private def isOverload(proposer: Int): Boolean = _statements.synchronized {
@@ -383,7 +387,7 @@ class Session(
       snapshot(proposer, "is accepted")
       false
     } else if (checkExpired) {
-      if(_statements.size >= numRetainedStatements) {
+      if (_statements.size >= numRetainedStatements) {
         snapshot(proposer, s"will be accepted, cleanUpExpired now")
         cleanUpExpired
       } else {
@@ -411,7 +415,8 @@ class Session(
   // Attention: do not use _statements.synchronized to prevent deadlock
   private def cleanUpExpired: Unit = _waitingRemove.synchronized {
     assert(_waitingRemove.size > 0)
-    val sorted = mutable.PriorityQueue[(Int, Long)](_waitingRemove.toSeq: _*)(Ordering.by[(Int, Long), Long](_._2).reverse)
+    val sorted = mutable.PriorityQueue[(Int, Long)](_waitingRemove.toSeq: _*)
+    (Ordering.by[(Int, Long), Long](_._2).reverse)
     LAT = sorted.dequeue()
     val now = new Date().getTime
     while (LAT._2 != 0 && LAT._2 <= now ) {
@@ -441,7 +446,7 @@ class Session(
       }
     } else {
       _waitingRemove.synchronized {
-        val newLAT =  new Date().getTime + resultDiscardTimeout
+        val newLAT = new Date().getTime + resultDiscardTimeout
         _waitingRemove(id) = newLAT
         if (newLAT < LAT._2) {
           LAT = (id, newLAT)
@@ -455,7 +460,8 @@ class Session(
     if (_statements.size < numRetainedStatements || checkExpired) {
       "buffer is free, please try to resubmit the code"
     } else {
-      s"buffer is busy，maybe free after ${TimeUnit.SECONDS.convert(LAT._2 - new Date().getTime, TimeUnit.MILLISECONDS)}s"
+      "buffer is busy, maybe free after " +
+        s"${TimeUnit.SECONDS.convert(LAT._2 - new Date().getTime, TimeUnit.MILLISECONDS)}s"
     }
   }
 

--- a/repl/src/test/scala/org/apache/livy/repl/SessionSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/SessionSpec.scala
@@ -88,30 +88,5 @@ class SessionSpec extends FunSpec with Eventually with LivyBaseUnitTestSuite wit
       }
     }
 
-    it("should remove old statements when reaching threshold") {
-      rscConf.set(RSCConf.Entry.RETAINED_STATEMENTS, 2)
-      session = new Session(rscConf, new SparkConf())
-      session.start()
-
-      session.statements.size should be (0)
-      session.execute("")
-      session.statements.size should be (1)
-      session.statements.map(_._1).toSet should be (Set(0))
-      session.execute("")
-      session.statements.size should be (2)
-      session.statements.map(_._1).toSet should be (Set(0, 1))
-      session.execute("")
-      eventually {
-        session.statements.size should be (2)
-        session.statements.map(_._1).toSet should be (Set(1, 2))
-      }
-
-      // Continue submitting statements, total statements in memory should be 2.
-      session.execute("")
-      eventually {
-        session.statements.size should be (2)
-        session.statements.map(_._1).toSet should be (Set(2, 3))
-      }
-    }
   }
 }

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
@@ -72,6 +72,9 @@ public class RSCConf extends ClientConf<RSCConf> {
     SASL_MECHANISMS("rpc.sasl.mechanisms", "DIGEST-MD5"),
     SASL_QOP("rpc.sasl.qop", null),
 
+    STAETMENT_RESULT_RETAINED_TIMEOUT("result-retained.timeout", "1h"),
+    STATEMENT_RESULT_DISCRAD_TIMEOUT("result-discard.timeout", "10m"),
+
     TEST_STUCK_END_SESSION("test.do-not-use.stuck-end-session", false),
     TEST_STUCK_START_DRIVER("test.do-not-use.stuck-start-driver", false),
 

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
@@ -44,7 +44,7 @@ public class RSCConf extends ClientConf<RSCConf> {
     CLIENT_SHUTDOWN_TIMEOUT("client.shutdown-timeout", "10s"),
     DRIVER_CLASS("driver-class", null),
     SESSION_KIND("session.kind", null),
-    SESSION_INTERPRETER_THREADS("session.threads", 1),
+    SESSION_INTERPRETER_THREADS("session.interpreter.threadPool.size", 1),
 
     LIVY_JARS("jars", null),
     SPARKR_PACKAGE("sparkr.package", null),
@@ -72,8 +72,8 @@ public class RSCConf extends ClientConf<RSCConf> {
     SASL_MECHANISMS("rpc.sasl.mechanisms", "DIGEST-MD5"),
     SASL_QOP("rpc.sasl.qop", null),
 
-    STAETMENT_RESULT_RETAINED_TIMEOUT("result-retained.timeout", "1h"),
-    STATEMENT_RESULT_DISCRAD_TIMEOUT("result-discard.timeout", "10m"),
+    STATEMENT_RESULT_RETAINED_TIMEOUT("result-retained.timeout", "1h"),
+    STATEMENT_RESULT_DISCARD_TIMEOUT("result-discard.timeout", "10m"),
 
     TEST_STUCK_END_SESSION("test.do-not-use.stuck-end-session", false),
     TEST_STUCK_START_DRIVER("test.do-not-use.stuck-start-driver", false),

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
@@ -44,6 +44,7 @@ public class RSCConf extends ClientConf<RSCConf> {
     CLIENT_SHUTDOWN_TIMEOUT("client.shutdown-timeout", "10s"),
     DRIVER_CLASS("driver-class", null),
     SESSION_KIND("session.kind", null),
+    SESSION_INTERPRETER_THREADS("session.threads", 1),
 
     LIVY_JARS("jars", null),
     SPARKR_PACKAGE("sparkr.package", null),

--- a/rsc/src/main/java/org/apache/livy/rsc/driver/StatementState.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/driver/StatementState.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public enum StatementState {
+  Rejected("rejected"),
   Waiting("waiting"),
   Running("running"),
   Available("available"),


### PR DESCRIPTION
## What changes were proposed in this pull request?
1.  interpreterExecutor of repl.Session change to newFixedThreadPool, size configurable
2. Try to cleanup _statements of Session by judge expired or not, rather than drop Eldest statement casually.
3. Reject statement request when buffer is full and none is expired
- The new Statechart Diagram of Statement looks like this: (brown box means inner sate, user unknowable)
![livy statement2](https://user-images.githubusercontent.com/16742851/50004024-b6d57600-ffe0-11e8-922d-78ad478e9324.png)
- so that user can configure these properties to control a statement's lifecycle

| Property Name                           | Default | Meaning                                                      |
| --------------------------------------- | ------- | ------------------------------------------------------------ |
| livy.rsc.server.statements.parallel.num | 1      | Size of ExecutorThreadPool |
| livy.rsc.retained-statements            | 100     | Buffer size of statement |
| livy.rsc.result-discard.timeout         | 10m     | **Expired Timeout after read**，When the user retrieves the query result, the state change to Readed from Available, and automatically becomes Expired after 10 minutes. Expired means when the buffer queue space is insufficient, this statement may be moved out of the buffer queue. |
| livy.rsc.result-retained.timeout        | 1h      | **Expired timeout before read**，After statement became Available, If user never get the query result within 1 hour , StatementState will change to Expired automatically. |

## How was this patch tested?

we run a jmeter test of 20 threads each post statement 1/60s, set "spark.scheduler.mode": "FAIR", print debug message in AM stdout, and examine the buffer state.