### PR TITLE
[LIVY-606][LIVY-152] fix the invalid conf of pyspark.archives and sparkr.package

### DIFF
--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -79,14 +79,6 @@
 # during session creation.
 # livy.repl.jars =
 
-# Location of PySpark archives. By default Livy will upload the file from SPARK_HOME, but
-# by caching the file in HDFS, startup time of PySpark sessions on YARN can be reduced.
-# livy.pyspark.archives =
-
-# Location of the SparkR package. By default Livy will upload the file from SPARK_HOME, but
-# by caching the file in HDFS, startup time of R sessions on YARN can be reduced.
-# livy.sparkr.package =
-
 # List of local directories from where files are allowed to be added to user sessions. By
 # default it's empty, meaning users can only reference remote URIs when starting their
 # sessions.

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -183,7 +183,7 @@ object InteractiveSession extends Logging {
     }
 
     def findSparkRArchive(): Option[String] = {
-      Option(livyConf.get(RSCConf.Entry.SPARKR_PACKAGE.key())).orElse {
+      builderProperties.get(RSCConf.Entry.SPARKR_PACKAGE.key()).orElse {
         sys.env.get("SPARK_HOME").flatMap { case sparkHome =>
           val path = Seq(sparkHome, "R", "lib", "sparkr.zip").mkString(File.separator)
           val rArchivesFile = new File(path)
@@ -247,7 +247,7 @@ object InteractiveSession extends Logging {
     }
 
     def findPySparkArchives(): Seq[String] = {
-      Option(livyConf.get(RSCConf.Entry.PYSPARK_ARCHIVES))
+      builderProperties.get(RSCConf.Entry.PYSPARK_ARCHIVES.key())
         .map(_.split(",").toSeq)
         .getOrElse {
           sys.env.get("SPARK_HOME") .map { case sparkHome =>


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Remove livy.pyspark.archives and livy.sparkr.package in livy.conf, which can be set in livy-client.conf.  

2. Replace "livyConf.get(RSCConf.Entry.PYSPARK_ARCHIVES)" with "builderProperties.get(RSCConf.Entry.PYSPARK_ARCHIVES.key())", because livyConf store the config of livy.conf which doesn't have  PYSPARK_ARCHIVES, and builderProperties has PYSPARK_ARCHIVES of livy-client.conf. The sames to SPARKR_PACKAGE.



## How was this patch tested?

Config the livy.rsc.sparkr.package by hdfs path, then livy will not upload zip from local to hdfs every time a session is started.

