### PR TITLE
[LIVY-560] Added support for hostnames that resolve to an external address

### DIFF
--- a/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
@@ -141,6 +141,10 @@ public class RSCConf extends ClientConf<RSCConf> {
           }
         }
       }
+    } else {
+      LOG.warn("Your hostname, {}, resolves to an external address; using {}.",
+          address.getCanonicalHostName(), address.getHostAddress());
+      return address.getHostAddress();
     }
 
     LOG.warn("Your hostname, {}, resolves to a loopback address, but we couldn't find "


### PR DESCRIPTION
## What changes were proposed in this pull request?

In RSC context when the local hostname does not resolves to a loopback address, the canonical hostname is used and sent to other nodes.
This is a problem when running Livy on Kubernetes as another node won't be able to resolve the hostname. The proposed change is to return the IP address of the host when it's hostname resolves to an external IP.

Closes https://issues.apache.org/jira/browse/LIVY-560
Probably closes https://issues.apache.org/jira/browse/LIVY-372 too

## How was this patch tested?

This was tested by successfully running Livy with Spark 2.4.0 on Kubernetes 1.13.2
