### PR TITLE
[LIVY-547]do not check expire when session in state busy

### DIFF
--- a/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
@@ -142,6 +142,8 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
             false
           } else if (session.isInstanceOf[BatchSession]) {
             false
+          } else if (SessionState.Busy.equals(session.state)) {
+            false
           } else {
             val currentTime = System.nanoTime()
             currentTime - session.lastActivity > sessionTimeout


### PR DESCRIPTION
## What changes were proposed in this pull request?
add a logic in check expired function to ensure interactiveSession will not expired in state busy。 

## How was this patch tested?
set livy.server.session.timeout to a short interval and submit a job by interactiveSession
this session will not be recycled in state busy。

