### PR TITLE
allow proxy user to view or modify his session

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/AccessManager.scala
+++ b/server/src/main/scala/org/apache/livy/server/AccessManager.scala
@@ -130,9 +130,9 @@ private[livy] class AccessManager(conf: LivyConf) extends Logging {
    * Check that the request's user has modify access to resources whose owner is the given target
    * user or whose proxy user is the given proxy user.
    */
-  def hasModifyAccess(target: String, proxyUser: Option[String], requestUser: String): Boolean = {
+  def hasModifyAccess(target: String, requestUser: String, proxyUser: String = ""): Boolean = {
     requestUser == target  ||
-    proxyUser != null && proxyUser.getOrElse(null) == requestUser ||
+    proxyUser == requestUser ||
     checkModifyPermissions(requestUser)
   }
 
@@ -140,9 +140,9 @@ private[livy] class AccessManager(conf: LivyConf) extends Logging {
    * Check that the request's user has view access to resources whose owner is the given target
    * user or whose proxy user is the given proxy user.
    */
-  def hasViewAccess(target: String, proxyUser: Option[String], requestUser: String): Boolean = {
+  def hasViewAccess(target: String, requestUser: String, proxyUser: String = ""): Boolean = {
     requestUser == target ||
-    proxyUser != null && proxyUser.getOrElse(null) == requestUser ||
+    proxyUser == requestUser ||
     checkViewPermissions(requestUser)
   }
 }

--- a/server/src/main/scala/org/apache/livy/server/AccessManager.scala
+++ b/server/src/main/scala/org/apache/livy/server/AccessManager.scala
@@ -127,16 +127,22 @@ private[livy] class AccessManager(conf: LivyConf) extends Logging {
   }
 
   /**
-   * Check that the request's user has modify access to resources owned by the given target user.
+   * Check that the request's user has modify access to resources whose owner is the given target
+   * user or whose proxy user is the given proxy user.
    */
-  def hasModifyAccess(target: String, requestUser: String): Boolean = {
-    requestUser == target || checkModifyPermissions(requestUser)
+  def hasModifyAccess(target: String, proxyUser: Option[String], requestUser: String): Boolean = {
+    requestUser == target  ||
+    proxyUser != null && proxyUser.getOrElse(null) == requestUser ||
+    checkModifyPermissions(requestUser)
   }
 
   /**
-   * Check that the request's user has view access to resources owned by the given target user.
+   * Check that the request's user has view access to resources whose owner is the given target
+   * user or whose proxy user is the given proxy user.
    */
-  def hasViewAccess(target: String, requestUser: String): Boolean = {
-    requestUser == target || checkViewPermissions(requestUser)
+  def hasViewAccess(target: String, proxyUser: Option[String], requestUser: String): Boolean = {
+    requestUser == target ||
+    proxyUser != null && proxyUser.getOrElse(null) == requestUser ||
+    checkViewPermissions(requestUser)
   }
 }

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -207,7 +207,7 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
 
   private def doWithSession(fn: (S => Any),
       allowAll: Boolean,
-      checkFn: Option[(String, String) => Boolean]): Any = {
+      checkFn: Option[(String, Option[String], String) => Boolean]): Any = {
     val idOrNameParam: String = params("id")
     val session = if (idOrNameParam.forall(_.isDigit)) {
       val sessionId = idOrNameParam.toInt
@@ -218,7 +218,7 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
     }
     session match {
       case Some(session) =>
-        if (allowAll || checkFn.map(_(session.owner, effectiveUser(request))).getOrElse(false)) {
+        if (allowAll || checkFn.map(_(session.owner, session.proxyUser, effectiveUser(request))).getOrElse(false)) {
           fn(session)
         } else {
           Forbidden()

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -207,7 +207,7 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
 
   private def doWithSession(fn: (S => Any),
       allowAll: Boolean,
-      checkFn: Option[(String, Option[String], String) => Boolean]): Any = {
+      checkFn: Option[(String, String, String) => Boolean]): Any = {
     val idOrNameParam: String = params("id")
     val session = if (idOrNameParam.forall(_.isDigit)) {
       val sessionId = idOrNameParam.toInt
@@ -219,7 +219,9 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
     session match {
       case Some(session) =>
         if (allowAll ||
-            checkFn.map(_(session.owner, session.proxyUser, effectiveUser(request)))
+            checkFn.map(_(session.owner,
+                          effectiveUser(request),
+                          session.proxyUser.getOrElse("")))
                    .getOrElse(false)) {
           fn(session)
         } else {

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -219,7 +219,8 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
     session match {
       case Some(session) =>
         if (allowAll ||
-            checkFn.map(_(session.owner, session.proxyUser, effectiveUser(request))).getOrElse(false)) {
+            checkFn.map(_(session.owner, session.proxyUser, effectiveUser(request)))
+                   .getOrElse(false)) {
           fn(session)
         } else {
           Forbidden()

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -218,7 +218,8 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
     }
     session match {
       case Some(session) =>
-        if (allowAll || checkFn.map(_(session.owner, session.proxyUser, effectiveUser(request))).getOrElse(false)) {
+        if (allowAll ||
+            checkFn.map(_(session.owner, session.proxyUser, effectiveUser(request))).getOrElse(false)) {
           fn(session)
         } else {
           Forbidden()

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
@@ -60,7 +60,9 @@ class BatchSessionServlet(
       session: BatchSession,
       req: HttpServletRequest): Any = {
     val logs =
-      if (accessManager.hasViewAccess(session.owner, session.proxyUser, effectiveUser(req))) {
+      if (accessManager.hasViewAccess(session.owner,
+                                      effectiveUser(req),
+                                      session.proxyUser.getOrElse(""))) {
         val lines = session.logLines()
 
         val size = 10

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
@@ -60,7 +60,7 @@ class BatchSessionServlet(
       session: BatchSession,
       req: HttpServletRequest): Any = {
     val logs =
-      if (accessManager.hasViewAccess(session.owner, effectiveUser(req))) {
+      if (accessManager.hasViewAccess(session.owner, session.proxyUser, effectiveUser(req))) {
         val lines = session.logLines()
 
         val size = 10

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -67,7 +67,7 @@ class InteractiveSessionServlet(
       session: InteractiveSession,
       req: HttpServletRequest): Any = {
     val logs =
-      if (accessManager.hasViewAccess(session.owner, effectiveUser(req))) {
+      if (accessManager.hasViewAccess(session.owner, session.proxyUser, effectiveUser(req))) {
         Option(session.logLines())
           .map { lines =>
             val size = 10

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -67,7 +67,9 @@ class InteractiveSessionServlet(
       session: InteractiveSession,
       req: HttpServletRequest): Any = {
     val logs =
-      if (accessManager.hasViewAccess(session.owner, session.proxyUser, effectiveUser(req))) {
+      if (accessManager.hasViewAccess(session.owner,
+                                      effectiveUser(req),
+                                      session.proxyUser.getOrElse(""))) {
         Option(session.logLines())
           .map { lines =>
             val size = 10

--- a/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
@@ -70,7 +70,10 @@ object SessionServletSpec {
       override protected def clientSessionView(
           session: Session,
           req: HttpServletRequest): Any = {
-        val logs = if (accessManager.hasViewAccess(session.owner, session.proxyUser, effectiveUser(req))) {
+        val hasViewAccess = accessManager.hasViewAccess(session.owner,
+                                                        session.proxyUser,
+                                                        effectiveUser(req))
+        val logs = if (hasViewAccess) {
           session.logLines()
         } else {
           Nil

--- a/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
@@ -71,8 +71,8 @@ object SessionServletSpec {
           session: Session,
           req: HttpServletRequest): Any = {
         val hasViewAccess = accessManager.hasViewAccess(session.owner,
-                                                        session.proxyUser,
-                                                        effectiveUser(req))
+                                                        effectiveUser(req),
+                                                        session.proxyUser.getOrElse(""))
         val logs = if (hasViewAccess) {
           session.logLines()
         } else {

--- a/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
@@ -70,7 +70,7 @@ object SessionServletSpec {
       override protected def clientSessionView(
           session: Session,
           req: HttpServletRequest): Any = {
-        val logs = if (accessManager.hasViewAccess(session.owner, effectiveUser(req))) {
+        val logs = if (accessManager.hasViewAccess(session.owner, session.proxyUser, effectiveUser(req))) {
           session.logLines()
         } else {
           Nil

--- a/server/src/test/scala/org/apache/livy/server/batch/BatchServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/BatchServletSpec.scala
@@ -76,6 +76,7 @@ class BatchServletSpec extends BaseSessionServletSpec[BatchSession, BatchRecover
     when(session.appId).thenReturn(Some(appId))
     when(session.appInfo).thenReturn(appInfo)
     when(session.logLines()).thenReturn(log)
+    when(session.proxyUser).thenReturn(None)
 
     val req = mock[HttpServletRequest]
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Allow proxy user to view or modify his session. Here is the link to the corresponding Jira
https://issues.apache.org/jira/browse/LIVY-592

## How was this patch tested?
Manually tested.

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
Here is the script for manual test. Basically the accepting criteria is that each proxy user can view (or modify) his session, but he cannot view other users' session log.
########################################################################
root@storage-0-0:~# echo Yukon900 | kinit bob
Password for bob@AZDATA.LOCAL:
Warning: Your password will expire in 41 days on Mon Jun 10 19:54:02 2019
root@storage-0-0:~# curl -k -X POST --negotiate -u : --data '{"kind": "pyspark", "proxyUser": "bob"}' -H "Content-Type:
application/json" 'https://gateway-0.gateway-svc.test.svc.cluster.local:8443/gateway/default/livy/v1/sessions'
{"id":3,"name":null,"appId":null,"owner":"knox","proxyUser":"bob","state":"starting","kind":"pyspark","appInfo":{"driverLogUrl":null,"sparkUiUrl":null},"log":["stdout: ","\nstderr: ","\nYARN Diagnostics: "]}

root@storage-0-0:~# curl -k --negotiate -u : 'https://gateway-0.gateway-svc.test.svc.cluster.local:8443/gateway/default/livy/v1/sessions' | grep log
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   377  100   377    0     0   1638      0 --:--:-- --:--:-- --:--:--  1639
100  2717  100  2717    0     0   8462      0 --:--:-- --:--:-- --:--:--  8462
{"from":0,"total":4,"sessions":[{"id":0,"name":null,"appId":"application_1556568005453_0001","owner":"admin","proxyUser":"admin","state":"idle","kind":"pyspark","appInfo":{"driverLogUrl":"http://storage-0-1.storage-0-svc.test.svc.cluster.local:8042/node/containerlogs/container_1556568005453_0001_01_000001/admin","sparkUiUrl":"http://master-svc.test.svc.cluster.local:8088/proxy/application_1556568005453_0001/"},"log":[]},{"id":1,"name":null,"appId":"application_1556568005453_0002","owner":"bob","proxyUser":"bob","state":"idle","kind":"pyspark","appInfo":{"driverLogUrl":"http://storage-0-1.storage-0-svc.test.svc.cluster.local:8042/node/containerlogs/container_1556568005453_0002_01_000001/bob","sparkUiUrl":"http://master-svc.test.svc.cluster.local:8088/proxy/application_1556568005453_0002/"},"log":["\t ApplicationMaster RPC port: -1","\t queue: default","\t start time: 1556568124444","\t final status: UNDEFINED","\t tracking URL: http://master-svc.test.svc.cluster.local:8088/proxy/application_1556568005453_0002/","\t user: bob","19/04/29 20:02:04 INFO util.ShutdownHookManager: Shutdown hook called","19/04/29 20:02:04 INFO util.ShutdownHookManager: Deleting directory /tmp/spark-7e43a04f-7c03-431d-933c-9a297f45f6cc","19/04/29 20:02:04 INFO util.ShutdownHookManager: Deleting directory /tmp/spark-530d70db-6f51-4923-a669-12ad3cce49b6","\nYARN Diagnostics: "]},{"id":2,"name":null,"appId":"application_1556568005453_0003","owner":"knox","proxyUser":"admin","state":"idle","kind":"pyspark","appInfo":{"driverLogUrl":"http://storage-0-0.storage-0-svc.test.svc.cluster.local:8042/node/containerlogs/container_1556568005453_0003_01_000001/admin","sparkUiUrl":"http://master-svc.test.svc.cluster.local:8088/proxy/application_1556568005453_0003/"},"log":[]},{"id":3,"name":null,"appId":"application_1556568005453_0004","owner":"knox","proxyUser":"bob","state":"idle","kind":"pyspark","appInfo":{"driverLogUrl":"http://storage-0-1.storage-0-svc.test.svc.cluster.local:8042/node/containerlogs/container_1556568005453_0004_01_000001/bob","sparkUiUrl":"http://master-svc.test.svc.cluster.local:8088/proxy/application_1556568005453_0004/"},"log":["\t ApplicationMaster RPC port: -1","\t queue: default","\t start time: 1556570499259","\t final status: UNDEFINED","\t tracking URL: http://master-svc.test.svc.cluster.local:8088/proxy/application_1556568005453_0004/","\t user: bob","19/04/29 20:41:39 INFO util.ShutdownHookManager: Shutdown hook called","19/04/29 20:41:39 INFO util.ShutdownHookManager: Deleting directory /tmp/spark-805ca9cc-3c9a-4951-bf05-1cae960987bf","19/04/29 20:41:39 INFO util.ShutdownHookManager: Deleting directory /tmp/spark-42744a2e-bda0-4316-a2ff-21d5fe0afcd3","\nYARN Diagnostics: "]}]}
########################################################################