### PR TITLE
[LIVY-613][REPL] Livy can't handle the java.sql.Date type correctly.

### DIFF
--- a/repl/src/main/scala/org/apache/livy/repl/SQLInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/SQLInterpreter.scala
@@ -26,13 +26,13 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.SparkSession
 import org.json4s._
+import org.json4s.JsonAST.{JNull, JString}
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
 
 import org.apache.livy.Logging
 import org.apache.livy.rsc.RSCConf
 import org.apache.livy.rsc.driver.SparkEntries
-import org.json4s.JsonAST.{JNull, JString}
 
 /**
  * A SQL interpreter which only accepts SQL query, execute the query and return the result. The

--- a/repl/src/main/scala/org/apache/livy/repl/SQLInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/SQLInterpreter.scala
@@ -18,6 +18,7 @@
 package org.apache.livy.repl
 
 import java.lang.reflect.InvocationTargetException
+import java.sql.Date
 
 import scala.util.control.NonFatal
 
@@ -31,6 +32,7 @@ import org.json4s.jackson.JsonMethods._
 import org.apache.livy.Logging
 import org.apache.livy.rsc.RSCConf
 import org.apache.livy.rsc.driver.SparkEntries
+import org.json4s.JsonAST.{JNull, JString}
 
 /**
  * A SQL interpreter which only accepts SQL query, execute the query and return the result. The
@@ -66,7 +68,14 @@ class SQLInterpreter(
     rscConf: RSCConf,
     sparkEntries: SparkEntries) extends Interpreter with Logging {
 
-  private implicit def formats = DefaultFormats
+  case object DateSerializer extends CustomSerializer[Date](_ => ( {
+    case JString(s) => Date.valueOf(s)
+    case JNull => null
+  }, {
+    case d: Date => JString(d.toString)
+  }))
+
+  private implicit def formats: Formats = DefaultFormats + DateSerializer
 
   private var spark: SparkSession = null
 

--- a/repl/src/test/scala/org/apache/livy/repl/SQLInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/SQLInterpreterSpec.scala
@@ -47,7 +47,9 @@ class SQLInterpreterSpec extends BaseInterpreterSpec {
   }
 
   it should "handle java.sql.Date tpye" in withInterpreter { interpreter =>
-    val personList = Seq(Person("Jerry", Date.valueOf("2019-07-24")), Person("Michael", Date.valueOf("2019-07-23")))
+    val personList = Seq(Person("Jerry", Date.valueOf("2019-07-24")),
+      Person("Michael", Date.valueOf("2019-07-23")))
+
     val rdd = sparkEntries.sc().parallelize(personList)
     val df = sparkEntries.sqlctx().createDataFrame(rdd)
     df.registerTempTable("person")


### PR DESCRIPTION
## What changes were proposed in this pull request?

When Spark table has `java.sql.Date` type column, Livy can't handle the `java.sql.Date` type correctly. e.g
```
create table test(
    name string,
    birthday date
);

insert into test values ('Livy', '2019-07-24')

curl -H "Content-Type:application/json" -X POST -d '{"code":"select * from test", "kind":"sql"}' 192.168.1.6:8998/sessions/48/statements
{"id":1,"code":"select * from test","state":"waiting","output":null,"progress":0.0}

curl 192.168.1.6:8998/sessions/48/statements/1
{"id":1,"code":"select * from test","state":"available","output":{"status":"ok","execution_count":1,"data":{"application/json":{"schema":{"type":"struct","fields":[{"name":"name","type":"string","nullable":true,"metadata":{}},{"name":"birthday","type":"date","nullable":true,"metadata":{}}]},"data":[["Livy",{}]]}}},"progress":1.0}
```
as you can see, the output of `select * from test` is `["Livy",{}]` , birthday column's value isn't handle  correctly.

The reason is that json4s can't handle `java.sql.Date`, so we should define the `CustomSerializer` for `java.sql.Date`.

This PR  add a `DateSerializer` to support `java.sql.Date` parser.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
