### PR TITLE
[LIVY-591] Changed ACLs enforcement to occur on proxy user, if available

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/AccessManager.scala
+++ b/server/src/main/scala/org/apache/livy/server/AccessManager.scala
@@ -111,7 +111,7 @@ private[livy] class AccessManager(conf: LivyConf) extends Logging {
     if (conf.getBoolean(LivyConf.IMPERSONATION_ENABLED)) {
       if (!target.forall(hasSuperAccess(_, requestUser))) {
         throw new AccessControlException(
-          s"User '$requestUser' not allowed to impersonate '$target'.")
+          s"User '$requestUser' not allowed to impersonate '${target.get}'.")
       }
       target.orElse(Option(requestUser))
     } else {

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -218,7 +218,9 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
     }
     session match {
       case Some(session) =>
-        if (allowAll || checkFn.map(_(session.owner, effectiveUser(request))).getOrElse(false)) {
+        if (allowAll ||
+            checkFn.map(_(session.proxyUser.getOrElse(session.owner),
+              effectiveUser(request))).getOrElse(false)) {
           fn(session)
         } else {
           Forbidden()

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
@@ -60,7 +60,8 @@ class BatchSessionServlet(
       session: BatchSession,
       req: HttpServletRequest): Any = {
     val logs =
-      if (accessManager.hasViewAccess(session.owner, effectiveUser(req))) {
+      if (accessManager.hasViewAccess(session.proxyUser.getOrElse(session.owner),
+          effectiveUser(req))) {
         val lines = session.logLines()
 
         val size = 10

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -67,7 +67,8 @@ class InteractiveSessionServlet(
       session: InteractiveSession,
       req: HttpServletRequest): Any = {
     val logs =
-      if (accessManager.hasViewAccess(session.owner, effectiveUser(req))) {
+      if (accessManager.hasViewAccess(session.proxyUser.getOrElse(session.owner),
+          effectiveUser(req))) {
         Option(session.logLines())
           .map { lines =>
             val size = 10

--- a/server/src/test/scala/org/apache/livy/server/batch/BatchServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/BatchServletSpec.scala
@@ -76,6 +76,7 @@ class BatchServletSpec extends BaseSessionServletSpec[BatchSession, BatchRecover
     when(session.appId).thenReturn(Some(appId))
     when(session.appInfo).thenReturn(appInfo)
     when(session.logLines()).thenReturn(log)
+    when(session.proxyUser).thenReturn(None)
 
     val req = mock[HttpServletRequest]
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
ACLs enforcement occurs by checking whether the user requesting for a
resource/access is owner of that resource or has sufficient permissions.

This check used to occur against the session owner, even when a proxy user was
specified during the creation of the resource. This can cause a issue where a
proxy user can create a resource but can't access or modify it.

The check has been modified to occur againt the session proxy user, defaulting
to session owner if proxy user is not specified.

## How was this patch tested?
Added a couple of unit tests