### PR TITLE
[LIVY-652]Thrifserver doesn't set session name correctly

### DIFF
--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
@@ -228,7 +228,7 @@ class LivyThriftSessionManager(val server: LivyThriftServer, val livyConf: LivyC
       createInteractiveRequest.kind = Spark
       val newSession = InteractiveSession.create(
         server.livySessionManager.nextId(),
-        None,
+        createInteractiveRequest.name,
         username,
         None,
         server.livyConf,

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
@@ -404,10 +404,13 @@ class BinaryThriftServerSuite extends ThriftServerBaseTest with CommonThriftTest
     withJdbcConnection("default", Seq(s"livy.session.name=${testSessionName}")) { c =>
       // execute a statement and block until session is ready
       val statement = c.createStatement()
-      statement.executeQuery("select current_database()")
-      statement.close()
+      try {
+        statement.executeQuery("select current_database()")
+      } finally {
+        statement.close()
+      }
 
-      assert(!livySessionManager.get(testSessionName).isEmpty)
+      assert(livySessionManager.get(testSessionName).get.name.get == testSessionName)
     }
   }
 }

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
@@ -402,7 +402,7 @@ class BinaryThriftServerSuite extends ThriftServerBaseTest with CommonThriftTest
     val testSessionName = "MySessionName"
     assert(livySessionManager.get(testSessionName).isEmpty)
     withJdbcConnection("default", Seq(s"livy.session.name=${testSessionName}")) { c =>
-      //execute a statement and block until session is ready
+      // execute a statement and block until session is ready
       val statement = c.createStatement()
       statement.executeQuery("select current_database()")
       statement.close()

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
@@ -396,6 +396,20 @@ class BinaryThriftServerSuite extends ThriftServerBaseTest with CommonThriftTest
       getTypeInfoTest(c)
     }
   }
+
+  test("LIVY-652: should set session name correctly") {
+    val livySessionManager = LivyThriftServer.getInstance.get.livySessionManager
+    val testSessionName = "MySessionName"
+    assert(livySessionManager.get(testSessionName).isEmpty)
+    withJdbcConnection("default", Seq(s"livy.session.name=${testSessionName}")) { c =>
+      //execute a statement and block until session is ready
+      val statement = c.createStatement()
+      statement.executeQuery("select current_database()")
+      statement.close()
+
+      assert(!livySessionManager.get(testSessionName).isEmpty)
+    }
+  }
 }
 
 class HttpThriftServerSuite extends ThriftServerBaseTest with CommonThriftTests {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Thriftserver should set session name as the value passed in livy.session.name , but it current always set it NONE

## How was this patch tested?

add IT

https://issues.apache.org/jira/browse/LIVY-652
