### PR TITLE
[LIVY-567] fix SparkApp of InteractiveSession cannot be recovered

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -383,7 +383,7 @@ class InteractiveSession(
   private val app = mockApp.orElse {
     val driverProcess = client.flatMap { c => Option(c.getDriverProcess) }
         .map(new LineBufferedProcess(_, livyConf.getInt(LivyConf.SPARK_LOGS_SIZE)))
-    driverProcess.map { _ => SparkApp.create(appTag, appId, driverProcess, livyConf, Some(this)) }
+    Option(SparkApp.create(appTag, appId, driverProcess, livyConf, Some(this)))
   }
 
   if (client.isEmpty) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

still create a SparkApp even driverProcess not exist, driverProcess only effects some logs, and we can get those log by visiting driverLogUrl.

## How was this patch tested?

recover livy server and observe in livy ui, validate whether sparkUiUrl can get from application. and  
whether livy session state changed when yarn state changed.

