### PR TITLE
[LIVY-571] cleanupStatement should not throw exception when statementId not exist

### DIFF
--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyExecuteStatementOperation.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyExecuteStatementOperation.scala
@@ -177,7 +177,7 @@ class LivyExecuteStatementOperation(
       val cleaned = rpcClient.cleanupStatement(sessionHandle, statementId).get()
       if (!cleaned) {
         warn(s"Fail to cleanup query $statementId (session = ${sessionHandle.getSessionId}), " +
-          s"can be ignored if query is failed")
+          s"this message can be ignored if the query failed.")
       }
     }
     setState(state)

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyExecuteStatementOperation.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyExecuteStatementOperation.scala
@@ -174,7 +174,11 @@ class LivyExecuteStatementOperation(
 
   private def cleanup(state: OperationState) {
     if (statementId != null && rpcClientValid) {
-      rpcClient.cleanupStatement(sessionHandle, statementId).get()
+      val cleaned = rpcClient.cleanupStatement(sessionHandle, statementId).get()
+      if (!cleaned) {
+        warn(s"Fail to cleanup query $statementId (session = ${sessionHandle.getSessionId}), " +
+          s"can be ignored if query is failed")
+      }
     }
     setState(state)
   }

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyExecuteStatementOperation.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyExecuteStatementOperation.scala
@@ -177,7 +177,7 @@ class LivyExecuteStatementOperation(
       val cleaned = rpcClient.cleanupStatement(sessionHandle, statementId).get()
       if (!cleaned) {
         warn(s"Fail to cleanup query $statementId (session = ${sessionHandle.getSessionId}), " +
-          s"this message can be ignored if the query failed.")
+          "this message can be ignored if the query failed.")
       }
     }
     setState(state)

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/rpc/RpcClient.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/rpc/RpcClient.scala
@@ -76,7 +76,7 @@ class RpcClient(livySession: InteractiveSession) extends Logging {
   def cleanupStatement(
       sessionHandle: SessionHandle,
       statementId: String,
-      cancelJob: Boolean = false): JobHandle[_] = {
+      cancelJob: Boolean = false): JobHandle[java.lang.Boolean] = {
     info(s"Cleaning up remote session for statementId = $statementId")
     require(null != statementId, s"Invalid statementId specified. statementId = $statementId")
     livySession.recordActivity()

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
@@ -151,7 +151,7 @@ class BinaryThriftServerSuite extends ThriftServerBaseTest with CommonThriftTest
   }
 
   test("LIVY-571: returns a meaningful exception when global_temp table doesn't exist") {
-    withJdbcConnection(jdbcUri("default")) { c =>
+    withJdbcConnection { c =>
       val caught = intercept[SQLException] {
         val statement = c.createStatement()
         try {

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
@@ -134,6 +134,29 @@ class BinaryThriftServerSuite extends ThriftServerBaseTest with CommonThriftTest
       statement.close()
     }
   }
+
+  test("invalid sql") {
+    assume(hiveSupportEnabled(formattedSparkVersion._1, livyConf))
+    withJdbcConnection(jdbcUri("default")) { c =>
+      var exceptionThrew = false
+
+      val statement = c.createStatement()
+      try {
+        try {
+          statement.executeQuery("use invalid_database")
+        } finally {
+          statement.close()
+        }
+      } catch {
+        case t: Throwable => {
+          exceptionThrew = true
+          assert(t.getMessage.contains("Database 'invalid_database' not found"))
+        }
+      }
+
+      assert(exceptionThrew)
+    }
+  }
 }
 
 class HttpThriftServerSuite extends ThriftServerBaseTest with CommonThriftTests {

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
@@ -151,7 +151,6 @@ class BinaryThriftServerSuite extends ThriftServerBaseTest with CommonThriftTest
   }
 
   test("LIVY-571: returns a meaningful exception when global_temp table doesn't exist") {
-    assume(hiveSupportEnabled(formattedSparkVersion._1, livyConf))
     withJdbcConnection(jdbcUri("default")) { c =>
       val caught = intercept[SQLException] {
         val statement = c.createStatement()

--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/CleanupStatementJob.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/CleanupStatementJob.java
@@ -23,7 +23,7 @@ import org.apache.livy.JobContext;
 /**
  * Job used to clean up state held for a statement.
  */
-public class CleanupStatementJob implements Job<Void> {
+public class CleanupStatementJob implements Job<Boolean> {
 
   private final String sessionId;
   private final String statementId;
@@ -38,10 +38,9 @@ public class CleanupStatementJob implements Job<Void> {
   }
 
   @Override
-  public Void call(JobContext ctx) {
+  public Boolean call(JobContext ctx) {
     ThriftSessionState session = ThriftSessionState.get(ctx, sessionId);
-    session.cleanupStatement(statementId);
-    return null;
+    return session.cleanupStatement(statementId);
   }
 
 }

--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ThriftSessionState.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ThriftSessionState.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ConcurrentMap;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.StructType;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ThriftSessionState.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ThriftSessionState.java
@@ -26,9 +26,10 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.StructType;
 
-import org.apache.livy.JobContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import org.apache.livy.JobContext;
 
 /**
  * State related to one Thrift session. One instance of this class is stored in the session's

--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ThriftSessionState.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ThriftSessionState.java
@@ -25,8 +25,6 @@ import java.util.concurrent.ConcurrentMap;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.StructType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.apache.livy.JobContext;
 
@@ -35,8 +33,6 @@ import org.apache.livy.JobContext;
  * shared object map for each Thrift session that connects to the backing Livy session.
  */
 class ThriftSessionState {
-
-  private static final Logger LOG = LoggerFactory.getLogger(ThriftSessionState.class);
 
   private static String SESSION_STATE_KEY_PREFIX = "livy.sessionState.";
   private static Object CREATE_LOCK = new Object();
@@ -105,12 +101,13 @@ class ThriftSessionState {
     return st;
   }
 
-  void cleanupStatement(String statementId) {
+  boolean cleanupStatement(String statementId) {
     checkNotNull(statementId, "No statement ID.");
     if (statements.remove(statementId) == null) {
-      LOG.warn("Statement {} not found in session {}",statementId, sessionId);
+      return false;
     } else {
       ctx.sc().cancelJobGroup(statementId);
+      return true;
     }
   }
 

--- a/thriftserver/session/src/test/java/org/apache/livy/thriftserver/session/ThriftSessionTest.java
+++ b/thriftserver/session/src/test/java/org/apache/livy/thriftserver/session/ThriftSessionTest.java
@@ -83,12 +83,12 @@ public class ThriftSessionTest {
     // Start a second session. Try to cleanup a statement that belongs to another session.
     String s2 = nextSession();
     waitFor(new RegisterSessionJob(s2));
-    expectError(new CleanupStatementJob(s2, st1), "not found in session");
+    waitFor(new CleanupStatementJob(s2, st1));
     waitFor(new UnregisterSessionJob(s2));
 
     // Clean up the statement's state.
     waitFor(new CleanupStatementJob(s1, st1));
-    expectError(new CleanupStatementJob(s1, st1), "not found in session");
+    waitFor(new CleanupStatementJob(s1, st1));
 
     // Insert data into the previously created table, and fetch results from it.
     String st2 = nextStatement();

--- a/thriftserver/session/src/test/java/org/apache/livy/thriftserver/session/ThriftSessionTest.java
+++ b/thriftserver/session/src/test/java/org/apache/livy/thriftserver/session/ThriftSessionTest.java
@@ -83,17 +83,17 @@ public class ThriftSessionTest {
     // Start a second session. Try to cleanup a statement that belongs to another session.
     String s2 = nextSession();
     waitFor(new RegisterSessionJob(s2));
-    waitFor(new CleanupStatementJob(s2, st1));
+    assertFalse(waitFor(new CleanupStatementJob(s2, st1)));
     waitFor(new UnregisterSessionJob(s2));
 
     // Clean up the statement's state.
-    waitFor(new CleanupStatementJob(s1, st1));
-    waitFor(new CleanupStatementJob(s1, st1));
+    assertTrue(waitFor(new CleanupStatementJob(s1, st1)));
+    assertFalse(waitFor(new CleanupStatementJob(s1, st1)));
 
     // Insert data into the previously created table, and fetch results from it.
     String st2 = nextStatement();
     waitFor(newSqlJob(s1, st2, "INSERT INTO test VALUES (1, \"one\"), (2, \"two\")"));
-    waitFor(new CleanupStatementJob(s1, st2));
+    assertTrue(waitFor(new CleanupStatementJob(s1, st2)));
 
     String st3 = nextStatement();
     waitFor(newSqlJob(s1, st3, "SELECT * FROM test"));
@@ -111,7 +111,7 @@ public class ThriftSessionTest {
     assertEquals(Integer.valueOf(2), cols[0].get(1));
     assertEquals("two", cols[1].get(1));
 
-    waitFor(new CleanupStatementJob(s1, st3));
+    assertTrue(waitFor(new CleanupStatementJob(s1, st3)));
 
     // Run a statement that returns a null, to make sure the receiving side sees it correctly.
     String st4 = nextStatement();
@@ -123,7 +123,7 @@ public class ThriftSessionTest {
     assertEquals(1, cols[0].size());
     assertTrue(cols[0].getNulls().get(0));
 
-    waitFor(new CleanupStatementJob(s1, st4));
+    assertTrue(waitFor(new CleanupStatementJob(s1, st4)));
 
     // Tear down the session.
     waitFor(new UnregisterSessionJob(s1));


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ThriftSessionState` is used to store query result by statementId. When an exception is thrown during execute query, no query result is stored. But when a statement is closed from beeline, a request is invoked to remove cached query result in `ThriftSessionState`.

Remove statement query result from `ThriftSessionState` currently throws an exception, hiding the original query failure exception and message. The PR makes it return cleanly, so the proper exception is reported to the end user.

## How was this patch tested?

Added unit tests.
