### PR TITLE
[LIVY-585][SERVER] Avoid duplicate stopping log when stop/interrupt a session

### DIFF
--- a/core/src/main/scala/org/apache/livy/sessions/SessionState.scala
+++ b/core/src/main/scala/org/apache/livy/sessions/SessionState.scala
@@ -44,15 +44,6 @@ object SessionState {
     case _ => throw new IllegalArgumentException(s"Illegal session state: $s")
   }
 
-  def isFinished(state: SessionState): Boolean = {
-    state match {
-      case s: FinishedSessionState =>
-        true
-      case _ =>
-        false
-    }
-  }
-
   object NotStarted extends SessionState("not_started", true)
 
   object Starting extends SessionState("starting", true)

--- a/core/src/main/scala/org/apache/livy/sessions/SessionState.scala
+++ b/core/src/main/scala/org/apache/livy/sessions/SessionState.scala
@@ -44,6 +44,15 @@ object SessionState {
     case _ => throw new IllegalArgumentException(s"Illegal session state: $s")
   }
 
+  def isFinished(state: SessionState): Boolean = {
+    state match {
+      case s: FinishedSessionState =>
+        true
+      case _ =>
+        false
+    }
+  }
+
   object NotStarted extends SessionState("not_started", true)
 
   object Starting extends SessionState("starting", true)

--- a/server/src/main/scala/org/apache/livy/sessions/Session.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/Session.scala
@@ -185,32 +185,32 @@ abstract class Session(
   def start(): Unit
 
   def stop(): Future[Unit] = Future {
-    try {
-      if (_stopped.compareAndSet(false, true)) {
+    if (_stopped.compareAndSet(false, true)) {
+      try {
         info(s"Stopping $this...")
         stopSession()
         info(s"Stopped $this.")
+      } catch {
+        case e: Exception =>
+          warn(s"Error stopping session $id.", e)
       }
-    } catch {
-      case e: Exception =>
-        warn(s"Error stopping session $id.", e)
-    }
 
-    try {
-      if (stagingDir != null) {
-        debug(s"Deleting session $id staging directory $stagingDir")
-        doAsOwner {
-          val fs = FileSystem.newInstance(livyConf.hadoopConf)
-          try {
-            fs.delete(stagingDir, true)
-          } finally {
-            fs.close()
+      try {
+        if (stagingDir != null) {
+          debug(s"Deleting session $id staging directory $stagingDir")
+          doAsOwner {
+            val fs = FileSystem.newInstance(livyConf.hadoopConf)
+            try {
+              fs.delete(stagingDir, true)
+            } finally {
+              fs.close()
+            }
           }
         }
+      } catch {
+        case e: Exception =>
+          warn(s"Error cleaning up session $id staging dir.", e)
       }
-    } catch {
-      case e: Exception =>
-        warn(s"Error cleaning up session $id staging dir.", e)
     }
   }
 

--- a/server/src/main/scala/org/apache/livy/sessions/Session.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/Session.scala
@@ -24,9 +24,11 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.concurrent.{ExecutionContext, Future}
+
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.fs.permission.FsPermission
 import org.apache.hadoop.security.UserGroupInformation
+
 import org.apache.livy.{LivyConf, Logging, Utils}
 import org.apache.livy.utils.AppInfo
 
@@ -211,6 +213,8 @@ abstract class Session(
         case e: Exception =>
           warn(s"Error cleaning up session $id staging dir.", e)
       }
+    } else {
+      debug(s"Redundant call on stop(), ${toString()} has been already stopped.")
     }
   }
 

--- a/server/src/main/scala/org/apache/livy/sessions/Session.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/Session.scala
@@ -185,9 +185,11 @@ abstract class Session(
 
   def stop(): Future[Unit] = Future {
     try {
-      info(s"Stopping $this...")
-      stopSession()
-      info(s"Stopped $this.")
+      if (!SessionState.isFinished(state)) {
+        info(s"Stopping $this...")
+        stopSession()
+        info(s"Stopped $this.")
+      }
     } catch {
       case e: Exception =>
         warn(s"Error stopping session $id.", e)

--- a/server/src/main/scala/org/apache/livy/sessions/Session.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/Session.scala
@@ -187,11 +187,12 @@ abstract class Session(
   def start(): Unit
 
   def stop(): Future[Unit] = Future {
-    if (_stopped.compareAndSet(false, true)) {
+    if (!_stopped.get()) {
       try {
         info(s"Stopping $this...")
         stopSession()
         info(s"Stopped $this.")
+        _stopped.compareAndSet(false, true)
       } catch {
         case e: Exception =>
           warn(s"Error stopping session $id.", e)


### PR DESCRIPTION
## What changes were proposed in this pull request?

There's duplicate stopping log when stop/interrupt a session. This happens because server logs stopping info when we stopping/interrupting a session at the first time. And when the session expired, it would be removed from session manager and call stop() and logs stopping info for the second time(Though, it does not really stop the session again at this time).

![dup-stopping-log](https://user-images.githubusercontent.com/16397174/55568688-be0cc500-5732-11e9-9d1a-48aafcbde409.jpg)

The fix is quite simple by adding a `_stopped` flag in Session's `stop()` method. 
 
## How was this patch tested?

N.A.(?)