### PR TITLE
[LIVY-603]Upgrade spark 2.4 from 2.4.0 to 2.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1056,7 +1056,7 @@
         <java.version>1.8</java.version>
         <py4j.version>0.10.7</py4j.version>
         <spark.bin.download.url>
-          http://mirrors.advancedhosters.com/apache/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
+          http://mirrors.advancedhosters.com/apache/spark/spark-2.4.3/spark-2.4.3-bin-hadoop2.7.tgz
         </spark.bin.download.url>
         <spark.bin.name>spark-2.4.0-bin-hadoop2.7</spark.bin.name>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1050,7 +1050,7 @@
         </property>
       </activation>
       <properties>
-        <spark.scala-2.11.version>2.4.0</spark.scala-2.11.version>
+        <spark.scala-2.11.version>2.4.3</spark.scala-2.11.version>
         <spark.version>${spark.scala-2.11.version}</spark.version>
         <netty.spark-2.11.version>4.1.17.Final</netty.spark-2.11.version>
         <java.version>1.8</java.version>
@@ -1058,7 +1058,7 @@
         <spark.bin.download.url>
           http://mirrors.advancedhosters.com/apache/spark/spark-2.4.3/spark-2.4.3-bin-hadoop2.7.tgz
         </spark.bin.download.url>
-        <spark.bin.name>spark-2.4.0-bin-hadoop2.7</spark.bin.name>
+        <spark.bin.name>spark-2.4.3-bin-hadoop2.7</spark.bin.name>
       </properties>
     </profile>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

update spark 2.4 config from 2.4.0 to 2.4.3, config with current pom.xml will fail because 2.4.0 spark is removed from http://mirrors.advancedhosters.com/apache/spark/

https://issues.apache.org/jira/browse/LIVY-603

## How was this patch tested?

Existing unit tests.

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
