### PR TITLE
[LIVY-643][Server] Support for a Livy Server running on Windows Operating System

### DIFF
--- a/client-common/src/main/java/org/apache/livy/client/common/OperatingSystemUtils.java
+++ b/client-common/src/main/java/org/apache/livy/client/common/OperatingSystemUtils.java
@@ -17,7 +17,6 @@
 
 package org.apache.livy.client.common;
 
-import com.sun.javafx.PlatformUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,10 +24,70 @@ import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Collections;
 import java.util.EnumSet;
-
 import static java.nio.file.attribute.PosixFilePermission.*;
 
+import com.sun.javafx.PlatformUtil;
+
+/*
+ * Utility class to get OS related information and perform OS-dependent actions
+ */
 public class OperatingSystemUtils {
+
+    public static boolean isPosixCompliant() {
+        return PlatformUtil.isMac() || PlatformUtil.isUnix();
+    }
+
+    public static boolean isWindows() {
+        return PlatformUtil.isWindows();
+    }
+
+    public static void doBasedOnOs(
+            Procedure doWhenPosixCompliant,
+            Procedure doWhenWindows,
+            String operationDescription) {
+        doBasedOnOsThrowsException(
+                () -> doWhenPosixCompliant.execute(),
+                () -> doWhenWindows.execute(),
+                operationDescription);
+    }
+
+    public static <ExceptionType extends Exception> void doBasedOnOsThrowsException(
+            ThrowingProcedure<ExceptionType> doWhenPosixCompliant,
+            ThrowingProcedure<ExceptionType> doWhenWindows,
+            String operationDescription) throws ExceptionType {
+        getBasedOnOS(doWhenPosixCompliant, doWhenWindows, operationDescription).execute();
+    }
+
+    public static <T> T getBasedOnOS(
+            T getWhenPosixCompliant,
+            T getWhenWindows,
+            String operationDescription) {
+        if (isPosixCompliant()) {
+            return getWhenPosixCompliant;
+        } else if (isWindows()) {
+            return getWhenWindows;
+        } else {
+            String seperator = operationDescription.isEmpty() ? "" : ": ";
+            throw new UnsupportedOperationException("Operation" + seperator + operationDescription +
+                                                            " is not supported on this OS");
+        }
+    }
+
+    public static void setOSAgnosticFilePermissions(File file,
+                                                    EnumSet<PosixFilePermission> permissions)
+            throws IOException {
+        OperatingSystemUtils.doBasedOnOsThrowsException(
+                () -> Files.setPosixFilePermissions(file.toPath(), permissions),
+                //whether or not a file is read-only is the only applicable permission on Windows
+                () -> file.setWritable(isWriteable(permissions), permissions.contains(OWNER_WRITE)),
+                "Setting file permissions"
+                                                       );
+    }
+
+    private static boolean isWriteable(EnumSet<PosixFilePermission> permissions) {
+        return !Collections.disjoint(permissions, EnumSet.of(OWNER_WRITE, GROUP_WRITE,
+                                                             OTHERS_WRITE));
+    }
 
     @FunctionalInterface
     public interface Procedure {
@@ -39,46 +98,6 @@ public class OperatingSystemUtils {
     public interface ThrowingProcedure<ExceptionType extends Exception> {
         void execute() throws ExceptionType;
     }
-
-    public static boolean isPosixCompliant() {
-        return PlatformUtil.isMac() || PlatformUtil.isUnix();
-    }
-
-    public static boolean isWindows() {
-        return PlatformUtil.isWindows();
-    }
-
-    public static void doBasedOnOs( Procedure doWhenPosixCompliant,  Procedure doWhenWindows, String operationDescription) {
-        doBasedOnOsThrowsException(() -> doWhenPosixCompliant.execute(), () -> doWhenWindows.execute(), operationDescription);
-    }
-
-    public static <ExceptionType extends Exception> void doBasedOnOsThrowsException( ThrowingProcedure<ExceptionType> doWhenPosixCompliant,  ThrowingProcedure<ExceptionType> doWhenWindows, String operationDescription) throws ExceptionType {
-        getBasedOnOS(doWhenPosixCompliant, doWhenWindows, operationDescription).execute();
-    }
-
-    public static <T> T getBasedOnOS(T getWhenPosixCompliant, T getWhenWindows, String operationDescription) {
-        if (isPosixCompliant()) {
-            return getWhenPosixCompliant;
-        } else if ( isWindows()) {
-            return getWhenWindows;
-        } else {
-            String seperator = operationDescription.isEmpty() ? "" : ": ";
-            throw new UnsupportedOperationException("Operation" + seperator + operationDescription + " is not supported on this OS");
-        }
-    }
-
-    public static void setOSAgnosticFilePermissions(File file, EnumSet<PosixFilePermission> permissions) throws IOException {
-        OperatingSystemUtils.doBasedOnOsThrowsException(
-                () -> Files.setPosixFilePermissions(file.toPath(), permissions),
-                () -> file.setWritable(isWriteable(permissions), permissions.contains(OWNER_WRITE)), //whether or not a file is read-only is the only applicable permission on Windows
-                "Setting file permissions"
-        );
-    }
-
-    private static boolean isWriteable(EnumSet<PosixFilePermission> permissions) {
-        return !Collections.disjoint(permissions, EnumSet.of(OWNER_WRITE, GROUP_WRITE, OTHERS_WRITE));
-    }
-
 
 
 }

--- a/client-common/src/main/java/org/apache/livy/client/common/OperatingSystemUtils.java
+++ b/client-common/src/main/java/org/apache/livy/client/common/OperatingSystemUtils.java
@@ -1,0 +1,81 @@
+package org.apache.livy.client.common;
+
+import com.sun.javafx.PlatformUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.function.Supplier;
+
+import static java.nio.file.attribute.PosixFilePermission.*;
+
+public class OperatingSystemUtils {
+
+
+    @FunctionalInterface
+    public interface Procedure {
+        void execute();
+    }
+
+    @FunctionalInterface
+    public interface ThrowingProcedure<ExceptionType extends Exception> {
+        void execute() throws ExceptionType;
+    }
+
+    @FunctionalInterface
+    public interface ThrowingSupplier<ExceptionType extends Exception, T> {
+        T get() throws ExceptionType;
+    }
+
+    public static boolean isPosixCompliant() {
+        return PlatformUtil.isMac() || PlatformUtil.isUnix();
+    }
+
+    public static boolean isWindows() {
+        return PlatformUtil.isWindows();
+    }
+
+    public static void doBasedOnOs( Procedure doWhenPosixCompliant,  Procedure doWhenWindows, String operationDescription) {
+        doBasedOnOsThrowsException(() -> doWhenPosixCompliant.execute(), () -> doWhenWindows.execute(), operationDescription);
+    }
+
+    public static <ExceptionType extends Exception> void doBasedOnOsThrowsException( ThrowingProcedure<ExceptionType> doWhenPosixCompliant,  ThrowingProcedure<ExceptionType> doWhenWindows, String operationDescription) throws ExceptionType {
+        getBasedOnOsThrowsException(
+                () -> {doWhenPosixCompliant.execute(); return null;},
+                () -> {doWhenWindows.execute(); return null;},
+                operationDescription);
+    }
+
+    public static <T> T getBasedOnOs( Supplier<T> doWhenPosixCompliant, Supplier<T> doWhenWindows, String operationDescription) {
+        return getBasedOnOsThrowsException(() -> doWhenPosixCompliant.get(), () -> doWhenWindows.get(), operationDescription);
+    }
+
+    public static <ExceptionType extends Exception, T> T getBasedOnOsThrowsException(ThrowingSupplier<ExceptionType, T> doWhenPosixCompliant, ThrowingSupplier<ExceptionType, T> doWhenWindows, String operationDescription) throws ExceptionType {
+        if (isPosixCompliant()) {
+            return doWhenPosixCompliant.get();
+        } else if ( isWindows()) {
+            return doWhenWindows.get();
+        } else {
+            String seperator = operationDescription.isEmpty() ? "" : ": ";
+            throw new UnsupportedOperationException("Operation" + seperator + operationDescription + " is not supported on this OS");
+        }
+    }
+
+    public static void setOSAgnosticFilePermissions(File file, EnumSet<PosixFilePermission> permissions) throws IOException {
+        OperatingSystemUtils.doBasedOnOsThrowsException(
+                () -> Files.setPosixFilePermissions(file.toPath(), permissions),
+                () -> file.setWritable(isWriteable(permissions), permissions.contains(OWNER_WRITE)), //whether or not a file is read-only is the applicable permission on Windows
+                "Setting file permissions"
+        );
+    }
+
+    private static boolean isWriteable(EnumSet<PosixFilePermission> permissions) {
+        return !Collections.disjoint(permissions, EnumSet.of(OWNER_WRITE, GROUP_WRITE, OTHERS_WRITE));
+    }
+
+
+
+}

--- a/client-common/src/main/java/org/apache/livy/client/common/OperatingSystemUtils.java
+++ b/client-common/src/main/java/org/apache/livy/client/common/OperatingSystemUtils.java
@@ -85,7 +85,8 @@ public class OperatingSystemUtils {
     }
 
     private static boolean isWriteable(EnumSet<PosixFilePermission> permissions) {
-        return !Collections.disjoint(permissions, EnumSet.of(OWNER_WRITE, GROUP_WRITE,
+        return !Collections.disjoint(permissions, EnumSet.of(OWNER_WRITE,
+                                                             GROUP_WRITE,
                                                              OTHERS_WRITE));
     }
 

--- a/client-common/src/test/java/org/apache/livy/client/common/TestOperatingSystemUtils.java
+++ b/client-common/src/test/java/org/apache/livy/client/common/TestOperatingSystemUtils.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.livy.client.common;
 
 import com.sun.javafx.PlatformUtil;
@@ -69,37 +86,19 @@ public class TestOperatingSystemUtils {
     public void testGetBasedOnOs() {
         String value = "";
         if (OperatingSystemUtils.isPosixCompliant()) {
-            value = OperatingSystemUtils.getBasedOnOs(
-                    () -> "pass",
-                    () -> "fail",
+            value = OperatingSystemUtils.getBasedOnOS(
+                    "pass",
+                    "fail",
                     ""
             );
         } else if (OperatingSystemUtils.isWindows()) {
-            value = OperatingSystemUtils.getBasedOnOs(
-                    () -> "fail",
-                    () -> "pass",
+            value = OperatingSystemUtils.getBasedOnOS(
+                    "fail",
+                    "pass",
                     ""
             );
         }
         assertEquals(value, "pass");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testGetBasedOnOsThrowsException() {
-        if (OperatingSystemUtils.isPosixCompliant()) {
-           OperatingSystemUtils.getBasedOnOsThrowsException(
-                    () -> {throw new IllegalArgumentException();},
-                    () -> "fail",
-                    ""
-            );
-        } else if (OperatingSystemUtils.isWindows()) {
-            OperatingSystemUtils.getBasedOnOsThrowsException(
-                    () -> "fail",
-                    () -> {throw new IllegalArgumentException();},
-                    ""
-            );
-        }
-       fail();
     }
 
     @Test

--- a/client-common/src/test/java/org/apache/livy/client/common/TestOperatingSystemUtils.java
+++ b/client-common/src/test/java/org/apache/livy/client/common/TestOperatingSystemUtils.java
@@ -17,17 +17,16 @@
 
 package org.apache.livy.client.common;
 
-import com.sun.javafx.PlatformUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.EnumSet;
-
 import static java.nio.file.attribute.PosixFilePermission.*;
+
+import com.sun.javafx.PlatformUtil;
+import org.junit.Before;
+import org.junit.Test;
 import static org.junit.Assert.*;
+
 
 public class TestOperatingSystemUtils {
 
@@ -40,12 +39,14 @@ public class TestOperatingSystemUtils {
 
     @Test
     public void testIsPosixCompliant() {
-        assertEquals(PlatformUtil.isUnix() || PlatformUtil.isMac(), OperatingSystemUtils.isPosixCompliant());
+        assertEquals(PlatformUtil.isUnix() || PlatformUtil.isMac(),
+                     OperatingSystemUtils.isPosixCompliant());
     }
 
     @Test
     public void testIsWindows() {
-        assertEquals(PlatformUtil.isWindows(), OperatingSystemUtils.isWindows());
+        assertEquals(PlatformUtil.isWindows(),
+                     OperatingSystemUtils.isWindows());
     }
 
     @Test
@@ -105,7 +106,9 @@ public class TestOperatingSystemUtils {
     public void testSetOSAgnosticFilePermissions() throws IOException {
         File f = File.createTempFile("testFile", ".txt");
         f.deleteOnExit();
-        OperatingSystemUtils.setOSAgnosticFilePermissions(f, EnumSet.of(OWNER_READ, OWNER_WRITE, OWNER_EXECUTE));
+        OperatingSystemUtils.setOSAgnosticFilePermissions(f, EnumSet.of(OWNER_READ,
+                                                                        OWNER_WRITE,
+                                                                        OWNER_EXECUTE));
         assertTrue(f.canExecute());
         assertTrue(f.canWrite());
         assertTrue(f.canRead());

--- a/client-common/src/test/java/org/apache/livy/client/common/TestOperatingSystemUtils.java
+++ b/client-common/src/test/java/org/apache/livy/client/common/TestOperatingSystemUtils.java
@@ -1,0 +1,123 @@
+package org.apache.livy.client.common;
+
+import com.sun.javafx.PlatformUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.EnumSet;
+
+import static java.nio.file.attribute.PosixFilePermission.*;
+import static org.junit.Assert.*;
+
+public class TestOperatingSystemUtils {
+
+    @Before
+    public void setUp() throws UnsupportedOperationException {
+        if ( !(PlatformUtil.isMac() || PlatformUtil.isWindows() || PlatformUtil.isUnix())) {
+            throw new UnsupportedOperationException("Not running on supported OS");
+        }
+    }
+
+    @Test
+    public void testIsPosixCompliant() {
+        assertEquals(PlatformUtil.isUnix() || PlatformUtil.isMac(), OperatingSystemUtils.isPosixCompliant());
+    }
+
+    @Test
+    public void testIsWindows() {
+        assertEquals(PlatformUtil.isWindows(), OperatingSystemUtils.isWindows());
+    }
+
+    @Test
+    public void testDoBasedOnOs() {
+        if (OperatingSystemUtils.isPosixCompliant()) {
+            OperatingSystemUtils.doBasedOnOs(
+                    () -> {},
+                    () -> fail(),
+                    ""
+            );
+        } else if (OperatingSystemUtils.isWindows()) {
+            OperatingSystemUtils.doBasedOnOs(
+                    () -> fail(),
+                    () -> {},
+                    ""
+            );
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDoBasedOnOsThrowsException() {
+        if (OperatingSystemUtils.isPosixCompliant()) {
+            OperatingSystemUtils.doBasedOnOsThrowsException(
+                    () -> {throw new IllegalArgumentException();},
+                    () -> fail(),
+                    ""
+            );
+        } else if (OperatingSystemUtils.isWindows()) {
+            OperatingSystemUtils.doBasedOnOsThrowsException(
+                    () -> fail(),
+                    () -> {throw new IllegalArgumentException();},
+                    ""
+            );
+        }
+    }
+
+    @Test
+    public void testGetBasedOnOs() {
+        String value = "";
+        if (OperatingSystemUtils.isPosixCompliant()) {
+            value = OperatingSystemUtils.getBasedOnOs(
+                    () -> "pass",
+                    () -> "fail",
+                    ""
+            );
+        } else if (OperatingSystemUtils.isWindows()) {
+            value = OperatingSystemUtils.getBasedOnOs(
+                    () -> "fail",
+                    () -> "pass",
+                    ""
+            );
+        }
+        assertEquals(value, "pass");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetBasedOnOsThrowsException() {
+        if (OperatingSystemUtils.isPosixCompliant()) {
+           OperatingSystemUtils.getBasedOnOsThrowsException(
+                    () -> {throw new IllegalArgumentException();},
+                    () -> "fail",
+                    ""
+            );
+        } else if (OperatingSystemUtils.isWindows()) {
+            OperatingSystemUtils.getBasedOnOsThrowsException(
+                    () -> "fail",
+                    () -> {throw new IllegalArgumentException();},
+                    ""
+            );
+        }
+       fail();
+    }
+
+    @Test
+    public void testSetOSAgnosticFilePermissions() throws IOException {
+        File f = File.createTempFile("testFile", ".txt");
+        f.deleteOnExit();
+        OperatingSystemUtils.setOSAgnosticFilePermissions(f, EnumSet.of(OWNER_READ, OWNER_WRITE, OWNER_EXECUTE));
+        assertTrue(f.canExecute());
+        assertTrue(f.canWrite());
+        assertTrue(f.canRead());
+
+        OperatingSystemUtils.setOSAgnosticFilePermissions(f, EnumSet.of(OWNER_READ));
+        if (OperatingSystemUtils.isPosixCompliant()) {
+            assertFalse(f.canExecute());
+        }
+        assertFalse(f.canWrite());
+        assertTrue(f.canRead());
+
+
+    }
+}

--- a/rsc/src/main/java/org/apache/livy/rsc/ContextLauncher.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/ContextLauncher.java
@@ -44,17 +44,16 @@ import static java.nio.file.attribute.PosixFilePermission.*;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.Promise;
-import org.apache.livy.client.common.OperatingSystemUtils;
 import org.apache.spark.launcher.SparkLauncher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.livy.client.common.OperatingSystemUtils;
 import org.apache.livy.client.common.TestUtils;
 import org.apache.livy.rsc.driver.RSCDriverBootstrapper;
 import org.apache.livy.rsc.rpc.Rpc;
 import org.apache.livy.rsc.rpc.RpcDispatcher;
 import org.apache.livy.rsc.rpc.RpcServer;
-
 import static org.apache.livy.rsc.RSCConf.Entry.*;
 
 /**

--- a/rsc/src/main/java/org/apache/livy/rsc/ContextLauncher.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/ContextLauncher.java
@@ -44,6 +44,7 @@ import static java.nio.file.attribute.PosixFilePermission.*;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.Promise;
+import org.apache.livy.client.common.OperatingSystemUtils;
 import org.apache.spark.launcher.SparkLauncher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -299,9 +300,8 @@ class ContextLauncher {
         }
       }
     }
-
     File file = File.createTempFile("livyConf", ".properties");
-    Files.setPosixFilePermissions(file.toPath(), EnumSet.of(OWNER_READ, OWNER_WRITE));
+    OperatingSystemUtils.setOSAgnosticFilePermissions(file, EnumSet.of(OWNER_READ, OWNER_WRITE));
     //file.deleteOnExit();
 
     Writer writer = new OutputStreamWriter(new FileOutputStream(file), UTF_8);

--- a/rsc/src/main/java/org/apache/livy/rsc/driver/RSCDriver.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/driver/RSCDriver.java
@@ -17,13 +17,12 @@
 
 package org.apache.livy.rsc.driver;
 
+
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.file.Files;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -33,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import static java.nio.file.attribute.PosixFilePermission.*;
 
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
@@ -41,12 +41,12 @@ import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.livy.client.common.OperatingSystemUtils;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.livy.client.common.OperatingSystemUtils;
 import org.apache.livy.client.common.Serializer;
 import org.apache.livy.rsc.BaseProtocol;
 import org.apache.livy.rsc.BypassJobStatus;
@@ -56,8 +56,6 @@ import org.apache.livy.rsc.Utils;
 import org.apache.livy.rsc.rpc.Rpc;
 import org.apache.livy.rsc.rpc.RpcDispatcher;
 import org.apache.livy.rsc.rpc.RpcServer;
-
-import static java.nio.file.attribute.PosixFilePermission.*;
 import static org.apache.livy.rsc.RSCConf.Entry.*;
 
 /**
@@ -94,7 +92,9 @@ public class RSCDriver extends BaseProtocol {
   public RSCDriver(SparkConf conf, RSCConf livyConf) throws Exception {
 
     this.localTmpDir = Files.createTempDirectory("rsc-tmp").toFile();
-    OperatingSystemUtils.setOSAgnosticFilePermissions(this.localTmpDir, EnumSet.of(OWNER_READ, OWNER_WRITE, OWNER_EXECUTE));
+    OperatingSystemUtils.setOSAgnosticFilePermissions(this.localTmpDir, EnumSet.of(OWNER_READ,
+                                                                                   OWNER_WRITE,
+                                                                                   OWNER_EXECUTE));
 
     this.executor = Executors.newCachedThreadPool();
     this.jobQueue = new LinkedList<>();

--- a/rsc/src/main/java/org/apache/livy/rsc/driver/RSCDriver.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/driver/RSCDriver.java
@@ -24,13 +24,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutorService;
@@ -47,6 +41,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.livy.client.common.OperatingSystemUtils;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.slf4j.Logger;
@@ -62,6 +57,7 @@ import org.apache.livy.rsc.rpc.Rpc;
 import org.apache.livy.rsc.rpc.RpcDispatcher;
 import org.apache.livy.rsc.rpc.RpcServer;
 
+import static java.nio.file.attribute.PosixFilePermission.*;
 import static org.apache.livy.rsc.RSCConf.Entry.*;
 
 /**
@@ -96,9 +92,10 @@ public class RSCDriver extends BaseProtocol {
   private final AtomicBoolean inShutdown;
 
   public RSCDriver(SparkConf conf, RSCConf livyConf) throws Exception {
-    Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rwx------");
-    this.localTmpDir = Files.createTempDirectory("rsc-tmp",
-      PosixFilePermissions.asFileAttribute(perms)).toFile();
+
+    this.localTmpDir = Files.createTempDirectory("rsc-tmp").toFile();
+    OperatingSystemUtils.setOSAgnosticFilePermissions(this.localTmpDir, EnumSet.of(OWNER_READ, OWNER_WRITE, OWNER_EXECUTE));
+
     this.executor = Executors.newCachedThreadPool();
     this.jobQueue = new LinkedList<>();
     this.clients = new ConcurrentLinkedDeque<>();

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -19,13 +19,12 @@ package org.apache.livy
 
 import java.io.File
 import java.lang.{Boolean => JBoolean, Long => JLong}
+import java.util.function.{Consumer, Supplier}
 import java.util.{Map => JMap}
 
 import scala.collection.JavaConverters._
-
 import org.apache.hadoop.conf.Configuration
-
-import org.apache.livy.client.common.ClientConf
+import org.apache.livy.client.common.{ClientConf, OperatingSystemUtils}
 import org.apache.livy.client.common.ClientConf.ConfEntry
 import org.apache.livy.client.common.ClientConf.DeprecatedConf
 
@@ -335,7 +334,10 @@ class LivyConf(loadDefaults: Boolean) extends ClientConf[LivyConf](null) {
 
   /** Return the path to the spark-submit executable. */
   def sparkSubmit(): String = {
-    sparkHome().map { _ + File.separator + "bin" + File.separator + "spark-submit" }.get
+    val posixSupplier = new Supplier[String]() { override def get() = "spark-submit" };
+    val windowsSupplier = new Supplier[String]() { override def get() = "spark-submit.cmd" };
+    val sparkSubmit = OperatingSystemUtils.getBasedOnOs(posixSupplier, windowsSupplier, "Getting Spark Submit");
+    sparkHome().map { _ + File.separator + "bin" + File.separator + sparkSubmit }.get
   }
 
   private val configDir: Option[File] = {

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -19,11 +19,12 @@ package org.apache.livy
 
 import java.io.File
 import java.lang.{Boolean => JBoolean, Long => JLong}
-import java.util.function.{Consumer, Supplier}
 import java.util.{Map => JMap}
 
 import scala.collection.JavaConverters._
+
 import org.apache.hadoop.conf.Configuration
+
 import org.apache.livy.client.common.{ClientConf, OperatingSystemUtils}
 import org.apache.livy.client.common.ClientConf.ConfEntry
 import org.apache.livy.client.common.ClientConf.DeprecatedConf
@@ -334,9 +335,11 @@ class LivyConf(loadDefaults: Boolean) extends ClientConf[LivyConf](null) {
 
   /** Return the path to the spark-submit executable. */
   def sparkSubmit(): String = {
-    val posixSupplier = new Supplier[String]() { override def get() = "spark-submit" };
-    val windowsSupplier = new Supplier[String]() { override def get() = "spark-submit.cmd" };
-    val sparkSubmit = OperatingSystemUtils.getBasedOnOs(posixSupplier, windowsSupplier, "Getting Spark Submit");
+    val sparkSubmit = OperatingSystemUtils
+      .getBasedOnOS(
+        "spark-submit",
+        "spark-submit.cmd",
+        "Getting Spark Submit");
     sparkHome().map { _ + File.separator + "bin" + File.separator + sparkSubmit }.get
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The ability to start up a Livy server on a Windows Operating System. 
(https://issues.apache.org/jira/browse/LIVY-643)

This PR also partially resolves some of the test issues when building in a Windows environment as described in https://issues.apache.org/jira/browse/LIVY-611. It does not resolve all of the issues with running tests on a windows environment. For example integration tests will fail because of line 299 of MiniCluster.scala (sys.process.Process(s"pkill -f $simpleName")). I believe that with the changes in this PR, should be able to resolve LIVY-611 with a future PR. 

## How was this patch tested?

Unit tests for new class, and I was able to start up a livy server (with  java -cp "./jars/*;./conf;" org.apache.livy.server.LivyServer) on a Docker windows container and submit spark requests to the livy server successfully. 