### PR TITLE
[LIVY-634] To support reuse hive PasswdAuthenticationProvider implementation in ThriftServer

### DIFF
--- a/thriftserver/server/pom.xml
+++ b/thriftserver/server/pom.xml
@@ -69,6 +69,10 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/thriftserver/server/pom.xml
+++ b/thriftserver/server/pom.xml
@@ -56,6 +56,21 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-common</artifactId>
+      <version>${hive.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.livy</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently Livy share same PasswdAuthenticationProvider interface with HiveServer2, but not able to reuse PasswdAuthenticationProvider implementation like LdapAuthenticationProviderImpl and PamAuthenticationProviderImpl. 

We can extend livy CustomAuthenticationProvider to support hive PasswdAuthenticationProvider  implementation. For example, to use LdapAuthenticationProviderImpl  we can add such configuration in livy.conf:
livy.server.thrift.authentication = CUSTOM
livy.server.thrift.custom.authentication.class = org.apache.hive.service.auth.LdapAuthenticationProviderImpl
livy.server.thrift.authentication.custom.hive.server2.authentication.ldap.url = xxxx
livy.server.thrift.authentication.custom.hive.server2.authentication.ldap.Domain = xxxx

https://issues.apache.org/jira/browse/LIVY-634

## How was this patch tested?

Tested manually.
