### PR TITLE
[LIVY-568][BUILD] Upgrade jackson version to 2.9.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <guava.version>15.0</guava.version>
     <httpclient.version>4.5.3</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>
-    <jackson.version>2.9.5</jackson.version>
+    <jackson.version>2.9.8</jackson.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <jetty.version>9.3.24.v20180605</jetty.version>
     <json4s.version>3.2.11</json4s.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to security issues of jackson databind module (https://github.com/FasterXML/jackson-databind/issues/2186) proposing to upgrade jackson version to 2.9.8.

## How was this patch tested?

Existing UTs.
