### PR TITLE
[LIVY-581] Fix edge-case where livy overrides user-provided spark properties instead of appending

### DIFF
--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -240,6 +240,11 @@ object LivyConf {
   val SPARK_FILES = "spark.files"
   val SPARK_ARCHIVES = "spark.yarn.dist.archives"
   val SPARK_PY_FILES = "spark.submit.pyFiles"
+  val SPARK_YARN_ARCHIVE = "spark.yarn.archive"
+  val SPARK_YARN_DIST_FILES = "spark.yarn.dist.files"
+  val SPARK_YARN_DIST_JARS = "spark.yarn.dist.jars"
+  val SPARK_YARN_JAR = "spark.yarn.jar"
+  val SPARK_YARN_JARS = "spark.yarn.jars"
 
   /**
    * These are Spark configurations that contain lists of files that the user can add to
@@ -257,11 +262,11 @@ object LivyConf {
     SPARK_FILES,
     SPARK_ARCHIVES,
     SPARK_PY_FILES,
-    "spark.yarn.archive",
-    "spark.yarn.dist.files",
-    "spark.yarn.dist.jars",
-    "spark.yarn.jar",
-    "spark.yarn.jars"
+    SPARK_YARN_ARCHIVE,
+    SPARK_YARN_DIST_FILES,
+    SPARK_YARN_DIST_JARS,
+    SPARK_YARN_JAR,
+    SPARK_YARN_JARS
   )
 
   case class DepConf(

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -290,8 +290,7 @@ object InteractiveSession extends Logging {
                           .map(_.split(",")).getOrElse(Array.empty[String])
       val sparkFiles = conf.get(LivyConf.SPARK_FILES)
                            .map(_.split(",")).getOrElse(Array.empty[String])
-      var files = Array.empty[String]
-      if (!sparkFiles.isEmpty || yarnFiles.isEmpty) files = sparkFiles else files = yarnFiles
+      val files = if (!sparkFiles.isEmpty || yarnFiles.isEmpty) sparkFiles else yarnFiles
       hiveSiteFile(files, livyConf) match {
         case (_, true) =>
           debug("Enable HiveContext because hive-site.xml is found in user request.")

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -285,8 +285,10 @@ object InteractiveSession extends Logging {
       }
     }
 
-    def mergeHiveSiteAndHiveDeps(sparkMajorVersion: Int, files: Array[String],
-                                 mergeJarsConf: String, mergeFilesConf: String): Unit = {
+    def mergeHiveSiteAndHiveDeps(sparkMajorVersion: Int,
+                                 files: Array[String],
+                                 mergeJarsConf: String,
+                                 mergeFilesConf: String): Unit = {
       hiveSiteFile(files, livyConf) match {
         case (_, true) =>
           debug("Enable HiveContext because hive-site.xml is found in user request.")
@@ -339,8 +341,8 @@ object InteractiveSession extends Logging {
       .map(_.split(",")).getOrElse(Array.empty[String])
     val sparkFiles = conf.get(LivyConf.SPARK_FILES)
       .map(_.split(",")).getOrElse(Array.empty[String])
-    val mergeJarsConf = if (conf.get(LivyConf.SPARK_JARS) != None ||
-      conf.get(LivyConf. SPARK_YARN_JARS) == None) {
+    val mergeJarsConf = if (conf.get(LivyConf.SPARK_JARS).isDefined ||
+      conf.get(LivyConf. SPARK_YARN_JARS).isEmpty) {
       LivyConf.SPARK_JARS
     } else {
       LivyConf.SPARK_YARN_JARS

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -339,9 +339,12 @@ object InteractiveSession extends Logging {
       .map(_.split(",")).getOrElse(Array.empty[String])
     val sparkFiles = conf.get(LivyConf.SPARK_FILES)
       .map(_.split(",")).getOrElse(Array.empty[String])
-    val mergeJarsConf = if (conf.get(LivyConf.SPARK_JARS) != None
-      || conf.get(LivyConf. SPARK_YARN_JARS) == None)
-      LivyConf.SPARK_JARS else LivyConf.SPARK_YARN_JARS
+    val mergeJarsConf = if (conf.get(LivyConf.SPARK_JARS) != None ||
+      conf.get(LivyConf. SPARK_YARN_JARS) == None) {
+      LivyConf.SPARK_JARS
+    } else {
+      LivyConf.SPARK_YARN_JARS
+    }
     val (files, mergeFilesConf) = if (!sparkFiles.isEmpty || yarnFiles.isEmpty) {
       (sparkFiles, LivyConf.SPARK_FILES)
     } else {


### PR DESCRIPTION
This commit fixes a bug in livy that yarn properties are overridden when hive is enabled in the spark sessions.

## What changes were proposed in this pull request?

Bugfix, append livy spark properties to the correct spark property (spark.yarn.X or spark.X. If the user have supplied spark config in spark.yarn.X and livy sets spark.X, spark will ignore spark.yarn.X which causes undesired behaviour since the user properties are then ignored. 
 
https://issues.apache.org/jira/browse/LIVY-581

## How was this patch tested?
Unit tests pass and this patch have been in production in our cluster since November last year

