### PR TITLE
[LIVY-609] LDAP auth for Livy thriftserver

### DIFF
--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -167,7 +167,12 @@ object LivyConf {
     Entry("livy.server.thrift.delegation.token.max-lifetime", "7d")
   val THRIFT_DELEGATION_TOKEN_RENEW_INTERVAL =
     Entry("livy.server.thrift.delegation.token.renew-interval", "1d")
-
+  // LDAP authentication
+  val THRIFT_LDAP_AUTHENTICATION_URL = Entry("livy.server.thrift.ldap.authentication.url", null)
+  val THRIFT_LDAP_AUTHENTICATION_BASEDN =
+    Entry("livy.server.thrift.ldap.authentication.basedn", null)
+  val THRIFT_LDAP_AUTHENTICATION_DOMAIN =
+    Entry("livy.server.thrift.ldap.authentication.domain", null)
   /**
    * Recovery mode of Livy. Possible values:
    * off: Default. Turn off recovery. Every time Livy shuts down, it stops and forgets all sessions.

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/auth/AuthFactory.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/auth/AuthFactory.scala
@@ -77,8 +77,9 @@ class AuthFactory(val conf: LivyConf) extends Logging {
   def getAuthTransFactory: TTransportFactory = {
     val isAuthKerberos = authTypeStr.equalsIgnoreCase(AuthTypes.KERBEROS.getAuthName)
     val isAuthNoSASL = authTypeStr.equalsIgnoreCase(AuthTypes.NOSASL.getAuthName)
-    // TODO: add LDAP and PAM when supported
-    val isAuthOther = authTypeStr.equalsIgnoreCase(AuthTypes.NONE.getAuthName) ||
+    // TODO: add PAM when supported
+    val isAuthOther = authTypeStr.equalsIgnoreCase(AuthTypes.LDAP.getAuthName) ||
+      authTypeStr.equalsIgnoreCase(AuthTypes.NONE.getAuthName) ||
       authTypeStr.equalsIgnoreCase(AuthTypes.CUSTOM.getAuthName)
 
     saslServer.map { server =>

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/auth/AuthenticationProvider.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/auth/AuthenticationProvider.scala
@@ -20,7 +20,6 @@ package org.apache.livy.thriftserver.auth
 import java.lang.reflect.InvocationTargetException
 import java.security.MessageDigest
 import java.util.Hashtable
-
 import javax.naming.{Context, NamingException}
 import javax.naming.directory.InitialDirContext
 import javax.security.sasl.AuthenticationException
@@ -92,8 +91,8 @@ class LdapAuthenticationProvider(conf: LivyConf) extends PasswdAuthenticationPro
         s"user or password, it is null")
     }
     var bindDn = "uid=" + user + "," + ldapBaseDN;
-    if(ldapDomain != null) {
-      bindDn = "uid=" + user + "@" + ldapDomain+ "," + ldapBaseDN;
+    if (ldapDomain != null) {
+      bindDn = "uid=" + user + "@" + ldapDomain + "," + ldapBaseDN;
     }
     val env = new Hashtable[String, Any]()
     env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory")
@@ -106,7 +105,8 @@ class LdapAuthenticationProvider(conf: LivyConf) extends PasswdAuthenticationPro
       ctx.close()
     } catch {
       case e: NamingException =>
-        throw new AuthenticationException(s"Error validating LDAP user: $bindDn, password: $password", e)
+        throw new AuthenticationException(s"Error validating " +
+          s"LDAP user: $bindDn, password: $password", e)
     }
   }
 }

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftHttpServlet.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftHttpServlet.scala
@@ -264,7 +264,7 @@ class ThriftHttpServlet(
 
 
   /**
-   * Do the authentication (LDAP/PAM not yet supported)
+   * Do the authentication (PAM not yet supported)
    */
   private def doPasswdAuth(request: HttpServletRequest, authType: String): String = {
     val userName = getUsername(request, authType)


### PR DESCRIPTION
## What changes were proposed in this pull request?

To fix LIVY-609, add LDAP auth for Livy thriftserver, it's a extension for AuthenticationProvider.
https://issues.apache.org/jira/browse/LIVY-609

## How was this patch tested?
Tested manually 