### PR TITLE
[LIVY-657][TEST]Fix travis failed on should not create sessions with duplicate names

### DIFF
--- a/server/src/test/scala/org/apache/livy/sessions/SessionManagerSpec.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/SessionManagerSpec.scala
@@ -17,8 +17,6 @@
 
 package org.apache.livy.sessions
 
-import java.util.concurrent.TimeUnit
-
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -29,7 +27,7 @@ import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.mock.MockitoSugar.mock
 
-import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf, Utils}
+import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 import org.apache.livy.server.batch.{BatchRecoveryMetadata, BatchSession}
 import org.apache.livy.server.interactive.InteractiveSession
 import org.apache.livy.server.recovery.SessionStore

--- a/server/src/test/scala/org/apache/livy/sessions/SessionManagerSpec.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/SessionManagerSpec.scala
@@ -94,10 +94,11 @@ class SessionManagerSpec extends FunSpec with Matchers with LivyBaseUnitTestSuit
       an[IllegalArgumentException] should be thrownBy manager.register(session2)
       manager.get(session1.id).isDefined should be(true)
       manager.get(session2.id).isDefined should be(false)
-      Utils.waitUntil({ () => session2.stopped }, Duration(10, TimeUnit.SECONDS))
-      assert(!session1.stopped)
-      assert(session2.stopped)
-      manager.shutdown()
+      eventually(timeout(10 seconds), interval(100 millis)) {
+        session1.stopped should be(false)
+        session2.stopped should be(true)
+        manager.shutdown()
+      }
     }
 
     it("batch session should not be gc-ed until application is finished") {

--- a/server/src/test/scala/org/apache/livy/sessions/SessionManagerSpec.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/SessionManagerSpec.scala
@@ -17,6 +17,8 @@
 
 package org.apache.livy.sessions
 
+import java.util.concurrent.TimeUnit
+
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -27,7 +29,7 @@ import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.mock.MockitoSugar.mock
 
-import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
+import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf, Utils}
 import org.apache.livy.server.batch.{BatchRecoveryMetadata, BatchSession}
 import org.apache.livy.server.interactive.InteractiveSession
 import org.apache.livy.server.recovery.SessionStore
@@ -92,6 +94,7 @@ class SessionManagerSpec extends FunSpec with Matchers with LivyBaseUnitTestSuit
       an[IllegalArgumentException] should be thrownBy manager.register(session2)
       manager.get(session1.id).isDefined should be(true)
       manager.get(session2.id).isDefined should be(false)
+      Utils.waitUntil({ () => session2.stopped }, Duration(10, TimeUnit.SECONDS))
       assert(!session1.stopped)
       assert(session2.stopped)
       manager.shutdown()


### PR DESCRIPTION

## What changes were proposed in this pull request?

Fix travis failed on "should not create sessions with duplicate names"

The cause of failed is as follows:

1. When session2 was stopped, it will call stop() method in Session.scala asynchronously by Scala Future. So when assert(session2.stopped), if the stop() method has not been executed asynchronously, the test will fail.

## How was this patch tested?

Existed UT and IT.