### PR TITLE
[LIVY-648][DOC] Wrong return message in cancel statement documentation

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -305,7 +305,7 @@ Cancel the specified statement in this session.
   <tr><th>Name</th><th>Description</th><th>Type</th></tr>
   <tr>
     <td>msg</td>
-    <td>is always "cancelled"</td>
+    <td>is always "canceled"</td>
     <td>string</td>
   </tr>
 </table>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix the trivial mistake in the documentation. "Canceled" vs "cancelled" (two Ls).
See details in the ticket https://issues.apache.org/jira/browse/LIVY-648

Or better to change message here?
https://github.com/apache/incubator-livy/blob/ae961700d71fd1669dec4f396c8990d3d8c93759/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala#L149

## How was this patch tested?
not need any tests
