### PR TITLE
[LIVY-592][Server] Allow proxy user to view or modify his session

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/AccessManager.scala
+++ b/server/src/main/scala/org/apache/livy/server/AccessManager.scala
@@ -130,9 +130,9 @@ private[livy] class AccessManager(conf: LivyConf) extends Logging {
    * Check that the request's user has modify access to resources whose owner is the given target
    * user or whose proxy user is the given proxy user.
    */
-  def hasModifyAccess(target: String, proxyUser: Option[String], requestUser: String): Boolean = {
+  def hasModifyAccess(target: String, requestUser: String, proxyUser: String = ""): Boolean = {
     requestUser == target  ||
-    proxyUser != null && proxyUser.getOrElse(null) == requestUser ||
+    proxyUser == requestUser ||
     checkModifyPermissions(requestUser)
   }
 
@@ -140,9 +140,9 @@ private[livy] class AccessManager(conf: LivyConf) extends Logging {
    * Check that the request's user has view access to resources whose owner is the given target
    * user or whose proxy user is the given proxy user.
    */
-  def hasViewAccess(target: String, proxyUser: Option[String], requestUser: String): Boolean = {
+  def hasViewAccess(target: String, requestUser: String, proxyUser: String = ""): Boolean = {
     requestUser == target ||
-    proxyUser != null && proxyUser.getOrElse(null) == requestUser ||
+    proxyUser == requestUser ||
     checkViewPermissions(requestUser)
   }
 }

--- a/server/src/main/scala/org/apache/livy/server/AccessManager.scala
+++ b/server/src/main/scala/org/apache/livy/server/AccessManager.scala
@@ -127,16 +127,22 @@ private[livy] class AccessManager(conf: LivyConf) extends Logging {
   }
 
   /**
-   * Check that the request's user has modify access to resources owned by the given target user.
+   * Check that the request's user has modify access to resources whose owner is the given target
+   * user or whose proxy user is the given proxy user.
    */
-  def hasModifyAccess(target: String, requestUser: String): Boolean = {
-    requestUser == target || checkModifyPermissions(requestUser)
+  def hasModifyAccess(target: String, proxyUser: Option[String], requestUser: String): Boolean = {
+    requestUser == target  ||
+    proxyUser != null && proxyUser.getOrElse(null) == requestUser ||
+    checkModifyPermissions(requestUser)
   }
 
   /**
-   * Check that the request's user has view access to resources owned by the given target user.
+   * Check that the request's user has view access to resources whose owner is the given target
+   * user or whose proxy user is the given proxy user.
    */
-  def hasViewAccess(target: String, requestUser: String): Boolean = {
-    requestUser == target || checkViewPermissions(requestUser)
+  def hasViewAccess(target: String, proxyUser: Option[String], requestUser: String): Boolean = {
+    requestUser == target ||
+    proxyUser != null && proxyUser.getOrElse(null) == requestUser ||
+    checkViewPermissions(requestUser)
   }
 }

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -207,7 +207,7 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
 
   private def doWithSession(fn: (S => Any),
       allowAll: Boolean,
-      checkFn: Option[(String, String) => Boolean]): Any = {
+      checkFn: Option[(String, Option[String], String) => Boolean]): Any = {
     val idOrNameParam: String = params("id")
     val session = if (idOrNameParam.forall(_.isDigit)) {
       val sessionId = idOrNameParam.toInt
@@ -218,7 +218,7 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
     }
     session match {
       case Some(session) =>
-        if (allowAll || checkFn.map(_(session.owner, effectiveUser(request))).getOrElse(false)) {
+        if (allowAll || checkFn.map(_(session.owner, session.proxyUser, effectiveUser(request))).getOrElse(false)) {
           fn(session)
         } else {
           Forbidden()

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -207,7 +207,7 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
 
   private def doWithSession(fn: (S => Any),
       allowAll: Boolean,
-      checkFn: Option[(String, Option[String], String) => Boolean]): Any = {
+      checkFn: Option[(String, String, String) => Boolean]): Any = {
     val idOrNameParam: String = params("id")
     val session = if (idOrNameParam.forall(_.isDigit)) {
       val sessionId = idOrNameParam.toInt
@@ -219,7 +219,9 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
     session match {
       case Some(session) =>
         if (allowAll ||
-            checkFn.map(_(session.owner, session.proxyUser, effectiveUser(request)))
+            checkFn.map(_(session.owner,
+                          effectiveUser(request),
+                          session.proxyUser.getOrElse("")))
                    .getOrElse(false)) {
           fn(session)
         } else {

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -219,7 +219,8 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
     session match {
       case Some(session) =>
         if (allowAll ||
-            checkFn.map(_(session.owner, session.proxyUser, effectiveUser(request))).getOrElse(false)) {
+            checkFn.map(_(session.owner, session.proxyUser, effectiveUser(request)))
+                   .getOrElse(false)) {
           fn(session)
         } else {
           Forbidden()

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -218,7 +218,8 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
     }
     session match {
       case Some(session) =>
-        if (allowAll || checkFn.map(_(session.owner, session.proxyUser, effectiveUser(request))).getOrElse(false)) {
+        if (allowAll ||
+            checkFn.map(_(session.owner, session.proxyUser, effectiveUser(request))).getOrElse(false)) {
           fn(session)
         } else {
           Forbidden()

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
@@ -60,7 +60,9 @@ class BatchSessionServlet(
       session: BatchSession,
       req: HttpServletRequest): Any = {
     val logs =
-      if (accessManager.hasViewAccess(session.owner, session.proxyUser, effectiveUser(req))) {
+      if (accessManager.hasViewAccess(session.owner,
+                                      effectiveUser(req),
+                                      session.proxyUser.getOrElse(""))) {
         val lines = session.logLines()
 
         val size = 10

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
@@ -60,7 +60,7 @@ class BatchSessionServlet(
       session: BatchSession,
       req: HttpServletRequest): Any = {
     val logs =
-      if (accessManager.hasViewAccess(session.owner, effectiveUser(req))) {
+      if (accessManager.hasViewAccess(session.owner, session.proxyUser, effectiveUser(req))) {
         val lines = session.logLines()
 
         val size = 10

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -67,7 +67,7 @@ class InteractiveSessionServlet(
       session: InteractiveSession,
       req: HttpServletRequest): Any = {
     val logs =
-      if (accessManager.hasViewAccess(session.owner, effectiveUser(req))) {
+      if (accessManager.hasViewAccess(session.owner, session.proxyUser, effectiveUser(req))) {
         Option(session.logLines())
           .map { lines =>
             val size = 10

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -67,7 +67,9 @@ class InteractiveSessionServlet(
       session: InteractiveSession,
       req: HttpServletRequest): Any = {
     val logs =
-      if (accessManager.hasViewAccess(session.owner, session.proxyUser, effectiveUser(req))) {
+      if (accessManager.hasViewAccess(session.owner,
+                                      effectiveUser(req),
+                                      session.proxyUser.getOrElse(""))) {
         Option(session.logLines())
           .map { lines =>
             val size = 10

--- a/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
@@ -297,6 +297,12 @@ class AclsEnabledSessionServletSpec extends BaseSessionServletSpec[Session, Reco
           assert(res.logs === IndexedSeq("log"))
         }
 
+        // LIVY-592: Proxy user cannot view its session log
+        // Proxy user should be able to see its session log
+        jget[MockSessionView](s"/${res.id}", headers = aliceHeaders) { res =>
+          assert(res.logs === IndexedSeq("log"))
+        }
+
         delete(res.id, adminHeaders, SC_OK)
       }
     }
@@ -312,6 +318,12 @@ class AclsEnabledSessionServletSpec extends BaseSessionServletSpec[Session, Reco
         delete(res.id, bobHeaders, SC_FORBIDDEN)
         delete(res.id, viewUserHeaders, SC_FORBIDDEN)
         delete(res.id, modifyUserHeaders, SC_OK)
+      }
+
+      // LIVY-592: Proxy user cannot view its session log
+      // Proxy user should be able to modify its session
+      jpost[MockSessionView]("/?doAs=alice", Map(), headers = adminHeaders) { res =>
+        delete(res.id, aliceHeaders, SC_OK)
       }
     }
 

--- a/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
@@ -70,7 +70,10 @@ object SessionServletSpec {
       override protected def clientSessionView(
           session: Session,
           req: HttpServletRequest): Any = {
-        val logs = if (accessManager.hasViewAccess(session.owner, session.proxyUser, effectiveUser(req))) {
+        val hasViewAccess = accessManager.hasViewAccess(session.owner,
+                                                        session.proxyUser,
+                                                        effectiveUser(req))
+        val logs = if (hasViewAccess) {
           session.logLines()
         } else {
           Nil

--- a/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
@@ -71,8 +71,8 @@ object SessionServletSpec {
           session: Session,
           req: HttpServletRequest): Any = {
         val hasViewAccess = accessManager.hasViewAccess(session.owner,
-                                                        session.proxyUser,
-                                                        effectiveUser(req))
+                                                        effectiveUser(req),
+                                                        session.proxyUser.getOrElse(""))
         val logs = if (hasViewAccess) {
           session.logLines()
         } else {

--- a/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
@@ -70,7 +70,7 @@ object SessionServletSpec {
       override protected def clientSessionView(
           session: Session,
           req: HttpServletRequest): Any = {
-        val logs = if (accessManager.hasViewAccess(session.owner, effectiveUser(req))) {
+        val logs = if (accessManager.hasViewAccess(session.owner, session.proxyUser, effectiveUser(req))) {
           session.logLines()
         } else {
           Nil

--- a/server/src/test/scala/org/apache/livy/server/batch/BatchServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/BatchServletSpec.scala
@@ -76,6 +76,7 @@ class BatchServletSpec extends BaseSessionServletSpec[BatchSession, BatchRecover
     when(session.appId).thenReturn(Some(appId))
     when(session.appInfo).thenReturn(appInfo)
     when(session.logLines()).thenReturn(log)
+    when(session.proxyUser).thenReturn(None)
 
     val req = mock[HttpServletRequest]
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This patch is ported from https://github.com/apache/incubator-livy/pull/172, with adding some unit tests.

Allow proxy user to view or modify his session. Here is the link to the corresponding Jira
https://issues.apache.org/jira/browse/LIVY-592

## How was this patch tested?
New unit tests and existing unit tests.