### PR TITLE
[LIVY-637][ThriftServer]Fix NullPointerException when create database using thriftserver

### DIFF
--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/serde/ThriftResultSet.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/serde/ThriftResultSet.scala
@@ -111,7 +111,10 @@ class ColumnOrientedResultSet(
   }
 
   override def toTRowSet: TRowSet = {
+    // Spark beeline use old hive-jdbc-client doesn’t do null point ref check. When we new TRowSet,
+    // setColumes make sure column set not null.
     val tRowSet = new TRowSet(rowOffset, new util.ArrayList[TRow])
+    tRowSet.setColumns(new util.ArrayList[TColumn]())
     columns.foreach { c =>
       tRowSet.addToColumns(ThriftResultSet.toTColumn(c))
     }


### PR DESCRIPTION

## What changes were proposed in this pull request?

Spark beeline use old hive-jdbc-client doesn’t do null point ref check. So  when new TRowSet, setColumes make sure column set not null.

## How was this patch tested?

Connect to livy's thriftserver using spark beeline. And create/use/drop database will no longer have nullpointerexceptions after execution.

![image](https://user-images.githubusercontent.com/13825159/63147414-b0484400-c030-11e9-8d14-b22238306194.png)
