### PR TITLE
[WIP][LIVY-664][Server] Spark application still running when Livy session creating was rejected

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -133,7 +133,7 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
       } else {
         // LIVY-664: Check if name is duplicated before create a session
         val newSessionName = sessionName(request)
-        if (newSessionName.isDefined && sessionManager.get(newSessionName.get).isDefined) {
+        if (newSessionName.isDefined && sessionManager.contains(newSessionName.get)) {
           BadRequest(ResponseMessage(s"Duplicate session name: ${newSessionName.get}"))
         }
         val session = sessionManager.register(createSession(request))
@@ -166,7 +166,7 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
   protected def remoteUser(req: HttpServletRequest): String = req.getRemoteUser()
 
   /**
-   * Return the session name
+   * Returns the session name
    */
   protected def sessionName(req: HttpServletRequest): Option[String]
 

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
@@ -79,4 +79,8 @@ class BatchSessionServlet(
       session.state.toString, session.appId, session.appInfo, logs)
   }
 
+  override protected def sessionName(req: HttpServletRequest): Option[String] = {
+    val createRequest = bodyAs[CreateBatchRequest](req)
+    createRequest.name
+  }
 }

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -88,6 +88,11 @@ class InteractiveSessionServlet(
       session.appInfo.asJavaMap, logs.asJava)
   }
 
+  override protected def sessionName(req: HttpServletRequest): Option[String] = {
+    val createRequest = bodyAs[CreateInteractiveRequest](req)
+    createRequest.name
+  }
+
   post("/:id/stop") {
     withModifyAccessSession { session =>
       Await.ready(session.stop(), Duration.Inf)

--- a/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
@@ -117,6 +117,10 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
 
   def get(sessionName: String): Option[S] = sessionsByName.get(sessionName)
 
+  def contains(id: Int): Boolean = sessions.contains(id)
+
+  def contains(sessionName: String): Boolean = sessionName.contains(sessionName)
+
   def size(): Int = sessions.size
 
   def all(): Iterable[S] = sessions.values

--- a/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
@@ -80,6 +80,8 @@ object SessionServletSpec {
         }
         MockSessionView(session.id, session.owner, session.proxyUser, logs)
       }
+
+      override protected def sessionName(req: HttpServletRequest): Option[String] = None
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Check if the session name is duplicated before submitting the application.

## How was this patch tested?
Existing UTs and ITs.
