### PR TITLE
[Minor] Fix spark 2.4.0 tgz file dead download link in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1036,7 +1036,7 @@
         <spark.version>${spark.scala-2.11.version}</spark.version>
         <netty.spark-2.11.version>4.1.17.Final</netty.spark-2.11.version>
         <spark.bin.download.url>
-          http://mirrors.advancedhosters.com/apache/spark/spark-2.3.3/spark-2.3.3-bin-hadoop2.7.tgz
+          https://archive.apache.org/dist/spark/spark-2.3.3/spark-2.3.3-bin-hadoop2.7.tgz
         </spark.bin.download.url>
         <spark.bin.name>spark-2.3.3-bin-hadoop2.7</spark.bin.name>
       </properties>
@@ -1056,7 +1056,7 @@
         <java.version>1.8</java.version>
         <py4j.version>0.10.7</py4j.version>
         <spark.bin.download.url>
-          http://mirrors.advancedhosters.com/apache/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
+          https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
         </spark.bin.download.url>
         <spark.bin.name>spark-2.4.0-bin-hadoop2.7</spark.bin.name>
       </properties>


### PR DESCRIPTION
## What changes were proposed in this pull request?
The download link for spark 2.4.0 tgz file in the pom.xml file is a dead link. This patch change all the spark tgz download links to the official spark release archive site, which should be more stable.

## How was this patch tested?
Existing test.
