### PR TITLE
[LIVY-550] quick failure when error happens in spark-submit process

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
@@ -98,6 +98,7 @@ object BatchSession extends Logging {
             case 0 =>
             case exitCode =>
               warn(s"spark-submit exited with code $exitCode")
+              s.stateChanged(SparkApp.State.STARTING, SparkApp.State.FAILED)
           }
         } finally {
           childProcesses.decrementAndGet()


### PR DESCRIPTION
## What changes were proposed in this pull request?
support batch session a quick failure when error happens in spark-submit process

## How was this patch tested?
submit a batch session with wrong username or queuename，observe session state in livy ui

