### PR TITLE
[LIVY-667][WIP] Collect a part of partition to the driver by batch to avoid OOM

### DIFF
--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/rpc/RpcClient.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/rpc/RpcClient.scala
@@ -50,7 +50,8 @@ class RpcClient(livySession: InteractiveSession) extends Logging {
       statementId,
       statement,
       defaultIncrementalCollect,
-      s"spark.${LivyConf.THRIFT_INCR_COLLECT_ENABLED}"))
+      s"spark.${LivyConf.THRIFT_INCR_COLLECT_ENABLED}",
+      livySession.livyConf.getInt(LivyConf.THRIFT_RESULTSET_DEFAULT_FETCH_SIZE)))
   }
 
   @throws[Exception]

--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ScalaRDDStreamIterator.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ScalaRDDStreamIterator.java
@@ -1,0 +1,31 @@
+package org.apache.livy.thriftserver.session;
+
+import java.util.Iterator;
+
+/**
+ * Wrapper that provides a Java iterator interface over a Scala iterator.
+ */
+class ScalaRDDStreamIterator<T> implements Iterator<T> {
+
+    private final RDDStreamIterator<T> it;
+
+    ScalaRDDStreamIterator(RDDStreamIterator<T> it) {
+        this.it = it;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return it.hasNext();
+    }
+
+    @Override
+    public T next() {
+        return it.next();
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/SqlJob.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/SqlJob.java
@@ -37,9 +37,10 @@ public class SqlJob implements Job<Void> {
   private final String statement;
   private final String defaultIncrementalCollect;
   private final String incrementalCollectEnabledProp;
+  private final Integer batchSize;
 
   public SqlJob() {
-    this(null, null, null, null, null);
+    this(null, null, null, null, null, Integer.MAX_VALUE);
   }
 
   public SqlJob(
@@ -47,12 +48,14 @@ public class SqlJob implements Job<Void> {
       String statementId,
       String statement,
       String defaultIncrementalCollect,
-      String incrementalCollectEnabledProp) {
+      String incrementalCollectEnabledProp,
+      Integer batchSize) {
     this.sessionId = sessionId;
     this.statementId = statementId;
     this.statement = statement;
     this.defaultIncrementalCollect = defaultIncrementalCollect;
     this.incrementalCollectEnabledProp = incrementalCollectEnabledProp;
+    this.batchSize = batchSize;
   }
 
   @Override
@@ -77,7 +80,7 @@ public class SqlJob implements Job<Void> {
 
     Iterator<Row> iter;
     if (incremental) {
-      iter = new ScalaIterator<>(df.rdd().toLocalIterator());
+      iter = new ScalaRDDStreamIterator<>(new RDDStreamIterator(df.rdd(), batchSize, spark.sparkContext(), scala.reflect.ClassTag$.MODULE$.apply(Row.class)));
     } else {
       iter = df.collectAsList().iterator();
     }

--- a/thriftserver/session/src/main/scala/org/apache/livy/thriftserver/session/RDDStreamIterator.scala
+++ b/thriftserver/session/src/main/scala/org/apache/livy/thriftserver/session/RDDStreamIterator.scala
@@ -1,0 +1,60 @@
+package org.apache.livy.thriftserver.session
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.SparkSession
+
+import scala.reflect.ClassTag
+
+class RDDStreamIterator[T: ClassTag] {
+  private var rdd: RDD[T] = _
+  private var batchSize: Int = _
+  private var sc: SparkContext = _
+  private var curPartitionIndex: Int = _
+  private var maxPartitionIndex: Int = _
+  private var curRowIndex: Int = _
+  private var partitionSizeList: Array[Int] = _
+
+  private var iter: Iterator[T] = _
+
+  def this(rdd: RDD[T], batchSize: Int, sc: SparkContext) = {
+    this()
+    this.rdd = rdd
+    this.batchSize = batchSize
+    this.sc = sc
+    this.curPartitionIndex = 0
+    this.maxPartitionIndex = rdd.partitions.length - 1
+    this.curRowIndex = 0
+    this.partitionSizeList = rdd.mapPartitions(iter => Iterator(iter.size), true).collect()
+    this.iter = collectPartitionByBatch(rdd, curRowIndex, batchSize, curPartitionIndex)
+  }
+
+  def collectPartitionByBatch[T:ClassTag](rdd: RDD[T], curRowIndex: Int, batchSize: Int, curPartitionIndex: Int): Iterator[T] = {
+    sc.runJob(rdd, (iter: Iterator[T]) => iter.slice(curRowIndex, curRowIndex + batchSize).toArray, Seq(curPartitionIndex)).head.iterator
+  }
+
+  def hasNext: Boolean = {
+    if(iter.hasNext) {
+      return true
+    }
+
+    if(curPartitionIndex > maxPartitionIndex) {
+      return false
+    }
+
+    iter = collectPartitionByBatch(rdd, curRowIndex, batchSize, curPartitionIndex)
+    if(curRowIndex + batchSize >= partitionSizeList(curPartitionIndex)) {
+      curPartitionIndex = curPartitionIndex + 1
+      curRowIndex = 0
+    } else {
+      curRowIndex = curRowIndex + batchSize
+    }
+
+    iter.hasNext
+  }
+
+  def next: T = {
+    iter.next()
+  }
+}

--- a/thriftserver/session/src/test/java/org/apache/livy/thriftserver/session/ThriftSessionTest.java
+++ b/thriftserver/session/src/test/java/org/apache/livy/thriftserver/session/ThriftSessionTest.java
@@ -201,7 +201,7 @@ public class ThriftSessionTest {
   }
 
   private SqlJob newSqlJob(String session, String stId, String statement) {
-    return new SqlJob(session, stId, statement, "true", "incrementalPropName");
+    return new SqlJob(session, stId, statement, "true", "incrementalPropName", Integer.MAX_VALUE);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Collecting a part of partition to the driver by batch to avoid OOM

Background:
1. When enable livy.server.thrift.incrementalCollect, thrift use "toLocalIterator" to load one partition at each time instead of the whole rdd to avoid OutOfMemory. However, if the largest partition is too big, the OutOfMemory still occurs.

2. This PR collect a part of partition to the driver by batch at each time to avoid OOM.

## How was this patch tested?

 create a big size of data into one partition and query them all.
