### PR TITLE
[LIVY-551] Add "doAs" impersonation support

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -810,3 +810,10 @@ A statement represents the result of an execution statement.
     <td>string</td>
   </tr>
 </table>
+
+### Proxy User - `doAs` support
+If superuser support is configured, Livy supports the `doAs` query parameter
+to specify the user to impersonate. The `doAs` query parameter can be used
+on any supported REST endpoint described above to perform the action as the
+specified user. If both `doAs` and `proxyUser` are specified during session
+or batch creation, the `doAs` parameter takes precedence.

--- a/server/src/main/scala/org/apache/livy/server/AccessManager.scala
+++ b/server/src/main/scala/org/apache/livy/server/AccessManager.scala
@@ -101,13 +101,13 @@ private[livy] class AccessManager(conf: LivyConf) extends Logging {
   /**
    * Checks that the request user can impersonate the target user.
    * If impersonation is enabled and the user does not have permission to impersonate
-   * then throws an `AccessControlException`. If impersonation is disabled returns false
+   * then throws an `AccessControlException`. If impersonation is disabled returns false.
    */
   def checkImpersonation(
       requestUser: String,
       impersonatedUser: String): Boolean = {
     if (conf.getBoolean(LivyConf.IMPERSONATION_ENABLED)) {
-      if (hasSuperAccess(requestUser, impersonatedUser)) {
+      if (hasSuperAccess(impersonatedUser, requestUser)) {
         true
       } else {
         throw new AccessControlException(
@@ -119,10 +119,10 @@ private[livy] class AccessManager(conf: LivyConf) extends Logging {
   }
 
   /**
-   * Check that the request user has is able to impersonate the given user.
+   * Check that the requesting user has admin access to resources owned by the given target user.
    */
-  def hasSuperAccess(requestUser: String, impersonatedUser: String): Boolean = {
-    requestUser == impersonatedUser || checkSuperUser(requestUser)
+  def hasSuperAccess(target: String, requestUser: String): Boolean = {
+    requestUser == target || checkSuperUser(requestUser)
   }
 
   /**
@@ -133,7 +133,7 @@ private[livy] class AccessManager(conf: LivyConf) extends Logging {
   }
 
   /**
-   * Check that the request user has view access to the given session
+   * Check that the request user has view access to the given session.
    */
   def hasViewAccess(session: Session, effectiveUser: String): Boolean = {
     session.owner == effectiveUser || checkViewPermissions(effectiveUser)

--- a/server/src/main/scala/org/apache/livy/server/AccessManager.scala
+++ b/server/src/main/scala/org/apache/livy/server/AccessManager.scala
@@ -119,6 +119,18 @@ private[livy] class AccessManager(conf: LivyConf) extends Logging {
   }
 
   /**
+   * Returns the impersonated user or None after checking if impersonation is allowed
+   */
+  def enforceProxyUser(owner: String,
+      proxyUser: Option[String]): Option[String] = {
+    if(conf.getBoolean(LivyConf.IMPERSONATION_ENABLED)) {
+      proxyUser.filter(checkImpersonation(owner, _)).orElse(Option(owner))
+    } else {
+      None
+    }
+  }
+
+  /**
    * Check that the requesting user has admin access to resources owned by the given target user.
    */
   def hasSuperAccess(target: String, requestUser: String): Boolean = {

--- a/server/src/main/scala/org/apache/livy/server/AccessManager.scala
+++ b/server/src/main/scala/org/apache/livy/server/AccessManager.scala
@@ -20,6 +20,7 @@ package org.apache.livy.server
 import java.security.AccessControlException
 
 import org.apache.livy.{LivyConf, Logging}
+import org.apache.livy.sessions.Session
 
 private[livy] class AccessManager(conf: LivyConf) extends Logging {
   private val aclsOn = conf.getBoolean(LivyConf.ACCESS_CONTROL_ENABLED)
@@ -98,46 +99,43 @@ private[livy] class AccessManager(conf: LivyConf) extends Logging {
   def isAccessControlOn: Boolean = aclsOn
 
   /**
-   * Checks that the requesting user can impersonate the target user.
-   * If the user does not have permission to impersonate, then throws an `AccessControlException`.
-   *
-   * @return The user that should be impersonated. That can be the target user if defined, the
-   *         request's user - which may not be defined - otherwise, or `None` if impersonation is
-   *         disabled.
+   * Checks that the request user can impersonate the target user.
+   * If impersonation is enabled and the user does not have permission to impersonate
+   * then throws an `AccessControlException`. If impersonation is disabled returns false
    */
   def checkImpersonation(
-      target: Option[String],
       requestUser: String,
-      livyConf: LivyConf): Option[String] = {
-    if (livyConf.getBoolean(LivyConf.IMPERSONATION_ENABLED)) {
-      if (!target.forall(hasSuperAccess(_, requestUser))) {
+      impersonatedUser: String): Boolean = {
+    if (conf.getBoolean(LivyConf.IMPERSONATION_ENABLED)) {
+      if (hasSuperAccess(requestUser, impersonatedUser)) {
+        true
+      } else {
         throw new AccessControlException(
-          s"User '$requestUser' not allowed to impersonate '$target'.")
+          s"User '$requestUser' not allowed to impersonate '$impersonatedUser'.")
       }
-      target.orElse(Option(requestUser))
     } else {
-      None
+      false
     }
   }
 
   /**
-   * Check that the requesting user has admin access to resources owned by the given target user.
+   * Check that the request user has is able to impersonate the given user.
    */
-  def hasSuperAccess(target: String, requestUser: String): Boolean = {
-    requestUser == target || checkSuperUser(requestUser)
+  def hasSuperAccess(requestUser: String, impersonatedUser: String): Boolean = {
+    requestUser == impersonatedUser || checkSuperUser(requestUser)
   }
 
   /**
-   * Check that the request's user has modify access to resources owned by the given target user.
+   * Check that the request user has modify access to the given session.
    */
-  def hasModifyAccess(target: String, requestUser: String): Boolean = {
-    requestUser == target || checkModifyPermissions(requestUser)
+  def hasModifyAccess(session: Session, effectiveUser: String): Boolean = {
+    session.owner == effectiveUser || checkModifyPermissions(effectiveUser)
   }
 
   /**
-   * Check that the request's user has view access to resources owned by the given target user.
+   * Check that the request user has view access to the given session
    */
-  def hasViewAccess(target: String, requestUser: String): Boolean = {
-    requestUser == target || checkViewPermissions(requestUser)
+  def hasViewAccess(session: Session, effectiveUser: String): Boolean = {
+    session.owner == effectiveUser || checkViewPermissions(effectiveUser)
   }
 }

--- a/server/src/main/scala/org/apache/livy/server/AccessManager.scala
+++ b/server/src/main/scala/org/apache/livy/server/AccessManager.scala
@@ -123,7 +123,7 @@ private[livy] class AccessManager(conf: LivyConf) extends Logging {
    */
   def enforceProxyUser(owner: String,
       proxyUser: Option[String]): Option[String] = {
-    if(conf.getBoolean(LivyConf.IMPERSONATION_ENABLED)) {
+    if (conf.getBoolean(LivyConf.IMPERSONATION_ENABLED)) {
       proxyUser.filter(checkImpersonation(owner, _)).orElse(Option(owner))
     } else {
       None

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -164,8 +164,7 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
    * Returns the impersonated user as given by "doAs" as a request parameter.
    */
   protected def impersonatedUser(request: HttpServletRequest): Option[String] = {
-    val impersonatedUser = Option(request.getParameter("doAs"))
-    impersonatedUser.filter(accessManager.checkImpersonation(remoteUser(request), _))
+    Option(request.getParameter("doAs"))
   }
 
   /**
@@ -173,22 +172,16 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
    */
   protected def proxyUser(request: HttpServletRequest,
       createRequestProxyUser: Option[String]): Option[String] = {
-    impersonatedUser(request).orElse(legacyProxyUser(remoteUser(request), createRequestProxyUser))
-  }
-
-  /**
-   * Returns the proxy user as determined by the json request body or owner if available.
-   * This is necessary to preserve backwards compatibility prior to "doAs" impersonation.
-   */
-  protected def legacyProxyUser(owner: String, bodyProxyUser: Option[String]): Option[String] = {
-    bodyProxyUser.filter(accessManager.checkImpersonation(owner, _)).orElse(Option(owner))
+    impersonatedUser(request).orElse(createRequestProxyUser).orElse(Option(remoteUser(request)))
   }
 
   /**
    * Gets the request user or impersonated user to determine the effective user.
    */
   protected def effectiveUser(request: HttpServletRequest): String = {
-    impersonatedUser(request).getOrElse(remoteUser(request))
+    val requestUser = remoteUser(request)
+    impersonatedUser(request).orElse(Option(requestUser))
+      .filter(accessManager.checkImpersonation(requestUser, _)).orNull
   }
 
   /**

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -180,7 +180,8 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
    * Gets the request user or impersonated user to determine the effective user.
    */
   protected def effectiveUser(request: HttpServletRequest): String = {
-    accessManager.checkImpersonation(impersonatedUser(request), remoteUser(request)).orNull
+    val requestUser = remoteUser(request)
+    accessManager.checkImpersonation(impersonatedUser(request), requestUser).getOrElse(requestUser)
   }
 
   /**

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -172,7 +172,7 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
    */
   protected def proxyUser(request: HttpServletRequest,
       createRequestProxyUser: Option[String]): Option[String] = {
-    impersonatedUser(request).orElse(createRequestProxyUser).orElse(Option(remoteUser(request)))
+    impersonatedUser(request).orElse(createRequestProxyUser)
   }
 
   /**

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -180,8 +180,8 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
    */
   protected def effectiveUser(request: HttpServletRequest): String = {
     val requestUser = remoteUser(request)
-    impersonatedUser(request).orElse(Option(requestUser))
-      .filter(accessManager.checkImpersonation(requestUser, _)).orNull
+    impersonatedUser(request).filter(accessManager.checkImpersonation(requestUser, _))
+      .getOrElse(requestUser)
   }
 
   /**

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
@@ -57,10 +57,12 @@ object BatchSession extends Logging {
       livyConf: LivyConf,
       accessManager: AccessManager,
       owner: String,
+      impersonatedUser: Option[String],
       sessionStore: SessionStore,
       mockApp: Option[SparkApp] = None): BatchSession = {
     val appTag = s"livy-batch-$id-${Random.alphanumeric.take(8).mkString}"
-    val impersonatedUser = accessManager.checkImpersonation(request.proxyUser, owner, livyConf)
+
+    impersonatedUser.filter(accessManager.checkImpersonation(owner, _))
 
     def createSparkApp(s: BatchSession): SparkApp = {
       val conf = SparkApp.prepareSparkConf(

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
@@ -61,7 +61,7 @@ object BatchSession extends Logging {
       sessionStore: SessionStore,
       mockApp: Option[SparkApp] = None): BatchSession = {
     val appTag = s"livy-batch-$id-${Random.alphanumeric.take(8).mkString}"
-    val impersonatedUser = accessManager.enforceProxyUser(owner, proxyUser)
+    val impersonatedUser = accessManager.checkImpersonation(proxyUser, owner)
 
     def createSparkApp(s: BatchSession): SparkApp = {
       val conf = SparkApp.prepareSparkConf(

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
@@ -57,12 +57,11 @@ object BatchSession extends Logging {
       livyConf: LivyConf,
       accessManager: AccessManager,
       owner: String,
-      impersonatedUser: Option[String],
+      proxyUser: Option[String],
       sessionStore: SessionStore,
       mockApp: Option[SparkApp] = None): BatchSession = {
     val appTag = s"livy-batch-$id-${Random.alphanumeric.take(8).mkString}"
-
-    impersonatedUser.foreach(accessManager.checkImpersonation(owner, _))
+    val impersonatedUser = proxyUser.filter(accessManager.checkImpersonation(owner, _))
 
     def createSparkApp(s: BatchSession): SparkApp = {
       val conf = SparkApp.prepareSparkConf(

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
@@ -61,7 +61,7 @@ object BatchSession extends Logging {
       sessionStore: SessionStore,
       mockApp: Option[SparkApp] = None): BatchSession = {
     val appTag = s"livy-batch-$id-${Random.alphanumeric.take(8).mkString}"
-    val impersonatedUser = proxyUser.filter(accessManager.checkImpersonation(owner, _))
+    val impersonatedUser = accessManager.enforceProxyUser(owner, proxyUser)
 
     def createSparkApp(s: BatchSession): SparkApp = {
       val conf = SparkApp.prepareSparkConf(

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
@@ -62,7 +62,7 @@ object BatchSession extends Logging {
       mockApp: Option[SparkApp] = None): BatchSession = {
     val appTag = s"livy-batch-$id-${Random.alphanumeric.take(8).mkString}"
 
-    impersonatedUser.filter(accessManager.checkImpersonation(owner, _))
+    impersonatedUser.foreach(accessManager.checkImpersonation(owner, _))
 
     def createSparkApp(s: BatchSession): SparkApp = {
       val conf = SparkApp.prepareSparkConf(

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
@@ -42,17 +42,13 @@ class BatchSessionServlet(
 
   override protected def createSession(req: HttpServletRequest): BatchSession = {
     val createRequest = bodyAs[CreateBatchRequest](req)
-    val owner = remoteUser(req)
-    val proxyUser = impersonatedUser(req)
-      .orElse(legacyProxyUser(owner, createRequest.proxyUser))
-
     BatchSession.create(
       sessionManager.nextId(),
       createRequest,
       livyConf,
       accessManager,
-      owner,
-      proxyUser,
+      remoteUser(req),
+      proxyUser(req, createRequest.proxyUser),
       sessionStore)
   }
 

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
@@ -56,7 +56,7 @@ class BatchSessionServlet(
       session: BatchSession,
       req: HttpServletRequest): Any = {
     val logs =
-      if (accessManager.hasViewAccess(session, effectiveUser(req))) {
+      if (accessManager.hasViewAccess(session.owner, effectiveUser(req))) {
         val lines = session.logLines()
 
         val size = 10

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -75,7 +75,7 @@ object InteractiveSession extends Logging {
       mockApp: Option[SparkApp] = None,
       mockClient: Option[RSCClient] = None): InteractiveSession = {
     val appTag = s"livy-session-$id-${Random.alphanumeric.take(8).mkString}"
-    val impersonatedUser = accessManager.enforceProxyUser(owner, proxyUser)
+    val impersonatedUser = accessManager.checkImpersonation(proxyUser, owner)
 
     val client = mockClient.orElse {
       val conf = SparkApp.prepareSparkConf(appTag, livyConf, prepareConf(

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -76,7 +76,7 @@ object InteractiveSession extends Logging {
       mockClient: Option[RSCClient] = None): InteractiveSession = {
     val appTag = s"livy-session-$id-${Random.alphanumeric.take(8).mkString}"
 
-    impersonatedUser.filter(accessManager.checkImpersonation(owner, _))
+    impersonatedUser.foreach(accessManager.checkImpersonation(owner, _))
 
     val client = mockClient.orElse {
       val conf = SparkApp.prepareSparkConf(appTag, livyConf, prepareConf(

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -75,7 +75,7 @@ object InteractiveSession extends Logging {
       mockApp: Option[SparkApp] = None,
       mockClient: Option[RSCClient] = None): InteractiveSession = {
     val appTag = s"livy-session-$id-${Random.alphanumeric.take(8).mkString}"
-    val impersonatedUser = proxyUser.filter(accessManager.checkImpersonation(owner, _))
+    val impersonatedUser = accessManager.enforceProxyUser(owner, proxyUser)
 
     val client = mockClient.orElse {
       val conf = SparkApp.prepareSparkConf(appTag, livyConf, prepareConf(

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -67,7 +67,7 @@ object InteractiveSession extends Logging {
   def create(
       id: Int,
       owner: String,
-      impersonatedUser: Option[String],
+      proxyUser: Option[String],
       livyConf: LivyConf,
       accessManager: AccessManager,
       request: CreateInteractiveRequest,
@@ -75,8 +75,7 @@ object InteractiveSession extends Logging {
       mockApp: Option[SparkApp] = None,
       mockClient: Option[RSCClient] = None): InteractiveSession = {
     val appTag = s"livy-session-$id-${Random.alphanumeric.take(8).mkString}"
-
-    impersonatedUser.foreach(accessManager.checkImpersonation(owner, _))
+    val impersonatedUser = proxyUser.filter(accessManager.checkImpersonation(owner, _))
 
     val client = mockClient.orElse {
       val conf = SparkApp.prepareSparkConf(appTag, livyConf, prepareConf(

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -67,6 +67,7 @@ object InteractiveSession extends Logging {
   def create(
       id: Int,
       owner: String,
+      impersonatedUser: Option[String],
       livyConf: LivyConf,
       accessManager: AccessManager,
       request: CreateInteractiveRequest,
@@ -74,7 +75,8 @@ object InteractiveSession extends Logging {
       mockApp: Option[SparkApp] = None,
       mockClient: Option[RSCClient] = None): InteractiveSession = {
     val appTag = s"livy-session-$id-${Random.alphanumeric.take(8).mkString}"
-    val impersonatedUser = accessManager.checkImpersonation(request.proxyUser, owner, livyConf)
+
+    impersonatedUser.filter(accessManager.checkImpersonation(owner, _))
 
     val client = mockClient.orElse {
       val conf = SparkApp.prepareSparkConf(appTag, livyConf, prepareConf(

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -52,9 +52,14 @@ class InteractiveSessionServlet(
 
   override protected def createSession(req: HttpServletRequest): InteractiveSession = {
     val createRequest = bodyAs[CreateInteractiveRequest](req)
+    val owner = remoteUser(req)
+    val proxyUser = impersonatedUser(req)
+      .orElse(legacyProxyUser(owner, createRequest.proxyUser))
+
     InteractiveSession.create(
       sessionManager.nextId(),
-      remoteUser(req),
+      owner,
+      proxyUser,
       livyConf,
       accessManager,
       createRequest,
@@ -65,7 +70,7 @@ class InteractiveSessionServlet(
       session: InteractiveSession,
       req: HttpServletRequest): Any = {
     val logs =
-      if (accessManager.hasViewAccess(session.owner, remoteUser(req))) {
+      if (accessManager.hasViewAccess(session, effectiveUser(req))) {
         Option(session.logLines())
           .map { lines =>
             val size = 10

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -66,7 +66,7 @@ class InteractiveSessionServlet(
       session: InteractiveSession,
       req: HttpServletRequest): Any = {
     val logs =
-      if (accessManager.hasViewAccess(session, effectiveUser(req))) {
+      if (accessManager.hasViewAccess(session.owner, effectiveUser(req))) {
         Option(session.logLines())
           .map { lines =>
             val size = 10

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -52,14 +52,10 @@ class InteractiveSessionServlet(
 
   override protected def createSession(req: HttpServletRequest): InteractiveSession = {
     val createRequest = bodyAs[CreateInteractiveRequest](req)
-    val owner = remoteUser(req)
-    val proxyUser = impersonatedUser(req)
-      .orElse(legacyProxyUser(owner, createRequest.proxyUser))
-
     InteractiveSession.create(
       sessionManager.nextId(),
-      owner,
-      proxyUser,
+      remoteUser(req),
+      proxyUser(req, createRequest.proxyUser),
       livyConf,
       accessManager,
       createRequest,

--- a/server/src/main/scala/org/apache/livy/sessions/Session.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/Session.scala
@@ -204,7 +204,7 @@ abstract class Session(val id: Int, val owner: String, val livyConf: LivyConf)
 
   protected def stopSession(): Unit
 
-  protected val proxyUser: Option[String]
+  val proxyUser: Option[String]
 
   protected def doAsOwner[T](fn: => T): T = {
     val user = proxyUser.getOrElse(owner)

--- a/server/src/main/scala/org/apache/livy/sessions/Session.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/Session.scala
@@ -204,6 +204,7 @@ abstract class Session(val id: Int, val owner: String, val livyConf: LivyConf)
 
   protected def stopSession(): Unit
 
+  // Visible for testing.
   val proxyUser: Option[String]
 
   protected def doAsOwner[T](fn: => T): T = {

--- a/server/src/test/scala/org/apache/livy/server/BaseSessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/BaseSessionServletSpec.scala
@@ -77,7 +77,6 @@ abstract class BaseSessionServletSpec[S <: Session, R <: RecoveryMetadata]
   addServlet(servlet, "/*")
 
   protected def toJson(msg: AnyRef): Array[Byte] = mapper.writeValueAsBytes(msg)
-
 }
 
 trait RemoteUserOverride {
@@ -86,5 +85,4 @@ trait RemoteUserOverride {
   override protected def remoteUser(req: HttpServletRequest): String = {
     req.getHeader(BaseSessionServletSpec.REMOTE_USER_HEADER)
   }
-
 }

--- a/server/src/test/scala/org/apache/livy/server/BaseSessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/BaseSessionServletSpec.scala
@@ -77,6 +77,7 @@ abstract class BaseSessionServletSpec[S <: Session, R <: RecoveryMetadata]
   addServlet(servlet, "/*")
 
   protected def toJson(msg: AnyRef): Array[Byte] = mapper.writeValueAsBytes(msg)
+
 }
 
 trait RemoteUserOverride {
@@ -85,4 +86,5 @@ trait RemoteUserOverride {
   override protected def remoteUser(req: HttpServletRequest): String = {
     req.getHeader(BaseSessionServletSpec.REMOTE_USER_HEADER)
   }
+
 }

--- a/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
@@ -156,6 +156,12 @@ class SessionServletSpec extends BaseSessionServletSpec[Session, RecoveryMetadat
           assert(res.proxyUser === Some("alice"))
           assert(res.logs === IndexedSeq("log"))
         }
+
+        jget[MockSessionView](s"/${res.id}?doAs=bob", headers = adminHeaders) { res =>
+          assert(res.owner === "alice")
+          assert(res.proxyUser === Some("alice"))
+          assert(res.logs === IndexedSeq("log"))
+        }
         delete(res.id, aliceHeaders, SC_OK)
       }
 
@@ -237,6 +243,13 @@ class AclsEnabledSessionServletSpec extends BaseSessionServletSpec[Session, Reco
     it("should only allow view accessible users to see non-sensitive information") {
       jpost[MockSessionView]("/", Map(), headers = aliceHeaders) { res =>
         jget[MockSessionView](s"/${res.id}", headers = bobHeaders) { res =>
+          assert(res.owner === "alice")
+          assert(res.proxyUser === Some("alice"))
+          // Other user cannot see the logs
+          assert(res.logs === Nil)
+        }
+
+        jget[MockSessionView](s"/${res.id}?doAs=bob", headers = adminHeaders) { res =>
           assert(res.owner === "alice")
           assert(res.proxyUser === Some("alice"))
           // Other user cannot see the logs

--- a/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
@@ -133,7 +133,7 @@ class SessionServletSpec extends BaseSessionServletSpec[Session, RecoveryMetadat
       }
     }
 
-    it("should allow other users to see non-sensitive information") {
+    it("should allow other users to see all information due to ACLs not enabled") {
       jpost[MockSessionView]("/", Map()) { res =>
         jget[MockSessionView](s"/${res.id}", headers = bobHeaders) { res =>
           assert(res.owner === null)

--- a/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
@@ -109,6 +109,13 @@ class SessionServletSpec extends BaseSessionServletSpec[Session, RecoveryMetadat
     }
 
     it("should attach owner information to sessions") {
+      jpost[MockSessionView]("/", Map()) { res =>
+        assert(res.owner === null)
+        assert(res.proxyUser === None)
+        assert(res.logs === IndexedSeq("log"))
+        delete(res.id, adminHeaders, SC_OK)
+      }
+
       jpost[MockSessionView]("/", Map(), headers = aliceHeaders) { res =>
         assert(res.owner === "alice")
         assert(res.proxyUser === Some("alice"))
@@ -125,6 +132,24 @@ class SessionServletSpec extends BaseSessionServletSpec[Session, RecoveryMetadat
     }
 
     it("should allow other users to see non-sensitive information") {
+      jpost[MockSessionView]("/", Map()) { res =>
+        jget[MockSessionView](s"/${res.id}", headers = bobHeaders) { res =>
+          assert(res.owner === null)
+          assert(res.proxyUser === None)
+          assert(res.logs === IndexedSeq("log"))
+        }
+        delete(res.id, adminHeaders, SC_OK)
+      }
+
+      jpost[MockSessionView]("/", Map(), headers = aliceHeaders) { res =>
+        jget[MockSessionView](s"/${res.id}") { res =>
+          assert(res.owner === "alice")
+          assert(res.proxyUser === Some("alice"))
+          assert(res.logs === IndexedSeq("log"))
+        }
+        delete(res.id, aliceHeaders, SC_OK)
+      }
+
       jpost[MockSessionView]("/", Map(), headers = aliceHeaders) { res =>
         jget[MockSessionView](s"/${res.id}", headers = bobHeaders) { res =>
           assert(res.owner === "alice")
@@ -194,6 +219,13 @@ class AclsEnabledSessionServletSpec extends BaseSessionServletSpec[Session, Reco
 
   describe("SessionServlet") {
     it("should attach owner information to sessions") {
+      jpost[MockSessionView]("/", Map()) { res =>
+        assert(res.owner === null)
+        assert(res.proxyUser === None)
+        assert(res.logs === IndexedSeq("log"))
+        delete(res.id, adminHeaders, SC_OK)
+      }
+
       jpost[MockSessionView]("/", Map(), headers = aliceHeaders) { res =>
         assert(res.owner === "alice")
         assert(res.proxyUser === Some("alice"))

--- a/server/src/test/scala/org/apache/livy/server/batch/BatchSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/BatchSessionSpec.scala
@@ -70,7 +70,7 @@ class BatchSessionSpec
 
       val conf = new LivyConf().set(LivyConf.LOCAL_FS_WHITELIST, sys.props("java.io.tmpdir"))
       val accessManager = new AccessManager(conf)
-      val batch = BatchSession.create(0, req, conf, accessManager, null, sessionStore)
+      val batch = BatchSession.create(0, req, conf, accessManager, null, None, sessionStore)
 
       Utils.waitUntil({ () => !batch.state.isActive }, Duration(10, TimeUnit.SECONDS))
       (batch.state match {
@@ -87,7 +87,7 @@ class BatchSessionSpec
       val mockApp = mock[SparkApp]
       val accessManager = new AccessManager(conf)
       val batch = BatchSession.create(
-        0, req, conf, accessManager, null, sessionStore, Some(mockApp))
+        0, req, conf, accessManager, null, None, sessionStore, Some(mockApp))
 
       val expectedAppId = "APPID"
       batch.appIdKnown(expectedAppId)

--- a/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
@@ -70,7 +70,7 @@ class InteractiveSessionSpec extends FunSpec
       SparkLauncher.DRIVER_EXTRA_CLASSPATH -> sys.props("java.class.path"),
       RSCConf.Entry.LIVY_JARS.key() -> ""
     )
-    InteractiveSession.create(0, null, livyConf, accessManager, req, sessionStore, mockApp)
+    InteractiveSession.create(0, null, None, livyConf, accessManager, req, sessionStore, mockApp)
   }
 
   private def executeStatement(code: String, codeType: Option[String] = None): JValue = {

--- a/server/src/test/scala/org/apache/livy/server/interactive/JobApiSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/JobApiSpec.scala
@@ -21,15 +21,16 @@ import java.io.File
 import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Paths}
-
 import javax.servlet.http.HttpServletResponse._
-import org.apache.hadoop.security.UserGroupInformation
 
 import scala.concurrent.duration._
 import scala.io.Source
 import scala.language.postfixOps
+
+import org.apache.hadoop.security.UserGroupInformation
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.mock.MockitoSugar.mock
+
 import org.apache.livy.{Job, JobHandle, LivyConf}
 import org.apache.livy.client.common.{BufferUtils, Serializer}
 import org.apache.livy.client.common.HttpMessages._
@@ -39,6 +40,7 @@ import org.apache.livy.sessions.{InteractiveSessionManager, SessionState}
 import org.apache.livy.test.jobs.{Echo, GetCurrentUser}
 
 class JobApiSpec extends BaseInteractiveServletSpec {
+
   protected val PROXY = "__proxy__"
 
   private var sessionId: Int = -1

--- a/server/src/test/scala/org/apache/livy/server/interactive/JobApiSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/JobApiSpec.scala
@@ -21,16 +21,16 @@ import java.io.File
 import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Paths}
+
 import javax.servlet.http.HttpServletResponse._
+import org.apache.hadoop.security.UserGroupInformation
 
 import scala.concurrent.duration._
 import scala.io.Source
 import scala.language.postfixOps
-
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.mock.MockitoSugar.mock
-
-import org.apache.livy.{Job, JobHandle}
+import org.apache.livy.{Job, JobHandle, LivyConf}
 import org.apache.livy.client.common.{BufferUtils, Serializer}
 import org.apache.livy.client.common.HttpMessages._
 import org.apache.livy.server.{AccessManager, RemoteUserOverride}
@@ -39,8 +39,7 @@ import org.apache.livy.sessions.{InteractiveSessionManager, SessionState}
 import org.apache.livy.test.jobs.{Echo, GetCurrentUser}
 
 class JobApiSpec extends BaseInteractiveServletSpec {
-
-  private val PROXY = "__proxy__"
+  protected val PROXY = "__proxy__"
 
   private var sessionId: Int = -1
 
@@ -124,6 +123,7 @@ class JobApiSpec extends BaseInteractiveServletSpec {
     }
 
     it("should support user impersonation") {
+      assume(createConf().getBoolean(LivyConf.IMPERSONATION_ENABLED))
       val headers = makeUserHeaders(PROXY)
       jpost[SessionInfo]("/", createRequest(inProcess = false), headers = headers) { data =>
         try {
@@ -139,6 +139,7 @@ class JobApiSpec extends BaseInteractiveServletSpec {
     }
 
     it("should honor impersonation requests") {
+      assume(createConf().getBoolean(LivyConf.IMPERSONATION_ENABLED))
       val request = createRequest(inProcess = false)
       request.proxyUser = Some(PROXY)
       jpost[SessionInfo]("/", request, headers = adminHeaders) { data =>
@@ -166,7 +167,7 @@ class JobApiSpec extends BaseInteractiveServletSpec {
 
   }
 
-  private def waitForIdle(id: Int): Unit = {
+  protected def waitForIdle(id: Int): Unit = {
     eventually(timeout(1 minute), interval(100 millis)) {
       jget[SessionInfo](s"/$id") { status =>
         status.state should be (SessionState.Idle.toString())
@@ -174,11 +175,11 @@ class JobApiSpec extends BaseInteractiveServletSpec {
     }
   }
 
-  private def deleteSession(id: Int): Unit = {
+  protected def deleteSession(id: Int): Unit = {
     jdelete[Map[String, Any]](s"/$id", headers = adminHeaders) { _ => }
   }
 
-  private def testResourceUpload(cmd: String, sessionId: Int): Unit = {
+  protected def testResourceUpload(cmd: String, sessionId: Int): Unit = {
     val f = File.createTempFile("uploadTestFile", cmd)
     val conf = createConf()
 
@@ -197,12 +198,12 @@ class JobApiSpec extends BaseInteractiveServletSpec {
     }
   }
 
-  private def testJobSubmission(sid: Int, sync: Boolean): Unit = {
+  protected def testJobSubmission(sid: Int, sync: Boolean): Unit = {
     val result = runJob(sid, new Echo(42), sync = sync)
     result should be (42)
   }
 
-  private def runJob[T](
+  protected def runJob[T](
       sid: Int,
       job: Job[T],
       sync: Boolean = false,
@@ -226,4 +227,49 @@ class JobApiSpec extends BaseInteractiveServletSpec {
     result.getOrElse(throw new IllegalStateException())
   }
 
+}
+
+class JobApiSpecNoImpersonation extends JobApiSpec {
+  override protected def createConf(): LivyConf = synchronized {
+    super.createConf()
+      .set(LivyConf.IMPERSONATION_ENABLED, false)
+  }
+
+  it("should not support user impersonation") {
+    assume(!createConf().getBoolean(LivyConf.IMPERSONATION_ENABLED))
+    val headers = makeUserHeaders(PROXY)
+    jpost[SessionInfo]("/", createRequest(inProcess = false), headers = headers) { data =>
+      try {
+        waitForIdle(data.id)
+        data.owner should be (PROXY)
+        data.proxyUser should be (null)
+        val user = runJob(data.id, new GetCurrentUser(), headers = headers)
+        user should be (UserGroupInformation.getCurrentUser.getUserName)
+      } finally {
+        deleteSession(data.id)
+      }
+    }
+  }
+
+  it("should not honor impersonation requests") {
+    assume(!createConf().getBoolean(LivyConf.IMPERSONATION_ENABLED))
+    val request = createRequest(inProcess = false)
+    request.proxyUser = Some(PROXY)
+    jpost[SessionInfo]("/", request, headers = adminHeaders) { data =>
+      try {
+        waitForIdle(data.id)
+        data.owner should be (ADMIN)
+        data.proxyUser should be (null)
+        val user = runJob(data.id, new GetCurrentUser(), headers = adminHeaders)
+        user should be (UserGroupInformation.getCurrentUser.getUserName)
+
+        // Test that files are uploaded to a new session directory.
+        assert(tempDir.listFiles().length === 0)
+        testResourceUpload("file", data.id)
+      } finally {
+        deleteSession(data.id)
+        assert(tempDir.listFiles().length === 0)
+      }
+    }
+  }
 }

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
@@ -229,6 +229,7 @@ class LivyThriftSessionManager(val server: LivyThriftServer, val livyConf: LivyC
       val newSession = InteractiveSession.create(
         server.livySessionManager.nextId(),
         username,
+        None,
         server.livyConf,
         server.accessManager,
         createInteractiveRequest,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently `proxyuser` is used in batches and sessions for impersonation. This should be extended to support impersonation for all endpoints. Adding the query parameter `doAs` matches others in the Hadoop ecosystem and will work across endpoints.

https://issues.apache.org/jira/browse/LIVY-551

## How was this patch tested?

Added unit and integration tests for this feature. Manually tested to ensure that `proxyuser` still works. Also checked that if both `proxyuser` and the new `doAs` parameter are specified that `doAs` takes precedence. 