### PR TITLE
[LIVY-574][TESTS][THRIFT] Add tests for metadata operations

### DIFF
--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftCLIService.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftCLIService.scala
@@ -397,7 +397,7 @@ abstract class ThriftCLIService(val cliService: LivyCLIService, val serviceName:
   override def GetTypeInfo(req: TGetTypeInfoReq): TGetTypeInfoResp = {
     val resp = new TGetTypeInfoResp
     try {
-      val operationHandle = cliService.getTypeInfo(new SessionHandle(req.getSessionHandle))
+      val operationHandle = cliService.getTypeInfo(createSessionHandle(req.getSessionHandle))
       resp.setOperationHandle(operationHandle.toTOperationHandle)
       resp.setStatus(ThriftCLIService.OK_STATUS)
     } catch {
@@ -412,7 +412,7 @@ abstract class ThriftCLIService(val cliService: LivyCLIService, val serviceName:
   override def GetCatalogs(req: TGetCatalogsReq): TGetCatalogsResp = {
     val resp = new TGetCatalogsResp
     try {
-      val opHandle = cliService.getCatalogs(new SessionHandle(req.getSessionHandle))
+      val opHandle = cliService.getCatalogs(createSessionHandle(req.getSessionHandle))
       resp.setOperationHandle(opHandle.toTOperationHandle)
       resp.setStatus(ThriftCLIService.OK_STATUS)
     } catch {
@@ -463,7 +463,7 @@ abstract class ThriftCLIService(val cliService: LivyCLIService, val serviceName:
   override def GetTableTypes(req: TGetTableTypesReq): TGetTableTypesResp = {
     val resp = new TGetTableTypesResp
     try {
-      val opHandle = cliService.getTableTypes(new SessionHandle(req.getSessionHandle))
+      val opHandle = cliService.getTableTypes(createSessionHandle(req.getSessionHandle))
       resp.setOperationHandle(opHandle.toTOperationHandle)
       resp.setStatus(ThriftCLIService.OK_STATUS)
     } catch {

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/operation/GetCatalogsOperation.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/operation/GetCatalogsOperation.scala
@@ -33,11 +33,11 @@ class GetCatalogsOperation(sessionHandle: SessionHandle)
   @throws(classOf[HiveSQLException])
   override def runInternal(): Unit = {
     setState(OperationState.RUNNING)
-    info("Fetching table type metadata")
+    info("Fetching catalogs metadata")
     try {
       // catalogs are actually not supported in spark, so this is a no-op
       setState(OperationState.FINISHED)
-      info("Fetching table type metadata has been successfully finished")
+      info("Fetching catalogs has been successfully finished")
     } catch {
       case e: Throwable =>
         setState(OperationState.ERROR)

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/operation/GetTypeInfoOperation.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/operation/GetTypeInfoOperation.scala
@@ -44,7 +44,7 @@ class GetTypeInfoOperation(sessionHandle: SessionHandle)
         val data = Array[Any](
           t.name,
           t.sqlType,
-          t.precision.getOrElse(null),
+          t.precision.orNull,
           null, // LITERAL_PREFIX
           null, // LITERAL_SUFFIX
           null, // CREATE_PARAMS
@@ -59,7 +59,7 @@ class GetTypeInfoOperation(sessionHandle: SessionHandle)
           0.toShort, // MAXIMUM_SCALE
           null, // SQL_DATA_TYPE
           null, // SQL_DATETIME_SUB
-          t.numPrecRadix.getOrElse(null))
+          t.numPrecRadix.orNull)
         rowSet.addRow(data)
       }
       setState(OperationState.FINISHED)

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/operation/GetTypeInfoOperation.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/operation/GetTypeInfoOperation.scala
@@ -44,21 +44,22 @@ class GetTypeInfoOperation(sessionHandle: SessionHandle)
         val data = Array[Any](
           t.name,
           t.sqlType,
-          t.precision,
+          t.precision.getOrElse(null),
           null, // LITERAL_PREFIX
           null, // LITERAL_SUFFIX
           null, // CREATE_PARAMS
-          DatabaseMetaData.typeNullable, // All types are nullable
+          DatabaseMetaData.typeNullable.toShort, // All types are nullable
           t.caseSensitive,
+          t.searchable,
           t.unsignedAttribute,
           false, // FIXED_PREC_SCALE
           false, // AUTO_INCREMENT
           null, // LOCAL_TYPE_NAME
-          0, // MINIMUM_SCALE
-          0, // MAXIMUM_SCALE
+          0.toShort, // MINIMUM_SCALE
+          0.toShort, // MAXIMUM_SCALE
           null, // SQL_DATA_TYPE
           null, // SQL_DATETIME_SUB
-          t.numPrecRadix)
+          t.numPrecRadix.getOrElse(null))
         rowSet.addRow(data)
       }
       setState(OperationState.FINISHED)

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/operation/MetadataOperation.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/operation/MetadataOperation.scala
@@ -33,6 +33,10 @@ abstract class MetadataOperation(sessionHandle: SessionHandle, opType: Operation
 
   protected def rowSet: ThriftResultSet
 
+  private var offset = 0
+
+  private lazy val EMPTY_ROW_SET = ThriftResultSet(getResultSetSchema, protocolVersion)
+
   @throws[HiveSQLException]
   override def close(): Unit = {
     setState(OperationState.CLOSED)
@@ -48,8 +52,14 @@ abstract class MetadataOperation(sessionHandle: SessionHandle, opType: Operation
     assertState(Seq(OperationState.FINISHED))
     validateFetchOrientation(orientation)
     if (orientation.equals(FetchOrientation.FETCH_FIRST)) {
-      rowSet.setRowOffset(0)
+      offset = 0
     }
-    rowSet
+
+    if (offset >= rowSet.numRows) {
+      EMPTY_ROW_SET
+    } else {
+      offset += rowSet.numRows
+      rowSet
+    }
   }
 }

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/operation/MetadataOperation.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/operation/MetadataOperation.scala
@@ -33,10 +33,6 @@ abstract class MetadataOperation(sessionHandle: SessionHandle, opType: Operation
 
   protected def rowSet: ThriftResultSet
 
-  private var offset = 0
-
-  private lazy val EMPTY_ROW_SET = ThriftResultSet(getResultSetSchema, protocolVersion)
-
   @throws[HiveSQLException]
   override def close(): Unit = {
     setState(OperationState.CLOSED)
@@ -52,14 +48,8 @@ abstract class MetadataOperation(sessionHandle: SessionHandle, opType: Operation
     assertState(Seq(OperationState.FINISHED))
     validateFetchOrientation(orientation)
     if (orientation.equals(FetchOrientation.FETCH_FIRST)) {
-      offset = 0
+      rowSet.setRowOffset(0)
     }
-
-    if (offset >= rowSet.numRows) {
-      EMPTY_ROW_SET
-    } else {
-      offset += rowSet.numRows
-      rowSet
-    }
+    rowSet.extractSubset(maxRows)
   }
 }

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/operation/MetadataOperation.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/operation/MetadataOperation.scala
@@ -50,6 +50,6 @@ abstract class MetadataOperation(sessionHandle: SessionHandle, opType: Operation
     if (orientation.equals(FetchOrientation.FETCH_FIRST)) {
       rowSet.setRowOffset(0)
     }
-    rowSet.extractSubset(maxRows)
+    rowSet.extractSubset(maxRows.toInt)
   }
 }

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/serde/ThriftResultSet.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/serde/ThriftResultSet.scala
@@ -32,7 +32,7 @@ abstract class ThriftResultSet {
   def addRow(row: Array[Any]): Unit
   def setRowOffset(rowOffset: Long): Unit
   def numRows: Int
-  def extractSubset(fetchRows: Long): ThriftResultSet
+  def extractSubset(maxRows: Int): ThriftResultSet
 }
 
 object ThriftResultSet {
@@ -123,10 +123,11 @@ class ColumnOrientedResultSet(
 
   override def numRows: Int = columns.headOption.map(_.size).getOrElse(0)
 
-  override def extractSubset(fetchRows: Long): ThriftResultSet = {
-    val nRows = Math.min(numRows - rowOffset, fetchRows)
+  override def extractSubset(maxRows: Int): ThriftResultSet = {
+    val nRows = Math.min(numRows, maxRows)
     val result = new ColumnOrientedResultSet(
-      columns.map(_.extractSubset(rowOffset.toInt, (rowOffset + nRows).toInt)))
+      columns.map(_.extractSubset(nRows))
+    )
     rowOffset += nRows
     result
   }

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/serde/ThriftResultSet.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/serde/ThriftResultSet.scala
@@ -125,9 +125,7 @@ class ColumnOrientedResultSet(
 
   override def extractSubset(maxRows: Int): ThriftResultSet = {
     val nRows = Math.min(numRows, maxRows)
-    val result = new ColumnOrientedResultSet(
-      columns.map(_.extractSubset(nRows))
-    )
+    val result = new ColumnOrientedResultSet(columns.map(_.extractSubset(nRows)))
     rowOffset += nRows
     result
   }

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/serde/ThriftResultSet.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/serde/ThriftResultSet.scala
@@ -32,6 +32,7 @@ abstract class ThriftResultSet {
   def addRow(row: Array[Any]): Unit
   def setRowOffset(rowOffset: Long): Unit
   def numRows: Int
+  def extractSubset(fetchRows: Long): ThriftResultSet
 }
 
 object ThriftResultSet {
@@ -121,4 +122,12 @@ class ColumnOrientedResultSet(
   override def setRowOffset(rowOffset: Long): Unit = this.rowOffset = rowOffset
 
   override def numRows: Int = columns.headOption.map(_.size).getOrElse(0)
+
+  override def extractSubset(fetchRows: Long): ThriftResultSet = {
+    val nRows = Math.min(numRows - rowOffset, fetchRows)
+    val result = new ColumnOrientedResultSet(
+      columns.map(_.extractSubset(rowOffset.toInt, (rowOffset + nRows).toInt)))
+    rowOffset += nRows
+    result
+  }
 }

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
@@ -393,7 +393,7 @@ class BinaryThriftServerSuite extends ThriftServerBaseTest with CommonThriftTest
 
   test("get types info test") {
     withJdbcConnection { c =>
-      getTypeInforTest(c)
+      getTypeInfoTest(c)
     }
   }
 }
@@ -453,7 +453,7 @@ class HttpThriftServerSuite extends ThriftServerBaseTest with CommonThriftTests 
 
   test("get types info test") {
     withJdbcConnection { c =>
-      getTypeInforTest(c)
+      getTypeInfoTest(c)
     }
   }
 }

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
@@ -209,7 +209,7 @@ trait CommonThriftTests {
     assert(!tableTypesResultSet.next())
   }
 
-  def getTypeInforTest(connection: Connection): Unit = {
+  def getTypeInfoTest(connection: Connection): Unit = {
     val metadata = connection.getMetaData
     val typeInfoResultSet = metadata.getTypeInfo()
     val expectResults = Array(

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
@@ -213,32 +213,32 @@ trait CommonThriftTests {
     val metadata = connection.getMetaData
     val typeInfoResultSet = metadata.getTypeInfo()
     val expectResults = Array(
-      ("void", Types.NULL, 0, 1, false, 0, true, false, false, "", 0, 0, 0, 0, 0),
-      ("boolean", Types.BOOLEAN, 0, 1, false, 2, true, false, false, "", 0, 0, 0, 0, 0),
-      ("byte", Types.TINYINT, 3, 1, false, 2, false, false, false, "", 0, 0, 0, 0, 10),
-      ("short", Types.SMALLINT, 5, 1, false, 2, false, false, false, "", 0, 0, 0, 0, 10),
-      ("integer", Types.INTEGER, 10, 1, false, 2, false, false, false, "", 0, 0, 0, 0, 10),
-      ("long", Types.BIGINT, 19, 1, false, 2, false, false, false, "", 0, 0, 0, 0, 10),
-      ("float", Types.FLOAT, 7, 1, false, 2, false, false, false, "", 0, 0, 0, 0, 10),
-      ("double", Types.DOUBLE, 15, 1, false, 2, false, false, false, "", 0, 0, 0, 0, 10),
-      ("date", Types.DATE, 0, 1, false, 2, true, false, false, "", 0, 0, 0, 0, 0),
-      ("timestamp", Types.TIMESTAMP, 0, 1, false, 2, true, false, false, "", 0, 0, 0, 0, 0),
-      ("string", Types.VARCHAR, 0, 1, true, 3, true, false, false, "", 0, 0, 0, 0, 0),
-      ("binary", Types.BINARY, 0, 1, false, 2, true, false, false, "", 0, 0, 0, 0, 0),
-      ("decimal", Types.DECIMAL, 38, 1, false, 2, false, false, false, "", 0, 0, 0, 0, 10),
-      ("array", Types.ARRAY, 0, 1, false, 2, true, false, false, "", 0, 0, 0, 0, 0),
-      ("map", Types.OTHER, 0, 1, false, 0, true, false, false, "", 0, 0, 0, 0, 0),
-      ("struct", Types.STRUCT, 0, 1, false, 2, true, false, false, "", 0, 0, 0, 0, 0),
-      ("udt", Types.OTHER, 0, 1, false, 0, true, false, false, "", 0, 0, 0, 0, 0)
+      ("void", Types.NULL, 0, 1, false, 0, true, false, false, null, 0, 0, 0, 0, 0),
+      ("boolean", Types.BOOLEAN, 0, 1, false, 2, true, false, false, null, 0, 0, 0, 0, 0),
+      ("byte", Types.TINYINT, 3, 1, false, 2, false, false, false, null, 0, 0, 0, 0, 10),
+      ("short", Types.SMALLINT, 5, 1, false, 2, false, false, false, null, 0, 0, 0, 0, 10),
+      ("integer", Types.INTEGER, 10, 1, false, 2, false, false, false, null, 0, 0, 0, 0, 10),
+      ("long", Types.BIGINT, 19, 1, false, 2, false, false, false, null, 0, 0, 0, 0, 10),
+      ("float", Types.FLOAT, 7, 1, false, 2, false, false, false, null, 0, 0, 0, 0, 10),
+      ("double", Types.DOUBLE, 15, 1, false, 2, false, false, false, null, 0, 0, 0, 0, 10),
+      ("date", Types.DATE, 0, 1, false, 2, true, false, false, null, 0, 0, 0, 0, 0),
+      ("timestamp", Types.TIMESTAMP, 0, 1, false, 2, true, false, false, null, 0, 0, 0, 0, 0),
+      ("string", Types.VARCHAR, 0, 1, true, 3, true, false, false, null, 0, 0, 0, 0, 0),
+      ("binary", Types.BINARY, 0, 1, false, 2, true, false, false, null, 0, 0, 0, 0, 0),
+      ("decimal", Types.DECIMAL, 38, 1, false, 2, false, false, false, null, 0, 0, 0, 0, 10),
+      ("array", Types.ARRAY, 0, 1, false, 2, true, false, false, null, 0, 0, 0, 0, 0),
+      ("map", Types.OTHER, 0, 1, false, 0, true, false, false, null, 0, 0, 0, 0, 0),
+      ("struct", Types.STRUCT, 0, 1, false, 2, true, false, false, null, 0, 0, 0, 0, 0),
+      ("udt", Types.OTHER, 0, 1, false, 0, true, false, false, null, 0, 0, 0, 0, 0)
     )
     for (expect <- expectResults) {
       typeInfoResultSet.next()
       assert(typeInfoResultSet.getString(1) == expect._1)
       assert(typeInfoResultSet.getInt(2) == expect._2)
       assert(typeInfoResultSet.getInt(3) == expect._3)
-      assert(typeInfoResultSet.getString(4) == "")
-      assert(typeInfoResultSet.getString(5) == "")
-      assert(typeInfoResultSet.getString(6) == "")
+      assert(typeInfoResultSet.getString(4) == null)
+      assert(typeInfoResultSet.getString(5) == null)
+      assert(typeInfoResultSet.getString(6) == null)
       assert(typeInfoResultSet.getShort(7) == expect._4)
       assert(typeInfoResultSet.getBoolean(8) == expect._5)
       assert(typeInfoResultSet.getShort(9) == expect._6)

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
@@ -17,11 +17,7 @@
 
 package org.apache.livy.thriftserver
 
-import java.sql.Connection
-import java.sql.Date
-import java.sql.SQLException
-import java.sql.Statement
-import java.sql.Types
+import java.sql.{Connection, Date, SQLException, Statement, Types}
 
 import org.apache.hive.jdbc.HiveStatement
 
@@ -198,7 +194,7 @@ trait CommonThriftTests {
   def getCatalogTest(connection: Connection): Unit = {
     val metadata = connection.getMetaData
     val catalogResultSet = metadata.getCatalogs()
-    // Spark doesn't support getCatalog. In current implementation, it's a no-op and not return
+    // Spark doesn't support getCatalog. In current implementation, it's a no-op and does not return
     // any data
     assert(!catalogResultSet.next())
   }
@@ -217,32 +213,32 @@ trait CommonThriftTests {
     val metadata = connection.getMetaData
     val typeInfoResultSet = metadata.getTypeInfo()
     val expectResults = Array(
-      ("void", Types.NULL, 0, 1, false, 0, true, false, false, null, 0, 0, 0, 0, 0),
-      ("boolean", Types.BOOLEAN, 0, 1, false, 2, true, false, false, null, 0, 0, 0, 0, 0),
-      ("byte", Types.TINYINT, 3, 1, false, 2, false, false, false, null, 0, 0, 0, 0, 10),
-      ("short", Types.SMALLINT, 5, 1, false, 2, false, false, false, null, 0, 0, 0, 0, 10),
-      ("integer", Types.INTEGER, 10, 1, false, 2, false, false, false, null, 0, 0, 0, 0, 10),
-      ("long", Types.BIGINT, 19, 1, false, 2, false, false, false, null, 0, 0, 0, 0, 10),
-      ("float", Types.FLOAT, 7, 1, false, 2, false, false, false, null, 0, 0, 0, 0, 10),
-      ("double", Types.DOUBLE, 15, 1, false, 2, false, false, false, null, 0, 0, 0, 0, 10),
-      ("date", Types.DATE, 0, 1, false, 2, true, false, false, null, 0, 0, 0, 0, 0),
-      ("timestamp", Types.TIMESTAMP, 0, 1, false, 2, true, false, false, null, 0, 0, 0, 0, 0),
-      ("string", Types.VARCHAR, 0, 1, true, 3, true, false, false, null, 0, 0, 0, 0, 0),
-      ("binary", Types.BINARY, 0, 1, false, 2, true, false, false, null, 0, 0, 0, 0, 0),
-      ("decimal", Types.DECIMAL, 38, 1, false, 2, false, false, false, null, 0, 0, 0, 0, 10),
-      ("array", Types.ARRAY, 0, 1, false, 2, true, false, false, null, 0, 0, 0, 0, 0),
-      ("map", Types.OTHER, 0, 1, false, 0, true, false, false, null, 0, 0, 0, 0, 0),
-      ("struct", Types.STRUCT, 0, 1, false, 2, true, false, false, null, 0, 0, 0, 0, 0),
-      ("udt", Types.OTHER, 0, 1, false, 0, true, false, false, null, 0, 0, 0, 0, 0)
+      ("void", Types.NULL, 0, 1, false, 0, true, false, false, "", 0, 0, 0, 0, 0),
+      ("boolean", Types.BOOLEAN, 0, 1, false, 2, true, false, false, "", 0, 0, 0, 0, 0),
+      ("byte", Types.TINYINT, 3, 1, false, 2, false, false, false, "", 0, 0, 0, 0, 10),
+      ("short", Types.SMALLINT, 5, 1, false, 2, false, false, false, "", 0, 0, 0, 0, 10),
+      ("integer", Types.INTEGER, 10, 1, false, 2, false, false, false, "", 0, 0, 0, 0, 10),
+      ("long", Types.BIGINT, 19, 1, false, 2, false, false, false, "", 0, 0, 0, 0, 10),
+      ("float", Types.FLOAT, 7, 1, false, 2, false, false, false, "", 0, 0, 0, 0, 10),
+      ("double", Types.DOUBLE, 15, 1, false, 2, false, false, false, "", 0, 0, 0, 0, 10),
+      ("date", Types.DATE, 0, 1, false, 2, true, false, false, "", 0, 0, 0, 0, 0),
+      ("timestamp", Types.TIMESTAMP, 0, 1, false, 2, true, false, false, "", 0, 0, 0, 0, 0),
+      ("string", Types.VARCHAR, 0, 1, true, 3, true, false, false, "", 0, 0, 0, 0, 0),
+      ("binary", Types.BINARY, 0, 1, false, 2, true, false, false, "", 0, 0, 0, 0, 0),
+      ("decimal", Types.DECIMAL, 38, 1, false, 2, false, false, false, "", 0, 0, 0, 0, 10),
+      ("array", Types.ARRAY, 0, 1, false, 2, true, false, false, "", 0, 0, 0, 0, 0),
+      ("map", Types.OTHER, 0, 1, false, 0, true, false, false, "", 0, 0, 0, 0, 0),
+      ("struct", Types.STRUCT, 0, 1, false, 2, true, false, false, "", 0, 0, 0, 0, 0),
+      ("udt", Types.OTHER, 0, 1, false, 0, true, false, false, "", 0, 0, 0, 0, 0)
     )
     for (expect <- expectResults) {
       typeInfoResultSet.next()
       assert(typeInfoResultSet.getString(1) == expect._1)
       assert(typeInfoResultSet.getInt(2) == expect._2)
       assert(typeInfoResultSet.getInt(3) == expect._3)
-      assert(typeInfoResultSet.getString(4) == null)
-      assert(typeInfoResultSet.getString(5) == null)
-      assert(typeInfoResultSet.getString(6) == null)
+      assert(typeInfoResultSet.getString(4) == "")
+      assert(typeInfoResultSet.getString(5) == "")
+      assert(typeInfoResultSet.getString(6) == "")
       assert(typeInfoResultSet.getShort(7) == expect._4)
       assert(typeInfoResultSet.getBoolean(8) == expect._5)
       assert(typeInfoResultSet.getShort(9) == expect._6)

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
@@ -190,6 +190,51 @@ trait CommonThriftTests {
       "Livy session has not yet started. Please wait for it to be ready...")
     assert(!logIterator.hasNext)
   }
+
+  def getCatalogTest(connection: Connection): Unit = {
+    val metadata = connection.getMetaData
+    val catalogResultSet = metadata.getCatalogs()
+    assert(!catalogResultSet.next())
+  }
+
+  def getTableTypeTest(connection: Connection): Unit = {
+    val metadata = connection.getMetaData
+    val tableTypesResultSet = metadata.getTableTypes()
+    tableTypesResultSet.next()
+    assert(tableTypesResultSet.getString(1) == "TABLE")
+    tableTypesResultSet.next()
+    assert(tableTypesResultSet.getString(1) == "VIEW")
+    assert(!tableTypesResultSet.next())
+  }
+
+  def getTypeInforTest(connection: Connection): Unit = {
+    val metadata = connection.getMetaData
+    val typeInfoResultSet = metadata.getTypeInfo()
+    typeInfoResultSet.next()
+    assert(typeInfoResultSet.getString(1) == "void")
+    assert(typeInfoResultSet.getInt(2) == 0)
+    assert(typeInfoResultSet.getInt(3) == 0)
+    assert(typeInfoResultSet.getString(4) == null)
+    assert(typeInfoResultSet.getString(5) == null)
+    assert(typeInfoResultSet.getString(6) == null)
+    assert(typeInfoResultSet.getShort(7) == 1)
+    assert(typeInfoResultSet.getBoolean(8) == false)
+    assert(typeInfoResultSet.getShort(9) == 0)
+    assert(typeInfoResultSet.getBoolean(10) == true)
+    assert(typeInfoResultSet.getBoolean(11) == false)
+    assert(typeInfoResultSet.getBoolean(12) == false)
+    assert(typeInfoResultSet.getString(13) == null)
+    assert(typeInfoResultSet.getShort(14) == 0)
+    assert(typeInfoResultSet.getShort(15) == 0)
+    assert(typeInfoResultSet.getInt(16) == 0)
+    assert(typeInfoResultSet.getInt(17) == 0)
+    assert(typeInfoResultSet.getInt(18) == 0)
+    val LEFT_TYPE_NUM = 16
+    for (i <- 1 to LEFT_TYPE_NUM) {
+      assert(typeInfoResultSet.next())
+    }
+    assert(!typeInfoResultSet.next())
+  }
 }
 
 class BinaryThriftServerSuite extends ThriftServerBaseTest with CommonThriftTests {
@@ -314,6 +359,24 @@ class BinaryThriftServerSuite extends ThriftServerBaseTest with CommonThriftTest
       operationLogRetrievalTest(statement)
     }
   }
+
+  test("fetch catalog test") {
+    withJdbcConnection { c =>
+      getCatalogTest(c)
+    }
+  }
+
+  test("get table types test") {
+    withJdbcConnection { c =>
+      getTableTypeTest(c)
+    }
+  }
+
+  test("get types info test") {
+    withJdbcConnection { c =>
+      getTypeInforTest(c)
+    }
+  }
 }
 
 class HttpThriftServerSuite extends ThriftServerBaseTest with CommonThriftTests {
@@ -354,6 +417,24 @@ class HttpThriftServerSuite extends ThriftServerBaseTest with CommonThriftTests 
   test("operation log retrieval test") {
     withJdbcStatement { statement =>
       operationLogRetrievalTest(statement)
+    }
+  }
+
+  test("fetch catalog test") {
+    withJdbcConnection { c =>
+      getCatalogTest(c)
+    }
+  }
+
+  test("get table types test") {
+    withJdbcConnection { c =>
+      getTableTypeTest(c)
+    }
+  }
+
+  test("get types info test") {
+    withJdbcConnection { c =>
+      getTypeInforTest(c)
     }
   }
 }

--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ColumnBuffer.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ColumnBuffer.java
@@ -204,6 +204,12 @@ public class ColumnBuffer {
     return nulls != null ? BitSet.valueOf(nulls) : new BitSet();
   }
 
+  /**
+   * Extract subset data to a new column buffer.
+   * @param start start row number
+   * @param end end row number, which is not included in the subset data
+   * @return
+   */
   public ColumnBuffer extractSubset(int start, int end) {
     ColumnBuffer subset = new ColumnBuffer(type);
     subset.currentSize = end - start;

--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ColumnBuffer.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ColumnBuffer.java
@@ -90,6 +90,42 @@ public class ColumnBuffer {
     }
   }
 
+  private ColumnBuffer(DataType type, byte[] nulls, Object values, int currentSize) {
+    this.type = type;
+    this.nulls = nulls;
+    this.currentSize = currentSize;
+
+    switch (type) {
+      case BOOLEAN:
+        bools = (boolean[]) values;
+        break;
+      case BYTE:
+        bytes = (byte[]) values;
+        break;
+      case SHORT:
+        shorts = (short[]) values;
+        break;
+      case INTEGER:
+        ints = (int[]) values;
+        break;
+      case LONG:
+        longs = (long[]) values;
+        break;
+      case FLOAT:
+        floats = (float[]) values;
+        break;
+      case DOUBLE:
+        doubles = (double[]) values;
+        break;
+      case BINARY:
+        buffers = (byte[][]) values;
+        break;
+      case STRING:
+        strings = (String[]) values;
+        break;
+    }
+  }
+
   public DataType getType() {
     return type;
   }
@@ -206,54 +242,69 @@ public class ColumnBuffer {
 
   /**
    * Extract subset data to a new column buffer.
-   * @param start start row number
-   * @param end end row number, which is not included in the subset data
+   * @param end index of the end row, exclusive
    */
-  public ColumnBuffer extractSubset(int start, int end) {
-    ColumnBuffer subset = new ColumnBuffer(type);
-
-    if (start < 0) {
-      start = 0;
-    }
+  public ColumnBuffer extractSubset(int end) {
     if (end > this.currentSize) {
       end = this.currentSize;
     }
-    if (end <= start) {
-      return subset;
+    if (end < 0) {
+      end = 0;
     }
 
-    subset.currentSize = end - start;
-    subset.ensureCapacity();
+    byte[] subNulls = getNulls().get(0, end).toByteArray();
+    int split = 0;
+    ColumnBuffer subset = null;
     switch (type) {
       case BOOLEAN:
-        System.arraycopy(bools, start, subset.bools, 0, end - start);
+        split = Math.min(bools.length, end);
+        subset = new ColumnBuffer(type, subNulls, Arrays.copyOfRange(bools, 0, split), end);
+        bools = Arrays.copyOfRange(bools, split, bools.length);
         break;
       case BYTE:
-        System.arraycopy(bytes, start, subset.bytes, 0, end - start);
+        split = Math.min(bytes.length, end);
+        subset = new ColumnBuffer(type, subNulls, Arrays.copyOfRange(bytes, 0, split), end);
+        bytes = Arrays.copyOfRange(bytes, split, bytes.length);
         break;
       case SHORT:
-        System.arraycopy(shorts, start, subset.shorts, 0, end - start);
+        split = Math.min(shorts.length, end);
+        subset = new ColumnBuffer(type, subNulls, Arrays.copyOfRange(shorts, 0, split), end);
+        shorts = Arrays.copyOfRange(shorts, split, shorts.length);
         break;
       case INTEGER:
-        System.arraycopy(ints, start, subset.ints, 0, end - start);
+        split = Math.min(ints.length, end);
+        subset = new ColumnBuffer(type, subNulls, Arrays.copyOfRange(ints, 0, split), end);
+        ints = Arrays.copyOfRange(ints, split, ints.length);
         break;
       case LONG:
-        System.arraycopy(longs, start, subset.longs, 0, end - start);
+        split = Math.min(longs.length, end);
+        subset = new ColumnBuffer(type, subNulls, Arrays.copyOfRange(longs, 0, split), end);
+        longs = Arrays.copyOfRange(longs, split, longs.length);
         break;
       case FLOAT:
-        System.arraycopy(floats, start, subset.floats, 0, end - start);
+        split = Math.min(floats.length, end);
+        subset = new ColumnBuffer(type, subNulls, Arrays.copyOfRange(floats, 0, split), end);
+        floats = Arrays.copyOfRange(floats, split, floats.length);
         break;
       case DOUBLE:
-        System.arraycopy(doubles, start, subset.doubles, 0, end - start);
+        split = Math.min(doubles.length, end);
+        subset = new ColumnBuffer(type, subNulls, Arrays.copyOfRange(doubles, 0, split), end);
+        doubles = Arrays.copyOfRange(doubles, split, doubles.length);
         break;
       case BINARY:
-        System.arraycopy(buffers, start, subset.buffers, 0, end - start);
+        split = Math.min(buffers.length, end);
+        subset = new ColumnBuffer(type, subNulls, Arrays.copyOfRange(buffers, 0, split), end);
+        buffers = Arrays.copyOfRange(buffers, split, buffers.length);
         break;
       case STRING:
-        System.arraycopy(strings, start, subset.strings, 0, end - start);
+        split = Math.min(strings.length, end);
+        subset = new ColumnBuffer(type, subNulls, Arrays.copyOfRange(strings, 0, split), end);
+        strings = Arrays.copyOfRange(strings, split, strings.length);
         break;
     }
-    subset.nulls = getNulls().get(start, end).toByteArray();
+    nulls = getNulls().get(end, currentSize).toByteArray();
+    currentSize = currentSize - end;
+
     return subset;
   }
 

--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ColumnBuffer.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ColumnBuffer.java
@@ -208,10 +208,20 @@ public class ColumnBuffer {
    * Extract subset data to a new column buffer.
    * @param start start row number
    * @param end end row number, which is not included in the subset data
-   * @return
    */
   public ColumnBuffer extractSubset(int start, int end) {
     ColumnBuffer subset = new ColumnBuffer(type);
+
+    if (start < 0) {
+      start = 0;
+    }
+    if (end > this.currentSize) {
+      end = this.currentSize;
+    }
+    if (end <= start) {
+      return subset;
+    }
+
     subset.currentSize = end - start;
     subset.ensureCapacity();
     switch (type) {
@@ -243,6 +253,7 @@ public class ColumnBuffer {
         System.arraycopy(strings, start, subset.strings, 0, end - start);
         break;
     }
+    subset.nulls = getNulls().get(start, end).toByteArray();
     return subset;
   }
 

--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ColumnBuffer.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ColumnBuffer.java
@@ -241,7 +241,9 @@ public class ColumnBuffer {
   }
 
   /**
-   * Extract subset data to a new column buffer.
+   * Extract subset data to a new ColumnBuffer. It will remove the extracted data from current
+   * ColumnBuffer.
+   *
    * @param end index of the end row, exclusive
    */
   public ColumnBuffer extractSubset(int end) {

--- a/thriftserver/session/src/test/java/org/apache/livy/thriftserver/session/ColumnBufferTest.java
+++ b/thriftserver/session/src/test/java/org/apache/livy/thriftserver/session/ColumnBufferTest.java
@@ -247,6 +247,31 @@ public class ColumnBufferTest {
       new byte[]{0, 1, 2},
       null});
     testExtractSubsetWithType(DataType.STRING, new Object[]{"a", "b", "c", "d", null});
+
+    // When null bits is less than currentSize
+    ColumnBuffer buffer = new ColumnBuffer(DataType.STRING);
+    buffer.add(null);
+    buffer.add("a");
+    buffer.add("b");
+    ColumnBuffer subset = buffer.extractSubset(2);
+    assertEquals(2, subset.size());
+    assertNull(subset.get(0));
+    assertEquals("a", subset.get(1));
+    assertTrue(subset.getNulls().get(0));
+
+    // When value array length is less than currentSize
+    buffer = new ColumnBuffer(DataType.STRING);
+    for (int i = 0; i < 110; i++) {
+      buffer.add(null);
+    }
+    subset = buffer.extractSubset(110);
+    BitSet nullBits = subset.getNulls();
+    assertEquals(110, subset.size());
+    for (int i = 0; i < 110; i++) {
+      assertNull(subset.get(i));
+      assertTrue(nullBits.get(i));
+    }
+    assertEquals(0, buffer.size());
   }
 
   private void testExtractSubsetWithType(
@@ -260,41 +285,44 @@ public class ColumnBufferTest {
     // The last one should be null
     assertNull(initValues[4]);
 
-    for (Object o : initValues) {
-      buffer.add(o);
+    for (int i = 0; i < initValues.length; i++) {
+      buffer.add(initValues[i]);
+      // Binary column buffer will wrap byte[] in a ByteBuffer
+      // We update initValues for the following comparision for Binary ColumnBuffer
+      if (type == DataType.BINARY && initValues[i] != null) {
+        initValues[i] = ByteBuffer.wrap((byte[]) initValues[i]);
+      }
     }
 
-    ColumnBuffer buffer1 = buffer.extractSubset(-1, 100);
+    ColumnBuffer buffer1 = buffer.extractSubset(100);
     assertEquals(5, buffer1.size());
     // null bit should be set
     assertTrue(buffer1.getNulls().get(4));
-    assertEquals(buffer.get(0), buffer1.get(0));
-    assertEquals(buffer.get(1), buffer1.get(1));
-    assertEquals(buffer.get(2), buffer1.get(2));
-    assertEquals(buffer.get(3), buffer1.get(3));
-    assertEquals(buffer.get(4), buffer1.get(4));
+    assertEquals(initValues[0], buffer1.get(0));
+    assertEquals(initValues[1], buffer1.get(1));
+    assertEquals(initValues[2], buffer1.get(2));
+    assertEquals(initValues[3], buffer1.get(3));
+    assertEquals(initValues[4], buffer1.get(4));
+    assertEquals(0, buffer.size());
 
-    // Extract a part without null
-    ColumnBuffer buffer2 = buffer.extractSubset(0, 2);
-    assertEquals(2, buffer2.size());
-    // null bits should not be set
-    assertEquals(0, buffer2.getNulls().size());
-    assertEquals(buffer.get(0), buffer2.get(0));
-    assertEquals(buffer.get(1), buffer2.get(1));
+    // extract negative index
+    ColumnBuffer buffer2 = buffer1.extractSubset(-1);
+    assertEquals(0, buffer2.size());
+    assertEquals(5, buffer1.size());
 
-    // Extract a single element part
-    ColumnBuffer buffer3 = buffer.extractSubset(4, 5);
+    // Extract single element
+    ColumnBuffer buffer3 = buffer1.extractSubset(1);
     assertEquals(1, buffer3.size());
-    assertTrue(buffer3.getNulls().get(0));
-    assertEquals(buffer.get(4), buffer3.get(0));
+    assertFalse(buffer3.getNulls().get(0));
+    assertEquals(initValues[0], buffer3.get(0));
+    assertEquals(4, buffer1.size());
 
-    // Extract no element part
-    ColumnBuffer buffer4 = buffer.extractSubset(3, 3);
-    assertEquals(0, buffer4.size());
-
-    // End < Start
-    ColumnBuffer buffer5 = buffer.extractSubset(2, 0);
-    assertEquals(0, buffer5.size());
+    // null bits should not be set
+    ColumnBuffer buffer4 = buffer1.extractSubset(2);
+    assertEquals(0, buffer4.getNulls().size());
+    assertEquals(initValues[1], buffer4.get(0));
+    assertEquals(initValues[2], buffer4.get(1));
+    assertEquals(2, buffer1.size());
   }
 
   public static class TestBean {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add unit test for existing meta operation: GetCatalogsOperation/GetTableTypesOperation/GetTypeInfoOperation.

We also fix issues we met.

## How was this patch tested?
Add new unit tests and existing test.

We also use SquirrelSQL test relate operations.
![image](https://user-images.githubusercontent.com/1297418/62930007-26a93400-bdee-11e9-9364-259308724db6.png)

![image](https://user-images.githubusercontent.com/1297418/62930073-42143f00-bdee-11e9-9409-62d07ad0eabd.png)
