### PR TITLE
LIVY-547: Livy kills session after livy.server.session.timeout even i…

### DIFF
--- a/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
@@ -150,6 +150,8 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
         case s: FinishedSessionState =>
           val currentTime = System.nanoTime()
           currentTime - s.time > sessionStateRetainedInSec
+        case SessionState.Busy =>
+            false
         case _ =>
           if (!sessionTimeoutCheck) {
             false


### PR DESCRIPTION
…f the session is active

Signed-off-by: Shanyu Zhao <shzhao@microsoft.com>

## What changes were proposed in this pull request?
To check for session expiration, if session state is busy, always return false.
https://issues.apache.org/jira/browse/LIVY-547

## How was this patch tested?

unit tests, integration tests and manual tests in a live cluster.

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
