### PR TITLE
[LIVY-598] Upgrade jackson to 2.9.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <guava.version>15.0</guava.version>
     <httpclient.version>4.5.3</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>
-    <jackson.version>2.9.8</jackson.version>
+    <jackson.version>2.9.9</jackson.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <jetty.version>9.3.24.v20180605</jetty.version>
     <json4s.version>3.2.11</json4s.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade the jackson dependency to 2.9.9 which fixes CVE-2019-12086.  Spark has also recently upgraded to jackson version 2.9.9.

## How was this patch tested?

Existing unit tests

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
