### PR TITLE
[LIVY-599] Upgrade jetty version to 9.4.18.v20190429

### DIFF
--- a/client-http/src/test/scala/org/apache/livy/client/http/LivyConnectionSpec.scala
+++ b/client-http/src/test/scala/org/apache/livy/client/http/LivyConnectionSpec.scala
@@ -37,8 +37,10 @@ class LivyConnectionSpec extends FunSpecLike with BeforeAndAfterAll with LivyBas
     def basicAuth(username: String, password: String, realm: String): SecurityHandler = {
       val roles = Array("user")
 
+      val userStore = new UserStore
+      userStore.addUser(username, Credential.getCredential(password), roles)
       val l = new HashLoginService()
-      l.putUser(username, Credential.getCredential(password), roles)
+      l.setUserStore(userStore)
       l.setName(realm)
 
       val constraint = new Constraint()

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <httpcore.version>4.4.4</httpcore.version>
     <jackson.version>2.9.8</jackson.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-    <jetty.version>9.3.24.v20180605</jetty.version>
+    <jetty.version>9.4.18.v20190429</jetty.version>
     <json4s.version>3.2.11</json4s.version>
     <junit.version>4.11</junit.version>
     <libthrift.version>0.9.3</libthrift.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade to jetty version 9.4.18.v20190429.
This has fixes for CVE-2019-10247 and spark has recently upgraded to this version

https://issues.apache.org/jira/browse/LIVY-599

## How was this patch tested?

Existing unit tests.

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
