### PR TITLE
[LIVY-644][TEST] Flaky test: Failed to execute goal org.jacoco:jacoco-maven-plugin:0.8.2:report-aggregate (jacoco-report) on project livy-coverage-report

### DIFF
--- a/integration-test/src/test/scala/org/apache/livy/test/InteractiveIT.scala
+++ b/integration-test/src/test/scala/org/apache/livy/test/InteractiveIT.scala
@@ -114,14 +114,16 @@ class InteractiveIT extends BaseIntegrationTestSuite {
   }
 
   test("application kills session") {
-    withNewSession(Spark) { s =>
+    val noCodeCoverageConf = s"${RSCConf.Entry.TEST_NO_CODE_COVERAGE_ANALYSIS.key()}"
+    withNewSession(Spark, Map(noCodeCoverageConf -> "true")) { s =>
       s.runFatalStatement("System.exit(0)")
     }
   }
 
   test("should kill RSCDriver if it doesn't respond to end session") {
     val testConfName = s"${RSCConf.LIVY_SPARK_PREFIX}${RSCConf.Entry.TEST_STUCK_END_SESSION.key()}"
-    withNewSession(Spark, Map(testConfName -> "true")) { s =>
+    val noCodeCoverageConf = s"${RSCConf.Entry.TEST_NO_CODE_COVERAGE_ANALYSIS.key()}"
+    withNewSession(Spark, Map(testConfName -> "true", noCodeCoverageConf -> "true")) { s =>
       val appId = s.appId()
       s.stop()
       val appReport = cluster.yarnClient.getApplicationReport(appId)

--- a/rsc/src/main/java/org/apache/livy/rsc/ContextLauncher.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/ContextLauncher.java
@@ -207,7 +207,7 @@ class ContextLauncher {
     if (!conf.getBoolean(CLIENT_IN_PROCESS) &&
         // For tests which doesn't shutdown RscDriver gracefully, JaCoCo exec isn't dumped properly.
         // Disable JaCoCo for this case.
-        !conf.getBoolean(TEST_STUCK_END_SESSION)) {
+        !conf.getBoolean(TEST_NO_CODE_COVERAGE_ANALYSIS)) {
       // For testing; propagate jacoco settings so that we also do coverage analysis
       // on the launched driver. We replace the name of the main file ("main.exec")
       // so that we don't end up fighting with the main test launcher.

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
@@ -71,6 +71,7 @@ public class RSCConf extends ClientConf<RSCConf> {
     SASL_MECHANISMS("rpc.sasl.mechanisms", "DIGEST-MD5"),
     SASL_QOP("rpc.sasl.qop", null),
 
+    TEST_NO_CODE_COVERAGE_ANALYSIS("test.do-not-use.no-code-coverage-analysis", false),
     TEST_STUCK_END_SESSION("test.do-not-use.stuck-end-session", false),
     TEST_STUCK_START_DRIVER("test.do-not-use.stuck-start-driver", false),
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This patch fixes the flaky test: Failed to execute goal org.jacoco:jacoco-maven-plugin:0.8.2:report-aggregate (jacoco-report) on project livy-coverage-report.

When JVM shutdown no gracefully in a test, the code coverage data file generated by jacoco may be corrupt. Jacoco will throw an exception when generate code coverage report.

In Livy integration test, two test cases shut down no gracefully(one of them uses System.exit). We can find random failure when jacoco process code coverage data file generated by that test case.

In this patch, we turn off the code coverage analysis on these two test cases.

## How was this patch tested?
Compare the jacoco data file generated in the integration test. Before the fix, there're 18 files, and after the fix there're 16 files, which means the fix works.

Run 10 builds on Travis each before and after the fix:
1. Before the fix: 3 builds failed due to the jacoco code coverage exception
2. After the fix: No build failed

Existing UTs and ITs.
