### PR TITLE
LIVY-612 Add Sessions Connect Documentation

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -242,6 +242,18 @@ Gets the log lines from this session.
   </tr>
 </table>
 
+### POST /sessions/{sessionId}/connect
+
+Connects to an existing session and updates its last activity time. This stops Livy from expiring a session due to inactivity.
+
+#### Request Parameters
+
+No Request Parameters
+
+#### Response Body
+
+The response body is the same as for `GET /sessions/{sessionId}`.
+
 ### GET /sessions/{sessionId}/statements
 
 Returns all the statements in a session.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Documentation was missing for the Sessions Connect REST end point.
This came up as a work around for https://issues.apache.org/jira/browse/LIVY-547 in the discussion on https://github.com/apache/incubator-livy/pull/138.  It would be good to document it.

https://issues.apache.org/jira/browse/LIVY-612

## How was this patch tested?

Not Tested.
