### PR TITLE
[LIVY-635][BUILD] Fix travis fail to build by excluding the dependency of hbase

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -318,6 +318,10 @@
               <groupId>org.slf4j</groupId>
               <artifactId>slf4j-log4j12</artifactId>
             </exclusion>
+            <exclusion>
+              <groupId>org.apache.hbase</groupId>
+              <artifactId>*</artifactId>
+            </exclusion>
           </exclusions>
         </dependency>
 

--- a/thriftserver/client/pom.xml
+++ b/thriftserver/client/pom.xml
@@ -34,11 +34,23 @@
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-jdbc</artifactId>
       <version>${hive.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-beeline</artifactId>
       <version>${hive.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
   <build>

--- a/thriftserver/server/pom.xml
+++ b/thriftserver/server/pom.xml
@@ -39,6 +39,10 @@
           <groupId>tomcat</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -136,6 +140,10 @@
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix travis fail to build by excluding the dependency of hbase.

## How was this patch tested?


existed UT and IT.