### PR TITLE
[LIVY-633][Server] session should not be gc-ed for long running queries

### DIFF
--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -49,6 +49,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.livy</groupId>
+      <artifactId>livy-core_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>com.esotericsoftware.kryo</groupId>

--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -53,6 +53,8 @@
       <groupId>org.apache.livy</groupId>
       <artifactId>livy-core_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
+      <!-- Or it will conflict with repl jars -->
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
@@ -34,7 +34,6 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
-import org.apache.livy.sessions.SessionState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +44,7 @@ import org.apache.livy.client.common.BufferUtils;
 import org.apache.livy.rsc.driver.AddFileJob;
 import org.apache.livy.rsc.driver.AddJarJob;
 import org.apache.livy.rsc.rpc.Rpc;
+import org.apache.livy.sessions.SessionState;
 
 import static org.apache.livy.rsc.RSCConf.Entry.*;
 

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
@@ -34,6 +34,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
+import org.apache.livy.sessions.SessionState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -319,7 +320,7 @@ public class RSCClient implements LivyClient {
 
   /**
    * Get the timestamp of the last activity of the repl. It will be updated when the repl state
-   * changed from busy to others
+   * changed from busy to idle
    *
    * @return last activity timestamp
    */
@@ -423,8 +424,9 @@ public class RSCClient implements LivyClient {
 
     private void handle(ChannelHandlerContext ctx, ReplState msg) {
       LOG.trace("Received repl state for {}", msg.state);
-      // Update last activity timestamp when state change is from busy to others.
-      if ("busy".equals(replState) || !"busy".equals(msg.state)) {
+      // Update last activity timestamp when state change is from busy to idle.
+      if (SessionState.Busy.state().equals(replState) && msg != null &&
+        SessionState.Idle.state().equals(msg.state)) {
         replLastActivity = System.nanoTime();
       }
       replState = msg.state;

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
@@ -425,8 +425,8 @@ public class RSCClient implements LivyClient {
     private void handle(ChannelHandlerContext ctx, ReplState msg) {
       LOG.trace("Received repl state for {}", msg.state);
       // Update last activity timestamp when state change is from busy to idle.
-      if (SessionState.Busy.state().equals(replState) && msg != null &&
-        SessionState.Idle.state().equals(msg.state)) {
+      if (SessionState.Busy$.MODULE$.state().equals(replState) && msg != null &&
+        SessionState.Idle$.MODULE$.state().equals(msg.state)) {
         replLastActivity = System.nanoTime();
       }
       replState = msg.state;

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -626,4 +626,16 @@ class InteractiveSession(
   }
 
   override def infoChanged(appInfo: AppInfo): Unit = { this.appInfo = appInfo }
+
+  override def lastActivity: Long = {
+    val serverSideLastActivity = super.lastActivity
+    if (serverSideState == SessionState.Running) {
+      // If the rsc client is running, we compare the lastActivity of the session and the repl,
+      // and return the more latest one
+      client.flatMap(s => Option(s.getReplLastActivity)).filter(_ > serverSideLastActivity)
+        .getOrElse(serverSideLastActivity)
+    } else {
+      serverSideLastActivity
+    }
+  }
 }

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -632,7 +632,7 @@ class InteractiveSession(
     if (serverSideState == SessionState.Running) {
       // If the rsc client is running, we compare the lastActivity of the session and the repl,
       // and return the more latest one
-      client.flatMap(s => Option(s.getReplLastActivity)).filter(_ > serverSideLastActivity)
+      client.flatMap { s => Option(s.getReplLastActivity) }.filter(_ > serverSideLastActivity)
         .getOrElse(serverSideLastActivity)
     } else {
       serverSideLastActivity

--- a/server/src/main/scala/org/apache/livy/sessions/Session.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/Session.scala
@@ -154,6 +154,7 @@ abstract class Session(
 
   protected var _appId: Option[String] = None
 
+  @volatile
   private var _lastActivity = System.nanoTime()
 
   // Directory where the session's staging files are created. The directory is only accessible

--- a/server/src/main/scala/org/apache/livy/sessions/Session.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/Session.scala
@@ -154,7 +154,6 @@ abstract class Session(
 
   protected var _appId: Option[String] = None
 
-  @volatile
   private var _lastActivity = System.nanoTime()
 
   // Directory where the session's staging files are created. The directory is only accessible

--- a/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
@@ -247,6 +247,21 @@ class InteractiveSessionSpec extends FunSpec
       }
     }
 
+    withSession("should refresh last activity time when statement finished") { session =>
+      val code =
+        """
+          |from time import sleep
+          |sleep(3)
+        """.stripMargin
+      session.executeStatement(ExecuteRequest(code, None))
+      val executionBeginTime = session.lastActivity
+
+      eventually(timeout(10 seconds), interval(100 millis)) {
+        session.state should be(SessionState.Idle)
+        session.lastActivity should be > executionBeginTime
+      }
+    }
+
     withSession("should error out the session if the interpreter dies") { session =>
       session.executeStatement(ExecuteRequest("import os; os._exit(666)", None))
       eventually(timeout(30 seconds), interval(100 millis)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, Livy records the last activity time of the session before statement execution. If a statement runs too long, exceeding then the session timeout, the session will be garbage collected after the statement execution.

This should not be the expected behavior. The statement execution time should not be count into idle. We should update the last activity time after the statement execution.

We cannot be updated when session changes state from busy to idle in the Session class. So in this patch, we add a replLastActivity field into the rscClient, which will be updated when the repl state changes. So when session changes its state from busy to idle, this field will catch the time and finally reflect on the session last activity.

## How was this patch tested?
Manual test. Also, add a new unit test.

Existing unit tests and integration tests.
