### PR TITLE
[LIVY-565] Ensure column buffer for string and binary returns all data.

### DIFF
--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ColumnBuffer.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ColumnBuffer.java
@@ -18,9 +18,11 @@ package org.apache.livy.thriftserver.session;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -41,8 +43,8 @@ import org.apache.spark.sql.types.StructField;
 public class ColumnBuffer {
 
   public static final int DEFAULT_SIZE = 100;
-  private static final String EMPTY_STRING = "";
-  private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.wrap(new byte[0]);
+  public static final String EMPTY_STRING = "";
+  public static final ByteBuffer EMPTY_BUFFER = ByteBuffer.wrap(new byte[0]);
 
   private final DataType type;
 
@@ -203,21 +205,10 @@ public class ColumnBuffer {
       return (doubles.length != currentSize) ? Arrays.copyOfRange(doubles, 0, currentSize)
         : doubles;
     case BINARY:
-      // org.apache.hadoop.hive.serde2.thrift.ColumnBuffer expects a List<ByteBuffer>, so convert
-      // when reading the value. The Hive/Thrift stack also dislikes nulls, and returning a
-      // list with a different number of elements than expected.
-      return Arrays.stream(buffers)
-        .limit(currentSize)
-        .map(b -> (b != null) ? ByteBuffer.wrap(b) : EMPTY_BUFFER)
-        .collect(Collectors.toList());
+      return toList(Arrays.stream(buffers).map(b -> (b != null) ? ByteBuffer.wrap(b) : null),
+          EMPTY_BUFFER);
     case STRING:
-      // org.apache.hadoop.hive.serde2.thrift.ColumnBuffer expects a List<String>, so convert
-      // when reading the value. The Hive/Thrift stack also dislikes nulls, and returning a
-      // list with a different number of elements than expected.
-      return Arrays.stream(strings)
-        .limit(currentSize)
-        .map(s -> (s != null) ? s : EMPTY_STRING)
-        .collect(Collectors.toList());
+      return toList(Arrays.stream(strings), EMPTY_STRING);
     }
 
     return null;
@@ -239,6 +230,25 @@ public class ColumnBuffer {
 
     int bitIdx = (index % Byte.SIZE);
     return (nulls[byteIdx] & (1 << bitIdx)) != 0;
+  }
+
+  /**
+   * Transforms and internal buffer into a list that meet's Hive expectations. Used for
+   * string and binary fields.
+   *
+   * org.apache.hadoop.hive.serde2.thrift.ColumnBuffer expects a List<String> or List<ByteBuffer>,
+   * depending on the column type. The Hive/Thrift stack also dislikes nulls, and returning a list
+   * with a different number of elements than expected.
+   */
+  private <T> List<T> toList(Stream<T> data, T defaultValue) {
+    final List<T> ret = new ArrayList<>(currentSize);
+    data.limit(currentSize).forEach(e -> {
+      ret.add(e != null ? e : defaultValue);
+    });
+    while (ret.size() < currentSize) {
+      ret.add(defaultValue);
+    }
+    return ret;
   }
 
   private void setNull(int index) {

--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ColumnBuffer.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ColumnBuffer.java
@@ -42,9 +42,9 @@ import org.apache.spark.sql.types.StructField;
  */
 public class ColumnBuffer {
 
-  public static final int DEFAULT_SIZE = 100;
-  public static final String EMPTY_STRING = "";
-  public static final ByteBuffer EMPTY_BUFFER = ByteBuffer.wrap(new byte[0]);
+  static final int DEFAULT_SIZE = 100;
+  static final String EMPTY_STRING = "";
+  static final ByteBuffer EMPTY_BUFFER = ByteBuffer.wrap(new byte[0]);
 
   private final DataType type;
 
@@ -233,7 +233,7 @@ public class ColumnBuffer {
   }
 
   /**
-   * Transforms and internal buffer into a list that meet's Hive expectations. Used for
+   * Transforms and internal buffer into a list that meets Hive expectations. Used for
    * string and binary fields.
    *
    * org.apache.hadoop.hive.serde2.thrift.ColumnBuffer expects a List<String> or List<ByteBuffer>,

--- a/thriftserver/session/src/test/java/org/apache/livy/thriftserver/session/ColumnBufferTest.java
+++ b/thriftserver/session/src/test/java/org/apache/livy/thriftserver/session/ColumnBufferTest.java
@@ -173,15 +173,59 @@ public class ColumnBufferTest {
 
   @Test
   public void testStringColumn() {
+    int nonNullCount = ColumnBuffer.DEFAULT_SIZE * 5;
+    int nullCount = ColumnBuffer.DEFAULT_SIZE * 2;
+
     ColumnBuffer col = new ColumnBuffer(DataType.STRING);
-    for (int i = 0; i < ColumnBuffer.DEFAULT_SIZE * 5; i++) {
+    for (int i = 0; i < nonNullCount; i++) {
       col.add(String.valueOf(i));
+    }
+
+    for (int i = 0; i < nullCount; i++) {
+      col.add(null);
     }
 
     @SuppressWarnings("unchecked")
     List<String> values = (List<String>) col.getValues();
-    for (int i = 0; i < ColumnBuffer.DEFAULT_SIZE * 5; i++) {
+    BitSet nulls = col.getNulls();
+    assertEquals(nonNullCount + nullCount, values.size());
+    for (int i = 0; i < nonNullCount; i++) {
       assertEquals(String.valueOf(i), values.get(i));
+      assertFalse(nulls.get(i));
+    }
+    for (int i = nonNullCount; i < nonNullCount + nullCount; i++) {
+      assertEquals(ColumnBuffer.EMPTY_STRING, values.get(i));
+      assertTrue(nulls.get(i));
+    }
+  }
+
+  @Test
+  public void testBinaryColumn() {
+    int nonNullCount = ColumnBuffer.DEFAULT_SIZE * 5;
+    int nullCount = ColumnBuffer.DEFAULT_SIZE * 2;
+
+    ColumnBuffer col = new ColumnBuffer(DataType.BINARY);
+    for (int i = 0; i < nonNullCount; i++) {
+      byte[] buf = new byte[Integer.SIZE];
+      ByteBuffer.wrap(buf).putInt(i);
+      col.add(buf);
+    }
+
+    for (int i = 0; i < nullCount; i++) {
+      col.add(null);
+    }
+
+    @SuppressWarnings("unchecked")
+    List<ByteBuffer> values = (List<ByteBuffer>) col.getValues();
+    BitSet nulls = col.getNulls();
+    assertEquals(nonNullCount + nullCount, values.size());
+    for (int i = 0; i < nonNullCount; i++) {
+      assertEquals(i, values.get(i).getInt());
+      assertFalse(nulls.get(i));
+    }
+    for (int i = nonNullCount; i < nonNullCount + nullCount; i++) {
+      assertEquals(ColumnBuffer.EMPTY_BUFFER, values.get(i));
+      assertTrue(nulls.get(i));
     }
   }
 


### PR DESCRIPTION
The code was failing to account for null values at the tail end of the buffer,
and could return a buffer that was too short for the number of rows being
returned.

Also added unit tests to verify the fix.