### PR TITLE
[LIVY-547][SERVER] Livy kills session after livy.server.session.timeout even if the session is active

### DIFF
--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -50,8 +50,12 @@
 
 # Enabled to check whether timeout Livy sessions should be stopped.
 # livy.server.session.timeout-check = true
+#
+# Whether or not to skip timeout check for a busy session
+# livy.server.session.timeout-check.skip-busy = false
 
-# Time in milliseconds on how long Livy will wait before timing out an idle session.
+# Time in milliseconds on how long Livy will wait before timing out an inactive session.
+# Note that the inactive session could be busy running jobs.
 # livy.server.session.timeout = 1h
 #
 # How long a finished session state should be kept in LivyServer for query.

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -216,6 +216,9 @@ object LivyConf {
   // Whether session timeout should be checked, by default it will be checked, which means inactive
   // session will be stopped after "livy.server.session.timeout"
   val SESSION_TIMEOUT_CHECK = Entry("livy.server.session.timeout-check", true)
+  // Whether session timeout check should skip busy sessions, if set to true, then busy sessions
+  // that have jobs running will never timeout.
+  val SESSION_TIMEOUT_CHECK_SKIP_BUSY = Entry("livy.server.session.timeout-check.skip-busy", false)
   // How long will an inactive session be gc-ed.
   val SESSION_TIMEOUT = Entry("livy.server.session.timeout", "1h")
   // How long a finished session state will be kept in memory

--- a/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
@@ -77,6 +77,8 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
 
 
   private[this] final val sessionTimeoutCheck = livyConf.getBoolean(LivyConf.SESSION_TIMEOUT_CHECK)
+  private[this] final val sessionTimeoutCheckSkipBusy =
+    livyConf.getBoolean(LivyConf.SESSION_TIMEOUT_CHECK_SKIP_BUSY)
   private[this] final val sessionTimeout =
     TimeUnit.MILLISECONDS.toNanos(livyConf.getTimeAsMs(LivyConf.SESSION_TIMEOUT))
   private[this] final val sessionStateRetainedInSec =
@@ -152,6 +154,8 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
           currentTime - s.time > sessionStateRetainedInSec
         case _ =>
           if (!sessionTimeoutCheck) {
+            false
+          } else if (session.state == SessionState.Busy && sessionTimeoutCheckSkipBusy) {
             false
           } else if (session.isInstanceOf[BatchSession]) {
             false

--- a/server/src/test/scala/org/apache/livy/sessions/MockSession.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/MockSession.scala
@@ -31,7 +31,8 @@ class MockSession(id: Int, owner: String, conf: LivyConf, name: Option[String] =
 
   override def logLines(): IndexedSeq[String] = IndexedSeq()
 
-  override def state: SessionState = SessionState.Idle
+  var serverState: SessionState = SessionState.Idle
+  override def state: SessionState = { serverState }
 
   override def recoveryMetadata: RecoveryMetadata = RecoveryMetadata(0)
 }

--- a/server/src/test/scala/org/apache/livy/sessions/MockSession.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/MockSession.scala
@@ -32,7 +32,7 @@ class MockSession(id: Int, owner: String, conf: LivyConf, name: Option[String] =
   override def logLines(): IndexedSeq[String] = IndexedSeq()
 
   var serverState: SessionState = SessionState.Idle
-  override def state: SessionState = { serverState }
+  override def state: SessionState = serverState
 
   override def recoveryMetadata: RecoveryMetadata = RecoveryMetadata(0)
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a new configuration:
  livy.server.session.timeout-check.skip-busy
To indicate whether or not to skip timeout check for a busy session. It defaults to false for 
backward compatibility.

https://issues.apache.org/jira/browse/LIVY-547

## How was this patch tested?

Manually tested the configuration.