### PR TITLE
[LIVY-566] When cancel a sql job through livy, actually the sparkjob still running 

### DIFF
--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyExecuteStatementOperation.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyExecuteStatementOperation.scala
@@ -22,11 +22,9 @@ import java.util.concurrent.{ConcurrentLinkedQueue, RejectedExecutionException}
 
 import scala.collection.mutable
 import scala.util.control.NonFatal
-
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.hive.service.cli._
-
-import org.apache.livy.Logging
+import org.apache.livy.{JobHandle, Logging}
 import org.apache.livy.thriftserver.SessionStates._
 import org.apache.livy.thriftserver.operation.Operation
 import org.apache.livy.thriftserver.rpc.RpcClient
@@ -59,6 +57,8 @@ class LivyExecuteStatementOperation(
   private var rowOffset = 0L
 
   private def statementId: String = opHandle.getHandleIdentifier.toString
+
+  private var jobHandle: JobHandle[_]=_
 
   private def rpcClientValid: Boolean =
     sessionManager.livySessionState(sessionHandle) == CREATION_SUCCESS && rpcClient.isValid
@@ -138,7 +138,7 @@ class LivyExecuteStatementOperation(
     setState(OperationState.RUNNING)
 
     try {
-      rpcClient.executeSql(sessionHandle, statementId, statement).get()
+      jobHandle=rpcClient.executeSql(sessionHandle, statementId, statement)
     } catch {
       case e: Throwable =>
         val currentState = getStatus.state
@@ -157,6 +157,7 @@ class LivyExecuteStatementOperation(
   override def cancel(state: OperationState): Unit = {
     info(s"Cancel $statementId with state $state")
     cleanup(state)
+    jobHandle.cancel(true)
   }
 
   override def shouldRunAsync: Boolean = runInBackground

--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/SqlJob.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/SqlJob.java
@@ -59,6 +59,7 @@ public class SqlJob implements Job<Void> {
 
   @Override
   public Void call(JobContext ctx) throws Exception {
+    ctx.sc().setJobGroup(statementId, statement)
     try {
       executeSql(ctx);
     } finally {

--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/SqlJob.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/SqlJob.java
@@ -59,7 +59,6 @@ public class SqlJob implements Job<Void> {
 
   @Override
   public Void call(JobContext ctx) throws Exception {
-    ctx.sc().setJobGroup(statementId, statement);
     try {
       executeSql(ctx);
     } finally {


### PR DESCRIPTION
## What changes were proposed in this pull request?
https://issues.apache.org/jira/browse/LIVY-566

(Please fill in changes proposed in this fix)
(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
