### PR TITLE
[LiVY-590] Add dependency to jersey-core

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -114,10 +114,6 @@
           <groupId>javax.servlet</groupId>
           <artifactId>servlet-api</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-core</artifactId>
-        </exclusion>
       </exclusions>
       <scope>${hadoop.scope}</scope>
     </dependency>

--- a/thriftserver/client/pom.xml
+++ b/thriftserver/client/pom.xml
@@ -31,6 +31,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.sun.jersey</groupId>
+      <artifactId>jersey-core</artifactId>
+      <version>1.19</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-jdbc</artifactId>
       <version>${hive.version}</version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

After I upgraded Livy to 0.6.0-incubating, I get following error message when starting livy-server. Also, the livy-server process cannot get the job's appId and status. (See the JIRA for the details)

```
19/04/24 15:05:41 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-ja
va classes where applicable
java.lang.NoClassDefFoundError: javax/ws/rs/ext/MessageBodyReader
        at java.lang.ClassLoader.defineClass1(Native Method)
..
        at org.apache.hadoop.yarn.util.timeline.TimelineUtils.<clinit>(TimelineUtils.java:50)
        at org.apache.hadoop.yarn.client.api.impl.YarnClientImpl.serviceInit(YarnClientImpl.java:179)
        at org.apache.hadoop.service.AbstractService.init(AbstractService.java:163)
        at org.apache.livy.utils.SparkYarnApp$.yarnClient$lzycompute(SparkYarnApp.scala:51)
        at org.apache.livy.utils.SparkYarnApp$.yarnClient(SparkYarnApp.scala:49)
        at org.apache.livy.server.LivyServer$$anonfun$start$6.apply(LivyServer.scala:145)
        at org.apache.livy.server.LivyServer$$anonfun$start$6.apply(LivyServer.scala:145)
        at scala.concurrent.impl.Future$PromiseCompletingRunnable.liftedTree1$1(Future.scala:24)
        at scala.concurrent.impl.Future$PromiseCompletingRunnable.run(Future.scala:24)
        at scala.concurrent.impl.ExecutionContextImpl$AdaptedForkJoinTask.exec(ExecutionContextImpl.scala:121)
        at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
        at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
        at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
        at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
Caused by: java.lang.ClassNotFoundException: javax.ws.rs.ext.MessageBodyReader
        at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        ... 50 more
```

Comparing livy 0.5.0 and 0.6.0 packages, I noticed that livy-0.6.0 does not have jersey-core jar file. Due to the lack of the jar file, we're getting the error above.

This change was made by a part of the changes in LIVY-502. This pull request reverts the change.

Looks like this issue is not happening in the CI. Unfortunately, I could not get why the issue does not happen in the CI env. (I'd like to double-check that the CI env does not have jersey-core jar.) However, I think we should not exclude jersey-core dependency because livy-server depends on hadoop and hadoop depends on jersey-core (MessageBodyReader). 

## How was this patch tested?

Tested manually and confirmed that this change can fix the issue we are seeing.
