### PR TITLE
[LIVY-566] When cancel a sql job through livy, actually the sparkjob still running

### DIFF
--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/SqlJob.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/SqlJob.java
@@ -59,7 +59,6 @@ public class SqlJob implements Job<Void> {
 
   @Override
   public Void call(JobContext ctx) throws Exception {
-    ctx.sc().setJobGroup(statementId, statement);
     try {
       executeSql(ctx);
     } finally {

--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/SqlJob.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/SqlJob.java
@@ -59,6 +59,7 @@ public class SqlJob implements Job<Void> {
 
   @Override
   public Void call(JobContext ctx) throws Exception {
+    ctx.sc().setJobGroup(statementId, statement);
     try {
       executeSql(ctx);
     } finally {


### PR DESCRIPTION
## What changes were proposed in this pull request?
https://issues.apache.org/jira/browse/LIVY-566

(Please fill in changes proposed in this fix)
(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
