### PR TITLE
[LIVY-563] Merge RSCConf to LivyConf when prepareBuilderProp

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -303,6 +303,19 @@ object InteractiveSession extends Logging {
             " classpath or user request.")
       }
     }
+    def mergeRSCConf():Unit={
+      import scala.collection.JavaConverters._
+      val it=livyConf.iterator().asScala
+      while(it.hasNext){
+        val m:java.util.Map.Entry[String,String]=it.next()
+        val key:String=m.getKey
+        val value:String=m.getValue
+        if(key.startsWith("livy.rsc.")){
+          builderProperties.put(key,value)
+        }
+      }
+    }
+
 
     val pySparkFiles = if (!LivyConf.TEST_MODE) {
       findPySparkArchives()
@@ -315,6 +328,7 @@ object InteractiveSession extends Logging {
     }
 
     mergeConfList(pySparkFiles, LivyConf.SPARK_PY_FILES)
+    mergeRSCConf()
 
     val sparkRArchive = if (!LivyConf.TEST_MODE) findSparkRArchive() else None
     sparkRArchive.foreach { archive =>

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -303,15 +303,15 @@ object InteractiveSession extends Logging {
             " classpath or user request.")
       }
     }
-    def mergeRSCConf():Unit={
-      import scala.collection.JavaConverters._
-      val it=livyConf.iterator().asScala
+
+    def mergeRSCConf(): Unit = {
+      val it = livyConf.iterator().asScala
       while(it.hasNext){
-        val m:java.util.Map.Entry[String,String]=it.next()
-        val key:String=m.getKey
-        val value:String=m.getValue
-        if(key.startsWith("livy.rsc.")){
-          builderProperties.put(key,value)
+        val m: java.util.Map.Entry[String, String] = it.next()
+        val key: String = m.getKey
+        val value: String = m.getValue
+        if(key.startsWith("livy.rsc.")) {
+          builderProperties.put(key, value)
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When create InterActiveSessin, prepareBuilderProp did not add all RSCConf(livy.rsc.)  to BuilderProp. After RSCServer started, the livy.rsc.* related configure which modified by user  take no effect. For example, livy.rsc.sql.num-rows and livy.rsc.rpc.max.size and so on. So when BuilderProp,add all RSCConf to properties.

https://issues.apache.org/jira/browse/LIVY-563

(Please fill in changes proposed in this fix)
(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
