### PR TITLE
[LIVY-565] Fix the bug that sql query row count is less than the actual row count of the table at some condition

### DIFF
--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ColumnBuffer.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ColumnBuffer.java
@@ -214,6 +214,8 @@ public class ColumnBuffer {
       // org.apache.hadoop.hive.serde2.thrift.ColumnBuffer expects a List<String>, so convert
       // when reading the value. The Hive/Thrift stack also dislikes nulls, and returning a
       // list with a different number of elements than expected.
+      strings=(strings.length != currentSize) ? Arrays.copyOfRange(strings, 0, currentSize)
+              : strings;
       return Arrays.stream(strings)
         .limit(currentSize)
         .map(s -> (s != null) ? s : EMPTY_STRING)


### PR DESCRIPTION
For example, there is a table with two columns ,which has two hundred rows ,and one of the column's data is all null .When the maxRows of sql query is 200 ,it will only return 100 rows.The cause is that the ColumnBuffer array ,only expands automatically when the inserted data size exceeds 100 , but does not expand if the one of column data is all null.

https://issues.apache.org/jira/browse/LIVY-565

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
