### PR TITLE
[LIVY-557] Make Travis-CI logs less verbose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,23 +50,23 @@ cache:
     - $HOME/.m2
 
 before_install:
-  - sudo apt-get -y install python3-pip python-dev
-  - sudo apt-get -y install libkrb5-dev
-  - sudo apt-get -y remove python-setuptools
-  - sudo pip2 install --upgrade "pip < 10.0.0" "setuptools < 36"
-  - sudo python3 -m pip install --upgrade "pip < 10.0.0" "setuptools < 36"
-  - sudo pip2 install codecov cloudpickle
-  - sudo python3 -m pip install cloudpickle
+  - sudo apt-get -q -y install python3-pip python-dev
+  - sudo apt-get -q -y install libkrb5-dev
+  - sudo apt-get -q -y remove python-setuptools
+  - sudo pip2 -q install --upgrade "pip < 10.0.0" "setuptools < 36"
+  - sudo python3 -m pip -q install --upgrade "pip < 10.0.0" "setuptools < 36"
+  - sudo pip2 -q install codecov cloudpickle
+  - sudo python3 -m pip -q install cloudpickle
 
 install:
-  - mvn $MVN_FLAG install -Dskip -DskipTests -DskipITs -Dmaven.javadoc.skip=true -B -V
+  - mvn $MVN_FLAG install -Dskip -DskipTests -DskipITs -Dmaven.javadoc.skip=true -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -B -V
 
 before_script:
-  - sudo pip2 install "requests >= 2.10.0" pytest flaky flake8 requests-kerberos
-  - sudo pip3 install "requests >= 2.10.0" pytest flaky requests-kerberos
+  - sudo pip2 -q install "requests >= 2.10.0" pytest flaky flake8 requests-kerberos
+  - sudo pip3 -q install "requests >= 2.10.0" pytest flaky requests-kerberos
 
 script:
-  - mvn $MVN_FLAG verify -e
+  - mvn $MVN_FLAG -Dorg.slf4j.simpleLogger.defaultLogLevel=warn verify -e
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ language: scala
   - 2.11.12
 
 env:
-  -MAVEN_OPTS=-Dorg.slf4j.simpleLogger.defaultLogLevel=warn
+  global:
+  - MAVEN_OPTS = "-Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ dist: trusty
 language: scala
   - 2.11.12
 
+env:
+  -MAVEN_OPTS=-Dorg.slf4j.simpleLogger.defaultLogLevel=warn
+
 matrix:
   include:
   - name: "Spark 2.2 Unit Tests"
@@ -60,14 +63,14 @@ before_install:
   - sudo python3 -m pip -q install cloudpickle
 
 install:
-  - mvn $MVN_FLAG install -Dskip -DskipTests -DskipITs -Dmaven.javadoc.skip=true -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -B -V
+  - mvn $MVN_FLAG install -Dskip -DskipTests -DskipITs -Dmaven.javadoc.skip=true -B -V
 
 before_script:
   - sudo pip2 -q install "requests >= 2.10.0" pytest flaky flake8 requests-kerberos
   - sudo pip3 -q install "requests >= 2.10.0" pytest flaky requests-kerberos
 
 script:
-  - mvn $MVN_FLAG -Dorg.slf4j.simpleLogger.defaultLogLevel=warn verify -e
+  - mvn $MVN_FLAG verify -e
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
   - sudo pip3 -q install "requests >= 2.10.0" pytest flaky requests-kerberos
 
 script:
-  - mvn $MVN_FLAG verify -Dmaven.javadoc.skip=true -B -V -e
+  - mvn $MVN_FLAG -Dmaven.javadoc.skip=true -B -V -e verify
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
     env: MVN_FLAG='-Pspark-2.4 -Pthriftserver -DskipTests'
 
 jdk:
-  - openjdk8
+  - oraclejdk8
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@
 #
 
 sudo: required
-dist: trusty
+dist: xenial
 language: scala
   - 2.11.12
 
@@ -38,19 +38,13 @@ matrix:
 jdk:
   - oraclejdk8
 
-addons:
-  apt:
-    sources:
-      r-packages-trusty
-    packages:
-      r-base
+# cache:
+#   pip: true
+#  directories:
+#    - $HOME/.m2
 
-cache:
-  pip: true
-  directories:
-    - $HOME/.m2
-
-before_install:
+install:
+  - sudo apt-get -qq install r-base
   - sudo apt-get -qq install python3-pip python-dev
   - sudo apt-get -qq install libkrb5-dev
   - sudo apt-get -qq remove python-setuptools
@@ -58,17 +52,11 @@ before_install:
   - sudo python3 -m pip -q install --upgrade "pip < 10.0.0" "setuptools < 36"
   - sudo pip2 -q install codecov cloudpickle
   - sudo python3 -m pip -q install cloudpickle
-  - export MAVEN_OPTS=-Dorg.slf4j.simpleLogger.defaultLogLevel=warn
-
-install:
-  - mvn $MVN_FLAG install -Dskip -DskipTests -DskipITs -Dmaven.javadoc.skip=true -B -V
-
-before_script:
   - sudo pip2 -q install "requests >= 2.10.0" pytest flaky flake8 requests-kerberos
   - sudo pip3 -q install "requests >= 2.10.0" pytest flaky requests-kerberos
 
 script:
-  - mvn $MVN_FLAG verify -e
+  - mvn $MVN_FLAG verify -Dmaven.javadoc.skip=true -B -V -e
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ language: scala
 
 env:
   global:
-  - MAVEN_OPTS = "-Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
+  - MAVEN_OPTS='-Dorg.slf4j.simpleLogger.defaultLogLevel=warn'
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
     env: MVN_FLAG='-Pspark-2.4 -Pthriftserver -DskipTests'
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,10 @@ matrix:
 jdk:
   - oraclejdk8
 
-# cache:
-#   pip: true
-#  directories:
-#    - $HOME/.m2
+cache:
+  pip: true
+  directories:
+    - $HOME/.m2
 
 install:
   - sudo apt-get -qq install r-base

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,6 @@ dist: trusty
 language: scala
   - 2.11.12
 
-env:
-  global:
-  - MAVEN_OPTS='-Dorg.slf4j.simpleLogger.defaultLogLevel=warn'
-
 matrix:
   include:
   - name: "Spark 2.2 Unit Tests"
@@ -62,6 +58,7 @@ before_install:
   - sudo python3 -m pip -q install --upgrade "pip < 10.0.0" "setuptools < 36"
   - sudo pip2 -q install codecov cloudpickle
   - sudo python3 -m pip -q install cloudpickle
+  - export MAVEN_OPTS=-Dorg.slf4j.simpleLogger.defaultLogLevel=warn
 
 install:
   - mvn $MVN_FLAG install -Dskip -DskipTests -DskipITs -Dmaven.javadoc.skip=true -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,9 @@ cache:
     - $HOME/.m2
 
 before_install:
-  - sudo apt-get -q -y install python3-pip python-dev
-  - sudo apt-get -q -y install libkrb5-dev
-  - sudo apt-get -q -y remove python-setuptools
+  - sudo apt-get -qq install python3-pip python-dev
+  - sudo apt-get -qq install libkrb5-dev
+  - sudo apt-get -qq remove python-setuptools
   - sudo pip2 -q install --upgrade "pip < 10.0.0" "setuptools < 36"
   - sudo python3 -m pip -q install --upgrade "pip < 10.0.0" "setuptools < 36"
   - sudo pip2 -q install codecov cloudpickle

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@
 sudo: required
 dist: trusty
 language: scala
+  - 2.11.12
 
 matrix:
   include:


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Set the base travis image to ubuntu Xenial.
- Set the Scala version to `2.11.12` to match the version in pom.xml.
- Install `r-base` directly from xenial repos (no need to add r-packages).
- Combine the two `mvn` builds into one (`script` and `install` sections in `.travis.yml`).
- Make apt-get and pip are quiet.
- ~Set the SLF4J log level to warn for maven.~ 

## How was this patch tested?
Tested on Travis:
- Before this change, travis logs were about 6K+ lines long.
- After this change, the logs are less than 4K for unit tests and less than 3K for integration tests.
- I also verified that
  - Travis uses scala 2.11.12.
  - r-base is installed.
  - mvn runs without a problem after combining the two mvn builds.
  - Warn level messages and outputs of builds/tests are still available in the logs.
  - apt-get and pip run in quiet mode.

## Sample Travis outputs
**A build log that is  big to fit into Travis UI (size 4MB)**: https://travis-ci.org/apache/incubator-livy/jobs/487096239
**A build log BEFORE this change  (size 643KB)**: https://travis-ci.org/apache/incubator-livy/jobs/487164276
**A build log AFTER this change (size 327KB)**: https://travis-ci.org/apache/incubator-livy/jobs/492011690
**~A build log with mvn log level set to warn (323 KB)**: ~https://travis-ci.org/apache/incubator-livy/jobs/490937880~
This change is reverted because it was silencing useful information in mvn.


Task-url: https://issues.apache.org/jira/browse/LIVY-557