### PR TITLE
[LIVY-545] Try to clear buffer by judge expired or not, rather than drop Eldest …

### DIFF
--- a/repl/src/main/scala/org/apache/livy/repl/ReplDriver.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/ReplDriver.scala
@@ -75,7 +75,9 @@ class ReplDriver(conf: SparkConf, livyConf: RSCConf)
     } else {
       assert(msg.from != null)
       assert(msg.size != null)
-      if (msg.size == 1) {
+      if (msg.from == -1) {
+        Array(new Statement(-1, session.getBufferState(), StatementState.Rejected, null))
+      } else if (msg.size == 1) {
         session.statements.get(msg.from).toArray
       } else {
         val until = msg.from + msg.size
@@ -86,6 +88,9 @@ class ReplDriver(conf: SparkConf, livyConf: RSCConf)
     // Update progress of statements when queried
     statements.foreach { s =>
       s.updateProgress(session.progressOfStatement(s.id))
+      if (s.state.get() == StatementState.Available) {
+        session.markHasRead(s.id)
+      }
     }
 
     new ReplJobResults(statements.sortBy(_.id))

--- a/repl/src/test/scala/org/apache/livy/repl/SessionSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/SessionSpec.scala
@@ -20,7 +20,11 @@ package org.apache.livy.repl
 import java.util.Properties
 import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
 
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
 import org.apache.spark.SparkConf
+import org.json4s.JsonAST
 import org.scalatest.{BeforeAndAfter, FunSpec}
 import org.scalatest.Matchers._
 import org.scalatest.concurrent.Eventually
@@ -29,7 +33,9 @@ import org.scalatest.time._
 import org.apache.livy.LivyBaseUnitTestSuite
 import org.apache.livy.repl.Interpreter.ExecuteResponse
 import org.apache.livy.rsc.RSCConf
+import org.apache.livy.rsc.driver.SparkEntries
 import org.apache.livy.sessions._
+
 
 class SessionSpec extends FunSpec with Eventually with LivyBaseUnitTestSuite with BeforeAndAfter {
   override implicit val patienceConfig =
@@ -88,10 +94,19 @@ class SessionSpec extends FunSpec with Eventually with LivyBaseUnitTestSuite wit
       }
     }
 
-    it("should remove old statements when reaching threshold") {
+    it("should remove expired statements when reaching threshold") {
       rscConf.set(RSCConf.Entry.RETAINED_STATEMENTS, 2)
-      session = new Session(rscConf, new SparkConf())
-      session.start()
+      rscConf.set(RSCConf.Entry.STATEMENT_RESULT_RETAINED_TIMEOUT, "1s")
+      val interpreter = new SparkInterpreter(new SparkConf()) {
+        override def execute(code: String): ExecuteResponse = {
+          Interpreter.ExecuteSuccess(new org.json4s.JObject(List[JsonAST.JField]()))
+        }
+        override def postStart(): Unit = {
+          entries = new SparkEntries(conf)
+        }
+      }
+      session = new Session(rscConf, new SparkConf(), Some(interpreter))
+      Await.result(session.start(), Duration.Inf)
 
       session.statements.size should be (0)
       session.execute("")
@@ -100,12 +115,11 @@ class SessionSpec extends FunSpec with Eventually with LivyBaseUnitTestSuite wit
       session.execute("")
       session.statements.size should be (2)
       session.statements.map(_._1).toSet should be (Set(0, 1))
-      session.execute("")
-      eventually {
-        session.statements.size should be (2)
-        session.statements.map(_._1).toSet should be (Set(1, 2))
+      eventually(timeout(Span(1500, Millis))) {
+        session.execute("")
+        session.statements.size should be (1)
+        session.statements.map(_._1).toSet should be (Set(2))
       }
-
       // Continue submitting statements, total statements in memory should be 2.
       session.execute("")
       eventually {

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
@@ -71,6 +71,9 @@ public class RSCConf extends ClientConf<RSCConf> {
     SASL_MECHANISMS("rpc.sasl.mechanisms", "DIGEST-MD5"),
     SASL_QOP("rpc.sasl.qop", null),
 
+    STATEMENT_RESULT_RETAINED_TIMEOUT("result-retained.timeout", "1h"),
+    STATEMENT_RESULT_DISCARD_TIMEOUT("result-discard.timeout", "10m"),
+
     TEST_STUCK_END_SESSION("test.do-not-use.stuck-end-session", false),
     TEST_STUCK_START_DRIVER("test.do-not-use.stuck-start-driver", false),
 

--- a/rsc/src/main/java/org/apache/livy/rsc/driver/StatementState.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/driver/StatementState.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public enum StatementState {
+  Rejected("rejected"),
   Waiting("waiting"),
   Running("running"),
   Available("available"),


### PR DESCRIPTION
## What changes were proposed in this pull request?
https://issues.apache.org/jira/browse/LIVY-545
1. Try to cleanup _statements of Session by judge expired or not, rather than drop Eldest statement casually.
2. Reject statement request when buffer is full and none is expired
- The new Statechart Diagram of Statement looks like this: (brown box means inner sate, user unknowable)
![livy statement2](https://user-images.githubusercontent.com/16742851/50004024-b6d57600-ffe0-11e8-922d-78ad478e9324.png)
- so that user can configure these properties to control a statement's lifecycle

| Property Name                           | Default | Meaning                                                      |
| --------------------------------------- | ------- | ------------------------------------------------------------ |
| livy.rsc.retained-statements            | 100     | Buffer size of statement |
| livy.rsc.result-discard.timeout         | 10m     | **Expired Timeout after read**，When the user retrieves the query result, the state change to Readed from Available, and automatically becomes Expired after 10 minutes. Expired means when the buffer queue space is insufficient, this statement may be moved out of the buffer queue. |
| livy.rsc.result-retained.timeout        | 1h      | **Expired timeout before read**，After statement became Available, If user never get the query result within 1 hour , StatementState will change to Expired automatically. |
## How was this patch tested?
we run a jmeter test of 20 threads each post statement 1/60s, set "spark.scheduler.mode": "FAIR", print debug message in AM stdout, and examine the buffer state.

we modify the "should remove expired statements when reaching threshold" of SessionSpec to fit this new character.