### PR TITLE
[LIVY-620] Spark batch session always ends with success when configuration is master yarn and deploy-mode client

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
@@ -101,6 +101,7 @@ object BatchSession extends Logging {
             case 0 =>
             case exitCode =>
               warn(s"spark-submit exited with code $exitCode")
+              s.stateChanged(SparkApp.State.KILLED)
           }
         } finally {
           childProcesses.decrementAndGet()
@@ -182,6 +183,14 @@ class BatchSession(
   override def stateChanged(oldState: SparkApp.State, newState: SparkApp.State): Unit = {
     synchronized {
       debug(s"$this state changed from $oldState to $newState")
+      if (_state != SessionState.Dead()) {
+        stateChanged(newState)
+      }
+    }
+  }
+
+  private def stateChanged(newState: SparkApp.State): Unit = {
+    synchronized {
       newState match {
         case SparkApp.State.RUNNING =>
           _state = SessionState.Running

--- a/server/src/test/scala/org/apache/livy/server/batch/BatchSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/BatchSessionSpec.scala
@@ -119,7 +119,7 @@ class BatchSessionSpec
       batch.appInfo shouldEqual expectedAppInfo
     }
 
-    it("should die with state killed when process exits with no 0 return code") {
+    it("should end with status dead when batch session exits with no 0 return code") {
       val req = new CreateBatchRequest()
       req.file = runForeverScript.toString
       req.conf = Map("spark.driver.extraClassPath" -> sys.props("java.class.path"))
@@ -133,7 +133,7 @@ class BatchSessionSpec
 
       Utils.waitUntil({ () => !batch.state.isActive }, Duration(10, TimeUnit.SECONDS))
       (batch.state match {
-        case SessionState.Killed(_) => true
+        case SessionState.Dead(_) => true
         case _ => false
       }) should be (true)
     }

--- a/server/src/test/scala/org/apache/livy/server/batch/BatchSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/BatchSessionSpec.scala
@@ -33,7 +33,7 @@ import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf, Utils}
 import org.apache.livy.server.AccessManager
 import org.apache.livy.server.recovery.SessionStore
 import org.apache.livy.sessions.SessionState
-import org.apache.livy.utils.{AppInfo, SparkApp}
+import org.apache.livy.utils.{AppInfo, Clock, SparkApp}
 
 class BatchSessionSpec
   extends FunSpec
@@ -49,6 +49,23 @@ class BatchSessionSpec
       writer.write(
         """
           |print "hello world"
+        """.stripMargin)
+    } finally {
+      writer.close()
+    }
+    script
+  }
+
+  val runForeverScript: Path = {
+    val script = Files.createTempFile("livy-test-run-forever-script", ".py")
+    script.toFile.deleteOnExit()
+    val writer = new FileWriter(script.toFile)
+    try {
+      writer.write(
+        """
+          |import time
+          |while True:
+          | time.sleep(1)
         """.stripMargin)
     } finally {
       writer.close()
@@ -100,6 +117,25 @@ class BatchSessionSpec
       val expectedAppInfo = AppInfo(Some("DRIVER LOG URL"), Some("SPARK UI URL"))
       batch.infoChanged(expectedAppInfo)
       batch.appInfo shouldEqual expectedAppInfo
+    }
+
+    it("should die with state killed when process exits with no 0 return code") {
+      val req = new CreateBatchRequest()
+      req.file = runForeverScript.toString
+      req.conf = Map("spark.driver.extraClassPath" -> sys.props("java.class.path"))
+
+      val conf = new LivyConf().set(LivyConf.LOCAL_FS_WHITELIST, sys.props("java.io.tmpdir"))
+      val accessManager = new AccessManager(conf)
+      val batch = BatchSession.create(0, None, req, conf, accessManager, null, None, sessionStore)
+      batch.start()
+      Clock.sleep(2)
+      batch.stopSession()
+
+      Utils.waitUntil({ () => !batch.state.isActive }, Duration(10, TimeUnit.SECONDS))
+      (batch.state match {
+        case SessionState.Killed(_) => true
+        case _ => false
+      }) should be (true)
     }
 
     def testRecoverSession(name: Option[String]): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Batch session should end with state dead when process exits with no 0 return code.
https://issues.apache.org/jira/browse/LIVY-620

## How was this patch tested?

1. Unit Test (included in this PR)
Submit batch session that runs forever, wait 2 seconds, kill that batch session and expect for state dead.

2. Also currently used in production environment.
