### PR TITLE
[LIVY-659][TEST]Fix travis failed on can kill spark-submit while it's running

### DIFF
--- a/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
@@ -32,6 +32,7 @@ import org.apache.hadoop.yarn.util.ConverterUtils
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
+import org.scalatest.concurrent.Eventually
 import org.scalatest.FunSpec
 import org.scalatest.mock.MockitoSugar.mock
 
@@ -232,11 +233,13 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite {
           livyConf,
           mockYarnClient)
 
-        Utils.waitUntil({ () => app.isRunning }, Duration(10, TimeUnit.SECONDS))
-        cleanupThread(app.yarnAppMonitorThread) {
-          app.kill()
-          verify(mockSparkSubmit, times(1)).destroy()
-          sparkSubmitRunningLatch.countDown()
+        Eventually.eventually(Eventually.timeout(10 seconds), Eventually.interval(100 millis)) {
+          assert(app.isRunning)
+          cleanupThread(app.yarnAppMonitorThread) {
+            app.kill()
+            verify(mockSparkSubmit, times(1)).destroy()
+            sparkSubmitRunningLatch.countDown()
+          }
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix travis failed on "can kill spark-submit while it's running"

The cause of failed is as follows:

1. The test does not mock the method getApplicationReport of mockYarnClient, so yarnClient.getApplicationReport will return null.

2. If the thread yarnAppMonitorThread run before the test executing app.kill(), yarnAppMonitorThread will throw NullPointerException when execute appReport.getDiagnostics.

3. Then the NullPointerException was caught by yarnAppMonitorThread, and yarnAppMonitorThread changeState(SparkApp.State.FAILED).

4. At last, the test execute app.kill(), but the app state is FAILED, so it won't execute process.foreach(_.destroy()), which cause verify(mockSparkSubmit, times(1)).destroy() failed.

## How was this patch tested?

Existed UT and IT.
