### PR TITLE
[LIVY-589] add operation log

### DIFF
--- a/conf/livy-client.conf.template
+++ b/conf/livy-client.conf.template
@@ -102,3 +102,11 @@
 
 # Number of statements kept in driver's memory
 # livy.rsc.retained-statements = 100
+
+# When true, rsc will save operation logs and make them available for clients
+# livy.rsc.logging.operation.enabled=false
+# Top level directory where operation logs are stored if logging functionality is enabled
+# livy.rsc.logging.operation.log.location=
+# The logging level for the statment. Possible values: EXECUTION, PERFORMANCE, VERBOSE, NONE
+# livy.rsc.logging.operation.level=VERBOSE
+

--- a/repl/src/main/scala/org/apache/livy/repl/ReplDriver.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/ReplDriver.scala
@@ -20,6 +20,7 @@ package org.apache.livy.repl
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
+import com.google.common.base.Joiner
 import io.netty.channel.ChannelHandlerContext
 import org.apache.spark.SparkConf
 
@@ -66,6 +67,18 @@ class ReplDriver(conf: SparkConf, livyConf: RSCConf)
     session.complete(EOLUtils.convertToSystemEOL(msg.code), msg.codeType, msg.cursor)
   }
 
+  def handle(ctx: ChannelHandlerContext, msg: BaseProtocol.GetJobLog): ReplJobResults = {
+    val statements = session.statements.get(msg.id.toInt)
+    val output = session.readLog(msg.id.toInt, msg.size)
+                        .map( x => s""""${Joiner.on("\n").join(x.iterator())} """" )
+                        .getOrElse("")
+    val resultStatements = statements.map{ item =>
+      val newStat = new Statement(item.id, item.code, item.state.get(), output)
+      newStat.updateProgress(item.progress)
+      newStat
+    }.map(Array(_)).getOrElse(Array.empty[Statement])
+    new ReplJobResults(resultStatements)
+  }
   /**
    * Return statement results. Results are sorted by statement id.
    */

--- a/rsc/src/main/java/org/apache/livy/rsc/BaseProtocol.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/BaseProtocol.java
@@ -202,6 +202,24 @@ public abstract class BaseProtocol extends RpcDispatcher {
     }
   }
 
+  public static class GetJobLog {
+    public boolean allResults;
+    public final String id;
+    public Long  size;
+
+    public GetJobLog(String id,  Long size) {
+      this.allResults = false;
+      this.id= id ;
+      this.size = size;
+    }
+
+    public GetJobLog(String id) {
+      this.allResults = true;
+      this.id=id ;
+      size = null;
+    }
+  }
+
   public static class ReplCompleteRequest {
     public final String code;
     public final String codeType;

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
@@ -302,6 +302,10 @@ public class RSCClient implements LivyClient {
     return deferredCall(new BaseProtocol.GetReplJobResults(), ReplJobResults.class);
   }
 
+  public Future<ReplJobResults> getJobLog(String id, Long size) throws Exception {
+    return deferredCall(new BaseProtocol.GetJobLog(id, size), ReplJobResults.class);
+  }
+
   public Future<String[]> completeReplCode(String code, String codeType, int cursor)
       throws Exception {
     return deferredCall(new BaseProtocol.ReplCompleteRequest(code, codeType, cursor),

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
@@ -43,6 +43,7 @@ public class RSCConf extends ClientConf<RSCConf> {
     CLIENT_IN_PROCESS("client.do-not-use.run-driver-in-process", false),
     CLIENT_SHUTDOWN_TIMEOUT("client.shutdown-timeout", "10s"),
     DRIVER_CLASS("driver-class", null),
+    SESSION_ID("session.id", null),
     SESSION_KIND("session.kind", null),
 
     LIVY_JARS("jars", null),
@@ -79,6 +80,11 @@ public class RSCConf extends ClientConf<RSCConf> {
 
     RETAINED_STATEMENTS("retained-statements", 100),
     RETAINED_SHARE_VARIABLES("retained.share-variables", 100),
+
+    //operation log
+    LOGGING_OPERATION_ENABLED("logging.operation.enabled" , false),
+    LOGGING_OPERATION_LEVEL("logging.operation.level" , "verbose"),
+    LOGGING_OPERATION_LOG_LOCATION("logging.operation.log.location" , null),
 
     // Number of result rows to get for SQL Interpreters.
     SQL_NUM_ROWS("sql.num-rows", 1000);
@@ -188,6 +194,7 @@ public class RSCConf extends ClientConf<RSCConf> {
     JOB_CANCEL_TRIGGER_INTERVAL("job_cancel.trigger_interval", "0.4"),
     JOB_CANCEL_TIMEOUT("job_cancel.timeout", "0.4"),
     RETAINED_STATEMENTS("retained_statements", "0.4");
+
 
     private final String key;
     private final String version;

--- a/rsc/src/main/java/org/apache/livy/rsc/operation/LogDivertAppender.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/operation/LogDivertAppender.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.rsc.operation;
+
+import java.io.CharArrayWriter;
+import java.util.Enumeration;
+import java.util.regex.Pattern;
+
+import com.google.common.base.Joiner;
+import org.apache.hadoop.hive.ql.exec.Task;
+import org.apache.hadoop.hive.ql.log.PerfLogger;
+import org.apache.hadoop.hive.ql.session.OperationLog;
+import org.apache.hadoop.hive.ql.session.OperationLog.LoggingLevel;
+import org.apache.log4j.*;
+import org.apache.log4j.spi.Filter;
+import org.apache.log4j.spi.LoggingEvent;
+
+/**
+ * An Appender to divert logs from individual threads to the LogObject they belong to.
+ */
+public class LogDivertAppender extends WriterAppender {
+  private static final Logger LOG = Logger.getLogger(LogDivertAppender.class.getName());
+  private final LogManager operationManager;
+  public static final Layout defaultVerboseLayout = new PatternLayout(
+          "%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n");
+  public static final Layout defaultNonVerboseLayout = new PatternLayout(
+          "%-5p : %m%n");
+  private boolean isVerbose;
+  private Layout verboseLayout;
+
+  /**
+   * A log filter that filters messages coming from the logger with the given names.
+   * It be used as a white list filter or a black list filter.
+   * We apply black list filter on the Loggers used by the log diversion stuff, so that
+   * they don't generate more logs for themselves when they process logs.
+   * White list filter is used for less verbose log collection
+   */
+  private static class NameFilter extends Filter {
+    private Pattern namePattern;
+    private LoggingLevel loggingMode;
+    private LogManager operationManager;
+
+    /* Patterns that are excluded in verbose logging level.
+     * Filter out messages coming from log processing classes, or we'll run an infinite loop.
+     */
+    private static final Pattern verboseExcludeNamePattern = Pattern.compile(Joiner.on("|")
+      .join(new String[] {LOG.getName(), OperationLog.class.getName(),
+      LogManager.class.getName()}));
+
+    /* Patterns that are included in execution logging level.
+     * In execution mode, show only select logger messages.
+     */
+    private static final Pattern executionIncludeNamePattern = Pattern.compile(Joiner.on("|")
+      .join(new String[] {"org.apache.hadoop.mapreduce.JobSubmitter",
+      "org.apache.hadoop.mapreduce.Job", "SessionState", Task.class.getName(),
+      "org.apache.hadoop.hive.ql.exec.spark.status.SparkJobMonitor"}));
+
+    /* Patterns that are included in performance logging level.
+     * In performance mode, show execution and performance logger messages.
+     */
+    private static final Pattern performanceIncludeNamePattern = Pattern.compile(
+      executionIncludeNamePattern.pattern() + "|" + PerfLogger.class.getName());
+
+    private void setCurrentNamePattern(LoggingLevel mode) {
+      if (mode == LoggingLevel.VERBOSE) {
+        this.namePattern = verboseExcludeNamePattern;
+      } else if (mode == LoggingLevel.EXECUTION) {
+        this.namePattern = executionIncludeNamePattern;
+      } else if (mode == LoggingLevel.PERFORMANCE) {
+        this.namePattern = performanceIncludeNamePattern;
+      }
+    }
+
+    NameFilter(
+      LoggingLevel loggingMode, LogManager op) {
+      this.operationManager = op;
+      this.loggingMode = loggingMode;
+      setCurrentNamePattern(loggingMode);
+    }
+
+    @Override
+    public int decide(LoggingEvent ev) {
+      OperationLog log = LogManager.getOperationLogByThread();
+      boolean excludeMatches = (loggingMode == LoggingLevel.VERBOSE);
+
+      if (log == null) {
+        return Filter.DENY;
+      }
+
+      LoggingLevel currentLoggingMode = log.getOpLoggingLevel();
+      // If logging is disabled, deny everything.
+      if (currentLoggingMode == LoggingLevel.NONE) {
+        return Filter.DENY;
+      }
+      // Look at the current session's setting
+      // and set the pattern and excludeMatches accordingly.
+      if (currentLoggingMode != loggingMode) {
+        loggingMode = currentLoggingMode;
+        setCurrentNamePattern(loggingMode);
+      }
+
+      boolean isMatch = namePattern.matcher(ev.getLoggerName()).matches();
+
+      if (excludeMatches == isMatch) {
+        // Deny if this is black-list filter (excludeMatches = true) and it
+        // matched
+        // or if this is whitelist filter and it didn't match
+        return Filter.DENY;
+      }
+      return Filter.NEUTRAL;
+    }
+  }
+
+  /** This is where the log message will go to */
+  private final CharArrayWriter writer = new CharArrayWriter();
+
+  private void setLayout(boolean isVerbose, Layout lo) {
+    if (isVerbose) {
+      if (lo == null) {
+        lo = defaultVerboseLayout;
+        LOG.info("Cannot find a Layout from a ConsoleAppender. Using default Layout pattern.");
+      }
+    } else {
+      lo = defaultNonVerboseLayout;
+    }
+    setLayout(lo);
+  }
+
+  private void initLayout(boolean isVerbose) {
+    // There should be a ConsoleAppender. Copy its Layout.
+    Logger root = Logger.getRootLogger();
+    Layout layout = null;
+
+    Enumeration<?> appenders = root.getAllAppenders();
+    while (appenders.hasMoreElements()) {
+      Appender ap = (Appender) appenders.nextElement();
+      if (ap.getClass().equals(ConsoleAppender.class)) {
+        layout = ap.getLayout();
+        break;
+      }
+    }
+    setLayout(isVerbose, layout);
+  }
+
+  public LogDivertAppender(LogManager operationManager,
+                           LoggingLevel loggingMode) {
+    isVerbose = (loggingMode == LoggingLevel.VERBOSE);
+    initLayout(isVerbose);
+    setWriter(writer);
+    setName("LogDivertAppender");
+    this.operationManager = operationManager;
+    this.verboseLayout = isVerbose ? layout : defaultVerboseLayout;
+    addFilter(new NameFilter(loggingMode, operationManager));
+  }
+
+  @Override
+  public void doAppend(LoggingEvent event) {
+    OperationLog log = LogManager.getOperationLogByThread();
+
+    // Set current layout depending on the verbose/non-verbose mode.
+    if (log != null) {
+      boolean isCurrModeVerbose = (log.getOpLoggingLevel() == LoggingLevel.VERBOSE);
+
+      // If there is a logging level change from verbose->non-verbose or vice-versa since
+      // the last subAppend call, change the layout to preserve consistency.
+      if (isCurrModeVerbose != isVerbose) {
+        isVerbose = isCurrModeVerbose;
+        setLayout(isVerbose, verboseLayout);
+      }
+    }
+    super.doAppend(event);
+  }
+
+  /**
+   * Overrides WriterAppender.subAppend(), which does the real logging. No need
+   * to worry about concurrency since log4j calls this synchronously.
+   */
+  @Override
+  protected void subAppend(LoggingEvent event) {
+    super.subAppend(event);
+    // That should've gone into our writer. Notify the LogContext.
+    String logOutput = writer.toString();
+    writer.reset();
+
+    OperationLog log = LogManager.getOperationLogByThread();
+    if (log == null) {
+      LOG.debug(" ---+++=== Dropped log event from thread " + event.getThreadName());
+      return;
+    }
+    log.writeOperationLog(logOutput);
+  }
+}

--- a/rsc/src/main/java/org/apache/livy/rsc/operation/LogManager.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/operation/LogManager.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.rsc.operation;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.session.OperationLog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.livy.rsc.RSCConf;
+
+/**
+ * LogManager
+ */
+public class LogManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LogManager.class);
+
+    public static final String prefix = "livy-";
+
+    private String rootDirPath = null;
+
+    private boolean isOperationLogEnabled = false;
+
+    private HiveConf hiveConf;
+
+    private Map<String, OperationLog> logs = Collections.synchronizedMap(new LinkedHashMap());
+
+    public List<String> readLog(String statementId, Long maxRow) throws SQLException {
+        OperationLog tl = this.getLog(statementId) ;
+        if(tl!=null){
+            return tl.readOperationLog(false, maxRow) ;
+        }
+        return null;
+    }
+
+    public void removeLog(String statementId){
+        OperationLog operationLog=logs.get(statementId);
+        if(operationLog!=null){
+            operationLog.close();
+        }
+        logs.remove(statementId);
+    }
+
+    public OperationLog getLog(String statementId) {
+        return logs.get(statementId);
+    }
+
+    public LogManager(RSCConf rscConf) {
+        initialize(rscConf);
+    }
+
+    private void initialize(RSCConf rscConf) {
+        String operationLogLocation = rscConf.get(RSCConf.Entry.LOGGING_OPERATION_LOG_LOCATION);
+        this.rootDirPath = operationLogLocation + File.separator +
+                prefix + rscConf.get(RSCConf.Entry.SESSION_ID);
+        isOperationLogEnabled = rscConf.getBoolean(RSCConf.Entry.LOGGING_OPERATION_ENABLED)
+                && new File(operationLogLocation).isDirectory();
+        String logLevel = rscConf.get(RSCConf.Entry.LOGGING_OPERATION_LEVEL);
+        if(isOperationLogEnabled){
+            hiveConf = new HiveConf();
+            hiveConf.setBoolVar(HiveConf.ConfVars.HIVE_SERVER2_LOGGING_OPERATION_ENABLED,
+                    isOperationLogEnabled);
+            hiveConf.set(HiveConf.ConfVars.HIVE_SERVER2_LOGGING_OPERATION_LOG_LOCATION.varname,
+                    operationLogLocation);
+            hiveConf.set(HiveConf.ConfVars.HIVE_SERVER2_LOGGING_OPERATION_LEVEL.varname,
+                    logLevel);
+            File rootDir = new File(this.rootDirPath);
+            if (!rootDir.exists()) {
+                rootDir.mkdir();
+            }
+        }
+    }
+
+    public void removeCurrentOperationLog() {
+        OperationLog.removeCurrentOperationLog();
+    }
+
+    public void registerOperationLog(String statementId) {
+        if (isOperationLogEnabled) {
+            OperationLog operationLog = logs.get(statementId);
+            if (operationLog == null) {
+                synchronized (this) {
+                    operationLog = logs.get(statementId);
+                    if (operationLog == null) {
+                        File operationLogFile = new File(
+                                rootDirPath,
+                                statementId);
+                        try {
+                            if (operationLogFile.exists()) {
+                                LOG.warn("The operation log file should not exist," +
+                                                " but it is already there: {}",
+                                        operationLogFile.getAbsolutePath());
+                                operationLogFile.delete();
+                            }
+                            if (!operationLogFile.createNewFile()) {
+                                if (!operationLogFile.canRead() || !operationLogFile.canWrite()) {
+                                    LOG.warn(
+                                            "The operation log file can't be recreated," +
+                                                    "or it cannot be read or written: {}",
+                                            operationLogFile.getAbsolutePath());
+                                    return;
+                                }
+                            }
+                        } catch (Exception e) {
+                            LOG.warn(
+                                    String.format("Unable to create operation log file: %s",
+                                            operationLogFile.getAbsolutePath()), e);
+                            return;
+                        }
+                        try {
+                            operationLog = new OperationLog(statementId, operationLogFile, hiveConf);
+                            logs.put(statementId, operationLog);
+                        } catch (FileNotFoundException e) {
+                            LOG.warn(String.format(
+                                    "Unable to instantiate OperationLog object for operation: %s ",
+                                    statementId), e);
+                            return;
+                        }
+                    }
+                }
+            }
+            if(operationLog!=null) {
+                // register this operationLog to current thread
+                OperationLog.setCurrentOperationLog(operationLog);
+            }
+        }
+    }
+
+    public void shutdown() {
+        if (isOperationLogEnabled) {
+            logs.forEach((k, v) -> v.close());
+            File rootDirFile = new File(rootDirPath);
+            if (rootDirFile.isDirectory()) {
+                rootDirFile.deleteOnExit();
+            }
+        }
+    }
+
+    public static OperationLog getOperationLogByThread() {
+        return OperationLog.getCurrentOperationLog();
+    }
+
+}

--- a/rsc/src/main/java/org/apache/livy/rsc/operation/LogManager.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/operation/LogManager.java
@@ -132,7 +132,8 @@ public class LogManager {
                             return;
                         }
                         try {
-                            operationLog = new OperationLog(statementId, operationLogFile, hiveConf);
+                            operationLog = new OperationLog(statementId,
+                                    operationLogFile, hiveConf);
                             logs.put(statementId, operationLog);
                         } catch (FileNotFoundException e) {
                             LOG.warn(String.format(

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -104,6 +104,7 @@ object InteractiveSession extends Logging {
       info(s"Creating Interactive session $id: [owner: $owner, request: $request]")
       val builder = new LivyClientBuilder()
         .setAll(builderProperties.asJava)
+        .setConf(RSCConf.Entry.SESSION_ID.key(), id.toString)
         .setConf("livy.client.session-id", id.toString)
         .setConf(RSCConf.Entry.DRIVER_CLASS.key(), "org.apache.livy.repl.ReplDriver")
         .setConf(RSCConf.Entry.PROXY_USER.key(), impersonatedUser.orNull)
@@ -496,6 +497,16 @@ class InteractiveSession(
   def getStatement(stmtId: Int): Option[Statement] = {
     ensureActive()
     val r = client.get.getReplJobResults(stmtId, 1).get()
+    if (r.statements.length < 1) {
+      None
+    } else {
+      Option(r.statements(0))
+    }
+  }
+
+  def getStatementLog(stmtId: String, size : Long): Option[Statement] = {
+    ensureActive()
+    val r = client.get.getJobLog(stmtId, size).get()
     if (r.statements.length < 1) {
       None
     } else {

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -147,6 +147,17 @@ class InteractiveSessionServlet(
       Ok(Map("msg" -> "canceled"))
     }
   }
+
+  get("/:id/statements/:statementId/log") {
+    withViewAccessSession { session =>
+      val statementId = params("statementId")
+      val size = params.get("size").map(_.toInt).getOrElse(50)
+      Map(
+        "statements" -> session.getStatementLog(statementId, size)
+      )
+    }
+  }
+
   // This endpoint is used by the client-http module to "connect" to an existing session and
   // update its last activity time. It performs authorization checks to make sure the caller
   // has access to the session, so even though it returns the same data, it behaves differently


### PR DESCRIPTION
## What changes were proposed in this pull request?
add the running log of the statement. The user can obtain the running log of the statement through /log. The life cycle of the log is consistent with the statement.
e.g.,

```shell
> curl -d '{"code" : "select * from tmp.ttt " ,"kind" : "sql"}' \
  -H 'Content-Type: application/json' \
  http://$livyhost:$port/sessions/0/statements
>response as below
{"id":1,"code":"select * from tmp.ttt ","state":"waiting","output":null,"progress":0.0}

// then i can get log like this
> curl http://$livyhost:$port/sessions/0/statements/1/log?size=10

>response as below
{
"statements": {
"id": 1,
"code": "select * from tmp.ttt ",
"state": "available",
"output": "19/04/13 12:40:01 DEBUG org.apache.spark.sql.hive.HiveSessionStateBuilder$$anon$1: \n=== Result of Batch Resolution ===\n!'Project [*] Project [name#5, age#6]\n!+- 'UnresolvedRelation `tmp`.`ttt` +- SubqueryAlias `tmp`.`ttt`\n! +- HiveTableRelation `tmp`.`ttt`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, [name#5, age#6]\n \n19/04/13 12:40:01 DEBUG org.apache.spark.sql.internal.BaseSessionStateBuilder$$anon$2: \n=== Result of Batch Finish Analysis ===\n GlobalLimit 1000 GlobalLimit 1000\n +- LocalLimit 1000 +- LocalLimit 1000 ",
"progress": 1
}
}

// and then  get next10 logs
> curl http://$livyhost:$port/sessions/0/statements/1/log?size=10
```

[LIVY-589](https://issues.apache.org/jira/browse/LIVY-589)

## How was this patch tested?

unit tests, integration tests and manual tests in a live cluster.

