### PR TITLE
[LIVY-645]Add Session Name, Owner, Proxy User information to Web UI

### DIFF
--- a/server/src/main/resources/org/apache/livy/server/ui/static/html/batches-table.html
+++ b/server/src/main/resources/org/apache/livy/server/ui/static/html/batches-table.html
@@ -35,6 +35,22 @@
     </th>
     <th>
       <span data-toggle="tooltip"
+            title="Application name for this session.">
+        Name
+      </span>
+    </th>
+    <th>
+      <span data-toggle="tooltip" title="Remote user who submitted this session">
+        Owner
+      </span>
+    </th>
+    <th>
+      <span data-toggle="tooltip" title="User to impersonate when running">
+        Proxy User
+      </span>
+    </th>
+    <th>
+      <span data-toggle="tooltip"
             title="Session State (not_started, starting, idle, busy,
             shutting_down, error, dead, success)">
         State

--- a/server/src/main/resources/org/apache/livy/server/ui/static/html/sessions-table.html
+++ b/server/src/main/resources/org/apache/livy/server/ui/static/html/sessions-table.html
@@ -35,6 +35,12 @@
       </span>
     </th>
     <th>
+      <span data-toggle="tooltip"
+            title="Application name for this session.">
+        Name
+      </span>
+    </th>
+    <th>
       <span data-toggle="tooltip" title="Remote user who submitted this session">
         Owner
       </span>

--- a/server/src/main/resources/org/apache/livy/server/ui/static/js/all-sessions.js
+++ b/server/src/main/resources/org/apache/livy/server/ui/static/js/all-sessions.js
@@ -21,6 +21,7 @@ function loadSessionsTable(sessions) {
       "<tr>" +
         tdWrap(uiLink("session/" + session.id, session.id)) +
         tdWrap(appIdLink(session)) +
+        tdWrap(session.name) +
         tdWrap(session.owner) +
         tdWrap(session.proxyUser) +
         tdWrap(session.kind) +
@@ -37,6 +38,9 @@ function loadBatchesTable(sessions) {
       "<tr>" +
         tdWrap(session.id) +
         tdWrap(appIdLink(session)) +
+        tdWrap(session.name) +
+        tdWrap(session.owner) +
+        tdWrap(session.proxyUser) +
         tdWrap(session.state) +
         tdWrap(logLinks(session, "batch")) +
         "</tr>"

--- a/server/src/main/resources/org/apache/livy/server/ui/static/js/session.js
+++ b/server/src/main/resources/org/apache/livy/server/ui/static/js/session.js
@@ -53,6 +53,7 @@ function appendSummary(session) {
     "<h3>Session " + session.id + "</h3>" +
     "<ul class='list-unstyled'>" +
       sumWrap("Application Id", appIdLink(session)) +
+      sumWrap("Name", session.name) +
       sumWrap("Owner", session.owner) +
       sumWrap("Proxy User", session.proxyUser) +
       sumWrap("Session Kind", session.kind) +

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
@@ -28,6 +28,8 @@ import org.apache.livy.utils.AppInfo
 case class BatchSessionView(
   id: Long,
   name: Option[String],
+  owner: String,
+  proxyUser: Option[String],
   state: String,
   appId: Option[String],
   appInfo: AppInfo,
@@ -73,8 +75,8 @@ class BatchSessionServlet(
       } else {
         Nil
       }
-    BatchSessionView(session.id, session.name, session.state.toString, session.appId,
-      session.appInfo, logs)
+    BatchSessionView(session.id, session.name, session.owner, session.proxyUser,
+      session.state.toString, session.appId, session.appInfo, logs)
   }
 
 }

--- a/server/src/test/scala/org/apache/livy/server/batch/BatchServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/BatchServletSpec.scala
@@ -66,6 +66,8 @@ class BatchServletSpec extends BaseSessionServletSpec[BatchSession, BatchRecover
     val id = 0
     val state = SessionState.Running
     val appId = "appid"
+    val owner = "owner"
+    val proxyUser = "proxyUser"
     val appInfo = AppInfo(Some("DRIVER LOG URL"), Some("SPARK UI URL"))
     val log = IndexedSeq[String]("log1", "log2")
 
@@ -76,7 +78,8 @@ class BatchServletSpec extends BaseSessionServletSpec[BatchSession, BatchRecover
     when(session.appId).thenReturn(Some(appId))
     when(session.appInfo).thenReturn(appInfo)
     when(session.logLines()).thenReturn(log)
-    when(session.proxyUser).thenReturn(None)
+    when(session.owner).thenReturn(owner)
+    when(session.proxyUser).thenReturn(Some(proxyUser))
 
     val req = mock[HttpServletRequest]
 
@@ -87,6 +90,8 @@ class BatchServletSpec extends BaseSessionServletSpec[BatchSession, BatchRecover
     view.name shouldEqual name
     view.state shouldEqual state.toString
     view.appId shouldEqual Some(appId)
+    view.owner shouldEqual owner
+    view.proxyUser shouldEqual Some(proxyUser)
     view.appInfo shouldEqual appInfo
     view.log shouldEqual log
   }

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
@@ -228,7 +228,7 @@ class LivyThriftSessionManager(val server: LivyThriftServer, val livyConf: LivyC
       createInteractiveRequest.kind = Spark
       val newSession = InteractiveSession.create(
         server.livySessionManager.nextId(),
-        None,
+        createInteractiveRequest.name,
         username,
         None,
         server.livyConf,

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
@@ -228,7 +228,7 @@ class LivyThriftSessionManager(val server: LivyThriftServer, val livyConf: LivyC
       createInteractiveRequest.kind = Spark
       val newSession = InteractiveSession.create(
         server.livySessionManager.nextId(),
-        createInteractiveRequest.name,
+        None,
         username,
         None,
         server.livyConf,


### PR DESCRIPTION
## What changes were proposed in this pull request?

1, Web UI, add Session Name to Interactive Sessions list
2, Web UI, add Session Name, Owner, Proxy User to Batch Sessions list
3,~~fix thrift server session doesn't set Session Name issue.~~ Move to PR #218

## How was this patch tested?

Update existing unit test, and have tested manually.

![AddName](https://user-images.githubusercontent.com/7855100/63513238-3de7d000-c518-11e9-8b18-613874ed635a.jpg)
![AddName2](https://user-images.githubusercontent.com/7855100/63513246-42ac8400-c518-11e9-9019-679bb82e4bb0.jpg)
