### PR TITLE
[LIVY-582][Tests] Hostname in python-api test should be lower case to avoid test failures

### DIFF
--- a/python-api/src/test/python/livy-tests/client_test.py
+++ b/python-api/src/test/python/livy-tests/client_test.py
@@ -26,7 +26,8 @@ from livy.client import HttpClient
 
 session_id = 0
 job_id = 1
-base_uri = 'http://{0}:{1}'.format(socket.gethostname(), 8998)
+# Make sure host name is lower case. See LIVY-582
+base_uri = 'http://{0}:{1}'.format(socket.gethostname().lower(), 8998)
 client_test = None
 invoked_queued_callback = False
 invoked_running_callback = False


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the python-API test code, when returning a mocked response, the mock lib will compare the URL with the predefined URLs case sensitive. However, the `Request` lib used in the Livy python API will change the URL to lower case. This will cause test failures on a machine with an upper case hostname.

This patch turns the hostname in python-API test code into the lower case to avoid such test failures.

## How was this patch tested?
Existing test. Run test specifically on a machine with an upper case hostname.
