### PR TITLE
[LIVY-642] Fix a rare status happened in yarn cause SparkApp change into error state

### DIFF
--- a/server/src/main/scala/org/apache/livy/utils/SparkYarnApp.scala
+++ b/server/src/main/scala/org/apache/livy/utils/SparkYarnApp.scala
@@ -215,7 +215,8 @@ class SparkYarnApp private[utils] (
            (YarnApplicationState.SUBMITTED, FinalApplicationStatus.UNDEFINED) |
            (YarnApplicationState.ACCEPTED, FinalApplicationStatus.UNDEFINED) =>
         SparkApp.State.STARTING
-      case (YarnApplicationState.RUNNING, FinalApplicationStatus.UNDEFINED) =>
+      case (YarnApplicationState.RUNNING, FinalApplicationStatus.UNDEFINED) |
+           (YarnApplicationState.RUNNING, FinalApplicationStatus.SUCCEEDED) =>
         SparkApp.State.RUNNING
       case (YarnApplicationState.FINISHED, FinalApplicationStatus.SUCCEEDED) =>
         SparkApp.State.FINISHED


### PR DESCRIPTION
some of batch session returned failed state while spark yarn application is succeeded. and in livy log，i find the reason：

```
2019-08-23 05:32:48,096 ERROR [Logging.scala:56] - Unknown YARN state RUNNING for app application_1559632632227_47808044 with final status SUCCEEDED.
```

it means yarn application state is RUNNING while final app status is SUCCEEDED, it's a correct status in yarn, means AM has not sync app state yet. and livy mapped this situatition as SparkApp.state.FAILED.
So, i think we should map this state into SparkApp.state.RUNNING，waiting for AM sync.