### PR TITLE
[LIVY-639][REPL] add start time and completion time and duration to the statements web ui

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -726,6 +726,21 @@ A statement represents the result of an execution statement.
     <td>The execution output</td>
     <td>statement output</td>
   </tr>
+  <tr>
+     <td>progress</td>
+     <td>The execution progress</td>
+     <td>double</td>
+  </tr>
+  <tr>
+     <td>started</td>
+     <td>The start time of statement code</td>
+     <td>long</td>
+  </tr>
+  <tr>
+     <td>completed</td>
+     <td>The complete time of statement code</td>
+     <td>long</td>
+  </tr> 
 </table>
 
 #### Statement State

--- a/repl/src/main/scala/org/apache/livy/repl/Session.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/Session.scala
@@ -160,13 +160,12 @@ class Session(
     val statement = new Statement(statementId, code, StatementState.Waiting, null)
     _statements.synchronized { _statements(statementId) = statement }
 
-    statement.started = System.currentTimeMillis()
-
     Future {
       setJobGroup(tpe, statementId)
       statement.compareAndTransit(StatementState.Waiting, StatementState.Running)
 
       if (statement.state.get() == StatementState.Running) {
+        statement.started = System.currentTimeMillis()
         statement.output = executeCode(interpreter(tpe), statementId, code)
       }
 

--- a/repl/src/main/scala/org/apache/livy/repl/Session.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/Session.scala
@@ -17,7 +17,6 @@
 
 package org.apache.livy.repl
 
-
 import java.util.{LinkedHashMap => JLinkedHashMap}
 import java.util.Map.Entry
 import java.util.concurrent.Executors
@@ -148,10 +147,6 @@ class Session(
     _statements.toMap
   }
 
-  def nowTime(): Long = {
-    return System.currentTimeMillis()
-  }
-
   def execute(code: String, codeType: String = null): Int = {
     val tpe = if (codeType != null) {
       Kind(codeType)
@@ -165,8 +160,7 @@ class Session(
     val statement = new Statement(statementId, code, StatementState.Waiting, null)
     _statements.synchronized { _statements(statementId) = statement }
 
-    val start = System.currentTimeMillis()
-    statement.started = nowTime()
+    statement.started = System.currentTimeMillis()
 
     Future {
       setJobGroup(tpe, statementId)
@@ -179,7 +173,7 @@ class Session(
       statement.compareAndTransit(StatementState.Running, StatementState.Available)
       statement.compareAndTransit(StatementState.Cancelling, StatementState.Cancelled)
       statement.updateProgress(1.0)
-      statement.completed = nowTime()
+      statement.completed = System.currentTimeMillis()
     }(interpreterExecutor)
 
     statementId
@@ -227,7 +221,7 @@ class Session(
       }
 
       if (statement.state.get() == StatementState.Cancelled) {
-        statement.completed = nowTime()
+        statement.completed = System.currentTimeMillis()
         info(s"Statement $statementId cancelled.")
       }
     }(cancelExecutor)

--- a/repl/src/main/scala/org/apache/livy/repl/Session.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/Session.scala
@@ -180,8 +180,6 @@ class Session(
       statement.compareAndTransit(StatementState.Cancelling, StatementState.Cancelled)
       statement.updateProgress(1.0)
       statement.completed = nowTime()
-      statement.duration = ((nowTime() - start) / 1000.0 / 60.0)
-        .formatted("%.1f").toDouble
     }(interpreterExecutor)
 
     statementId
@@ -230,8 +228,6 @@ class Session(
 
       if (statement.state.get() == StatementState.Cancelled) {
         statement.completed = nowTime()
-        statement.duration = ((nowTime() - statement.started) / 1000.0 / 60.0)
-          .formatted("%.1f").toDouble
         info(s"Statement $statementId cancelled.")
       }
     }(cancelExecutor)

--- a/rsc/src/main/java/org/apache/livy/rsc/driver/Statement.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/driver/Statement.java
@@ -28,9 +28,9 @@ public class Statement {
   @JsonRawValue
   public volatile String output;
   public double progress;
-  public String duration;
-  public String started;
-  public String completed;
+  public double duration;
+  public long started;
+  public long completed;
 
   public Statement(Integer id, String code, StatementState state, String output) {
     this.id = id;
@@ -58,27 +58,5 @@ public class Statement {
     } else {
       this.progress = p;
     }
-  }
-
-  public void setDuration(String d) {
-    if (this.state.get().isOneOf(StatementState.Cancelled, StatementState.Available)) {
-      this.duration = d;
-    }
-  }
-
-  public String getStarted() {
-    return started;
-  }
-
-  public void setStarted(String started) {
-    this.started = started;
-  }
-
-  public String getCompleted() {
-    return completed;
-  }
-
-  public void setCompleted(String completed) {
-    this.completed = completed;
   }
 }

--- a/rsc/src/main/java/org/apache/livy/rsc/driver/Statement.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/driver/Statement.java
@@ -28,6 +28,9 @@ public class Statement {
   @JsonRawValue
   public volatile String output;
   public double progress;
+  public String duration;
+  public String started;
+  public String completed;
 
   public Statement(Integer id, String code, StatementState state, String output) {
     this.id = id;
@@ -55,5 +58,27 @@ public class Statement {
     } else {
       this.progress = p;
     }
+  }
+
+  public void setDuration(String d) {
+    if (this.state.get().isOneOf(StatementState.Cancelled, StatementState.Available)) {
+      this.duration = d;
+    }
+  }
+
+  public String getStarted() {
+    return started;
+  }
+
+  public void setStarted(String started) {
+    this.started = started;
+  }
+
+  public String getCompleted() {
+    return completed;
+  }
+
+  public void setCompleted(String completed) {
+    this.completed = completed;
   }
 }

--- a/rsc/src/main/java/org/apache/livy/rsc/driver/Statement.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/driver/Statement.java
@@ -28,9 +28,8 @@ public class Statement {
   @JsonRawValue
   public volatile String output;
   public double progress;
-  public double duration;
-  public long started;
-  public long completed;
+  public long started = 0;
+  public long completed = 0;
 
   public Statement(Integer id, String code, StatementState state, String output) {
     this.id = id;

--- a/server/src/main/resources/org/apache/livy/server/ui/static/html/statements-table.html
+++ b/server/src/main/resources/org/apache/livy/server/ui/static/html/statements-table.html
@@ -56,6 +56,24 @@
         Output
       </span>
     </th>
+    <th>
+      <span data-toggle="tooltip"
+            title="The statement code of started time">
+        Started
+      </span>
+    </th>
+    <th>
+      <span data-toggle="tooltip"
+            title="The statement code of completed time">
+        Completed
+      </span>
+    </th>
+    <th>
+      <span data-toggle="tooltip"
+            title="The statement code of duration time">
+        Duration
+      </span>
+    </th>
   </tr>
   </thead>
   <tbody class="statements-table-body">

--- a/server/src/main/resources/org/apache/livy/server/ui/static/html/statements-table.html
+++ b/server/src/main/resources/org/apache/livy/server/ui/static/html/statements-table.html
@@ -58,19 +58,19 @@
     </th>
     <th>
       <span data-toggle="tooltip"
-            title="The statement code of started time">
+            title="The start time of statement code">
         Started
       </span>
     </th>
     <th>
       <span data-toggle="tooltip"
-            title="The statement code of completed time">
+            title="The complete time of statement code">
         Completed
       </span>
     </th>
     <th>
       <span data-toggle="tooltip"
-            title="The statement code of duration time">
+            title="The duration time of statement code">
         Duration
       </span>
     </th>

--- a/server/src/main/resources/org/apache/livy/server/ui/static/js/session.js
+++ b/server/src/main/resources/org/apache/livy/server/ui/static/js/session.js
@@ -35,7 +35,8 @@ function formatError(output) {
 }
 
 function timeWrap(time) {
-  if (time == 0.0) {
+  time = (time / 1000.0 / 60.0).toFixed(1)
+  if (time <= 0.0) {
     return "0.0min"
   } else {
     return time + "min"
@@ -43,6 +44,9 @@ function timeWrap(time) {
 }
 
 function localDateTime(timestamp) {
+  if(timestamp <= 0) {
+    return '-'
+  }
   var now = new Date(timestamp),
       y = now.getFullYear(),
       m = now.getMonth() + 1,
@@ -90,7 +94,7 @@ function loadStatementsTable(statements) {
         tdWrap(statementOutput(statement.output)) +
         tdWrap(localDateTime(statement.started)) +
         tdWrap(localDateTime(statement.completed)) +
-        tdWrap(timeWrap(statement.duration)) +
+        tdWrap(timeWrap(statement.completed - statement.started)) +
        "</tr>"
     );
   });

--- a/server/src/main/resources/org/apache/livy/server/ui/static/js/session.js
+++ b/server/src/main/resources/org/apache/livy/server/ui/static/js/session.js
@@ -34,6 +34,22 @@ function formatError(output) {
   return preWrap(errStr);
 }
 
+function timeWrap(time) {
+  if (time == 0.0) {
+    return "0.0min"
+  } else {
+    return time + "min"
+  }
+}
+
+function localDateTime(timestamp) {
+  var now = new Date(timestamp),
+      y = now.getFullYear(),
+      m = now.getMonth() + 1,
+      d = now.getDate();
+  return y + "-" + (m < 10 ? "0" + m : m) + "-" + (d < 10 ? "0" + d : d) + " " + now.toTimeString().substr(0, 8);
+}
+
 function statementOutput(output) {
   if (output) {
     var data = output.data;
@@ -72,9 +88,9 @@ function loadStatementsTable(statements) {
         tdWrap(progressBar(statement.progress)) +
         tdWrap(statement.output ? statement.output.status : "") +
         tdWrap(statementOutput(statement.output)) +
-        tdWrap(statement.started) +
-        tdWrap(statement.completed) +
-        tdWrap(statement.duration) +
+        tdWrap(localDateTime(statement.started)) +
+        tdWrap(localDateTime(statement.completed)) +
+        tdWrap(timeWrap(statement.duration)) +
        "</tr>"
     );
   });

--- a/server/src/main/resources/org/apache/livy/server/ui/static/js/session.js
+++ b/server/src/main/resources/org/apache/livy/server/ui/static/js/session.js
@@ -35,7 +35,7 @@ function formatError(output) {
 }
 
 function formatDuration(milliseconds) {
-  if(milliseconds <= 0) {
+  if(milliseconds < 0) {
     return '-'
   }
   if (milliseconds < 100) {

--- a/server/src/main/resources/org/apache/livy/server/ui/static/js/session.js
+++ b/server/src/main/resources/org/apache/livy/server/ui/static/js/session.js
@@ -34,20 +34,35 @@ function formatError(output) {
   return preWrap(errStr);
 }
 
-function timeWrap(time) {
-  time = (time / 1000.0 / 60.0).toFixed(1)
-  if (time <= 0.0) {
-    return "0.0min"
-  } else {
-    return time + "min"
-  }
-}
-
-function localDateTime(timestamp) {
-  if(timestamp <= 0) {
+function formatDuration(milliseconds) {
+  if(milliseconds <= 0) {
     return '-'
   }
-  var now = new Date(timestamp),
+  if (milliseconds < 100) {
+    return milliseconds + " ms";
+  }
+  var seconds = milliseconds * 1.0 / 1000;
+  if (seconds < 1) {
+    return seconds.toFixed(1) + " s";
+  }
+  if (seconds < 60) {
+    return seconds.toFixed(0) + " s";
+  }
+  var minutes = seconds / 60;
+  if (minutes < 10) {
+    return minutes.toFixed(1) + " min";
+  } else if (minutes < 60) {
+    return minutes.toFixed(0) + " min";
+  }
+  var hours = minutes / 60;
+  return hours.toFixed(1) + " h";
+}
+
+function localDateTime(milliseconds) {
+  if(milliseconds <= 0) {
+    return '-'
+  }
+  var now = new Date(milliseconds),
       y = now.getFullYear(),
       m = now.getMonth() + 1,
       d = now.getDate();
@@ -94,7 +109,7 @@ function loadStatementsTable(statements) {
         tdWrap(statementOutput(statement.output)) +
         tdWrap(localDateTime(statement.started)) +
         tdWrap(localDateTime(statement.completed)) +
-        tdWrap(timeWrap(statement.completed - statement.started)) +
+        tdWrap(formatDuration(statement.completed - statement.started)) +
        "</tr>"
     );
   });

--- a/server/src/main/resources/org/apache/livy/server/ui/static/js/session.js
+++ b/server/src/main/resources/org/apache/livy/server/ui/static/js/session.js
@@ -72,6 +72,9 @@ function loadStatementsTable(statements) {
         tdWrap(progressBar(statement.progress)) +
         tdWrap(statement.output ? statement.output.status : "") +
         tdWrap(statementOutput(statement.output)) +
+        tdWrap(statement.started) +
+        tdWrap(statement.completed) +
+        tdWrap(statement.duration) +
        "</tr>"
     );
   });


### PR DESCRIPTION
## What changes were proposed in this pull request?

add start time and completion time and duration to the statements web ui

JIRA: https://issues.apache.org/jira/browse/LIVY-639?filter=-2

## How was this patch tested?

Existing test set and our test environment

![DeepinScreenshot_select-area_20190816153300](https://user-images.githubusercontent.com/23738217/63151060-2487e500-c03b-11e9-92d1-f3eb497c322c.png)


