### PR TITLE
[LIVY-597] Upgrade guava version to latest

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -39,6 +39,7 @@
     <cluster.spec>default</cluster.spec>
     <skipDeploy>true</skipDeploy>
     <livy.test.thrift.enabled>false</livy.test.thrift.enabled>
+    <guava.version>15.0</guava.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <spark.version>${spark.scala-2.11.version}</spark.version>
     <hive.version>3.0.0</hive.version>
     <commons-codec.version>1.9</commons-codec.version>
-    <guava.version>15.0</guava.version>
+    <guava.version>27.1-jre</guava.version>
     <httpclient.version>4.5.3</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>
     <jackson.version>2.9.8</jackson.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The guava 15.0 that Livy is using is affected by CVE-2018-10237.

It seems Livy's guava usage is limited and we can upgrade the version
seamlessly.

https://issues.apache.org/jira/browse/LIVY-597

## How was this patch tested?

Existing unit tests.