### PR TITLE
[LIVY-587] Remove unused guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,6 @@
     <spark.version>${spark.scala-2.11.version}</spark.version>
     <hive.version>3.0.0</hive.version>
     <commons-codec.version>1.9</commons-codec.version>
-    <guava.version>15.0</guava.version>
     <httpclient.version>4.5.3</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>
     <jackson.version>2.9.8</jackson.version>
@@ -281,12 +280,6 @@
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>${commons-codec.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${guava.version}</version>
       </dependency>
 
       <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -75,11 +75,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
     </dependency>

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -31,7 +31,6 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.{Random, Try}
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.google.common.annotations.VisibleForTesting
 import org.apache.hadoop.fs.Path
 import org.apache.spark.launcher.SparkLauncher
 
@@ -155,7 +154,6 @@ object InteractiveSession extends Logging {
       mockApp)
   }
 
-  @VisibleForTesting
   private[interactive] def prepareBuilderProp(
     conf: Map[String, String],
     kind: Kind,

--- a/server/src/main/scala/org/apache/livy/utils/LineBufferedStream.scala
+++ b/server/src/main/scala/org/apache/livy/utils/LineBufferedStream.scala
@@ -18,6 +18,7 @@
 package org.apache.livy.utils
 
 import java.io.InputStream
+import java.util
 import java.util.concurrent.locks.ReentrantLock
 
 import scala.io.Source
@@ -26,9 +27,16 @@ import com.google.common.collect.EvictingQueue
 
 import org.apache.livy.Logging
 
+class CircularQueue[T](var capacity: Int) extends util.LinkedList[T] {
+  override def add(t: T): Boolean = {
+    if (size >= capacity) removeFirst
+    super.add(t)
+  }
+}
+
 class LineBufferedStream(inputStream: InputStream, logSize: Int) extends Logging {
 
-  private[this] val _lines: EvictingQueue[String] = EvictingQueue.create[String](logSize)
+  private[this] val _lines: CircularQueue[String] = new CircularQueue[String](logSize)
 
   private[this] val _lock = new ReentrantLock()
   private[this] val _condition = _lock.newCondition()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Guava was unused any more, and it's too heavy to include, so remove the guava dependency.  

## How was this patch tested?

Existing unit tests.


