### PR TITLE
[LIVY-543] Clean thriftserver dependencies from Hive's jetty

### DIFF
--- a/thriftserver/server/pom.xml
+++ b/thriftserver/server/pom.xml
@@ -50,6 +50,10 @@
           <groupId>org.apache.hive</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -104,11 +108,10 @@
       <version>2.25.1</version>
     </dependency>
 
-    <!-- needed for compiling successfully when using JobContext -->
     <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-hive_${scala.binary.version}</artifactId>
-      <scope>provided</scope>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-runner</artifactId>
+      <version>${jetty.version}</version>
     </dependency>
 
     <!-- needed for testing -->


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hive 3.0 uses Jetty 9.3.8. So there are some jars coming from hive dependency which are conflicting with our Jetty dependencies which were upgraded in LIVY-526. Hence we should ignore the dependencies Hive has on Jetty and use our own version. After the refactor which has been done in the thriftserver, this should be easy.

The PR removes also an extra-dependency which was left in the thriftserver-server module which is not needed anymore after the refactor which created the thriftserver-session module.

## How was this patch tested?

manual tests, checking the generated JARs

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
