### PR TITLE
[LIVY-649] Use HTTP method DELETE instead of POST for statement cancellation API

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -295,7 +295,7 @@ Returns a specified statement in a session.
 The <a href="#statement">statement</a> object.
 
 
-### POST /sessions/{sessionId}/statements/{statementId}/cancel
+### DELETE /sessions/{sessionId}/statements/{statementId}
 
 Cancel the specified statement in this session.
 

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -142,7 +142,7 @@ class InteractiveSessionServlet(
     }
   }
 
-  post("/:id/statements/:statementId/cancel") {
+  delete("/:id/statements/:statementId") {
     withModifyAccessSession { session =>
       val statementId = params("statementId")
       session.cancelStatement(statementId.toInt)

--- a/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionServletSpec.scala
@@ -136,7 +136,7 @@ class InteractiveSessionServletSpec extends BaseInteractiveServletSpec {
       data("statements").asInstanceOf[Seq[Map[String, Any]]](0)("id") should be (0)
     }
 
-    jpost[Map[String, Any]]("/0/statements/0/cancel", null, HttpServletResponse.SC_OK) { data =>
+    jdelete[Map[String, Any]]("/0/statements/0") { data =>
       data should equal(Map("msg" -> "canceled"))
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Unify Livy REST API to use more common DELETE method instead of POST for statement cancellation API.
Before:
POST /sessions/{sessionId}/statements/{statementId}/cancel
After:
DELETE /sessions/{sessionId}/statements/{statementId}

https://issues.apache.org/jira/browse/LIVY-649

## How was this patch tested?
unit tests
manual verification:
![image](https://user-images.githubusercontent.com/31073930/63628303-681eb800-c614-11e9-9868-33c5a40a9e1f.png)

