### PR TITLE
 LIVY-617: Livy session leak on Yarn when creating session duplicated names

### DIFF
--- a/server/src/test/scala/org/apache/livy/sessions/MockSession.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/MockSession.scala
@@ -27,7 +27,7 @@ class MockSession(id: Int, owner: String, conf: LivyConf, name: Option[String] =
 
   override def start(): Unit = ()
 
-  var stopped = false 
+  var stopped = false
   override protected def stopSession(): Unit = {stopped = true}
 
   override def logLines(): IndexedSeq[String] = IndexedSeq()

--- a/server/src/test/scala/org/apache/livy/sessions/MockSession.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/MockSession.scala
@@ -28,7 +28,9 @@ class MockSession(id: Int, owner: String, conf: LivyConf, name: Option[String] =
   override def start(): Unit = ()
 
   var stopped = false
-  override protected def stopSession(): Unit = {stopped = true}
+  override protected def stopSession(): Unit = {
+    stopped = true
+  }
 
   override def logLines(): IndexedSeq[String] = IndexedSeq()
 

--- a/server/src/test/scala/org/apache/livy/sessions/MockSession.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/MockSession.scala
@@ -27,7 +27,8 @@ class MockSession(id: Int, owner: String, conf: LivyConf, name: Option[String] =
 
   override def start(): Unit = ()
 
-  override protected def stopSession(): Unit = ()
+  var stopped = false 
+  override protected def stopSession(): Unit = {stopped = true}
 
   override def logLines(): IndexedSeq[String] = IndexedSeq()
 

--- a/server/src/test/scala/org/apache/livy/sessions/SessionManagerSpec.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/SessionManagerSpec.scala
@@ -76,6 +76,8 @@ class SessionManagerSpec extends FunSpec with Matchers with LivyBaseUnitTestSuit
       an[IllegalArgumentException] should be thrownBy manager.register(session2)
       manager.get(session1.id).isDefined should be(true)
       manager.get(session2.id).isDefined should be(false)
+      assert(!session1.stopped)
+      assert(session2.stopped)
       manager.shutdown()
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
When creating a session with duplicated name, instead of throw exception in SessionManager.register() method, we should stop the session. Otherwise the session driver process will keep running and end up creating a leaked Yarn application.

https://issues.apache.org/jira/browse/LIVY-617

## How was this patch tested?

This is just a simple fix and verified with manual end to end test.
