### PR TITLE
[LIVY-667][WIP] Collect a part of partition to the driver by batch to avoid OOM

### DIFF
--- a/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
@@ -81,7 +81,10 @@ public class RSCConf extends ClientConf<RSCConf> {
     RETAINED_SHARE_VARIABLES("retained.share-variables", 100),
 
     // Number of result rows to get for SQL Interpreters.
-    SQL_NUM_ROWS("sql.num-rows", 1000);
+    SQL_NUM_ROWS("sql.num-rows", 1000),
+
+    THRIFT_COLLECT_RDD_BATCH_ENABLED("thrift.collect.rdd.batch.enabled", false),
+    THRIFT_COLLECT_RDD_BATCH_SIZE("thrift.collect.rdd.batch.size", 100);
 
     private final String key;
     private final Object dflt;

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -100,7 +100,6 @@ object LivyConf {
 
   // Thrift configurations
   val THRIFT_SERVER_ENABLED = Entry("livy.server.thrift.enabled", false)
-  val THRIFT_INCR_COLLECT_ENABLED = Entry("livy.server.thrift.incrementalCollect", false)
   val THRIFT_SESSION_CREATION_TIMEOUT = Entry("livy.server.thrift.session.creationTimeout", "10m")
   // The following configs are the same present in Hive
   val THRIFT_RESULTSET_DEFAULT_FETCH_SIZE =

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -111,6 +111,10 @@ object InteractiveSession extends Logging {
       Option(builder.build().asInstanceOf[RSCClient])
     }
 
+    request.conf.foreach {
+      case (key, value) => livyConf.set(key, value)
+    }
+
     new InteractiveSession(
       id,
       name,

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
@@ -38,6 +38,7 @@ import org.apache.hive.service.server.ThreadFactoryWithGarbageCleanup
 
 import org.apache.livy.LivyConf
 import org.apache.livy.Logging
+import org.apache.livy.rsc.RSCConf
 import org.apache.livy.server.interactive.{CreateInteractiveRequest, InteractiveSession}
 import org.apache.livy.sessions.Spark
 import org.apache.livy.thriftserver.SessionStates._
@@ -535,6 +536,7 @@ object LivyThriftSessionManager extends Logging {
   // variable
   private val livySessionIdConfigKey = "set:hiveconf:livy.server.sessionId"
   private val livySessionConfRegexp = "set:hiveconf:livy.session.conf.(.*)".r
+  private val livyRSCConfRegexp = "set:hiveconf:livy.rsc.(.*)".r
   private val hiveVarPattern = "set:hivevar:(.*)".r
 
   private def convertConfValueToInt(key: String, value: String) = {
@@ -579,6 +581,8 @@ object LivyThriftSessionManager extends Logging {
                 createInteractiveRequest.heartbeatTimeoutInSecond = heartbeatTimeoutInSecond
               }
             case livySessionConfRegexp(livyConfKey) => extraLivyConf += (livyConfKey -> value)
+            case livyRSCConfRegexp(livyConfKey) =>
+              extraLivyConf += ((RSCConf.RSC_CONF_PREFIX + livyConfKey) -> value)
             // set the hivevars specified by the user
             case hiveVarPattern(confKey) => statements += s"set hivevar:${confKey.trim}=$value"
             case _ if key == livySessionIdConfigKey => // Ignore it, we handle it later

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/rpc/RpcClient.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/rpc/RpcClient.scala
@@ -20,12 +20,13 @@ package org.apache.livy.thriftserver.rpc
 import org.apache.hive.service.cli.SessionHandle
 
 import org.apache.livy._
+import org.apache.livy.rsc.RSCConf
 import org.apache.livy.server.interactive.InteractiveSession
 import org.apache.livy.thriftserver.session._
 
 class RpcClient(livySession: InteractiveSession) extends Logging {
   private val defaultIncrementalCollect =
-    livySession.livyConf.getBoolean(LivyConf.THRIFT_INCR_COLLECT_ENABLED).toString
+    livySession.livyConf.getBoolean(RSCConf.Entry.THRIFT_COLLECT_RDD_BATCH_ENABLED).toString
 
   private val rscClient = livySession.client.get
 
@@ -40,6 +41,7 @@ class RpcClient(livySession: InteractiveSession) extends Logging {
       sessionHandle: SessionHandle,
       statementId: String,
       statement: String): JobHandle[_] = {
+    val batchSize = livySession.livyConf.getInt(RSCConf.Entry.THRIFT_COLLECT_RDD_BATCH_SIZE)
     info(s"RSC client is executing SQL query: $statement, statementId = $statementId, session = " +
       sessionHandle)
     require(null != statementId, s"Invalid statementId specified. StatementId = $statementId")
@@ -50,7 +52,8 @@ class RpcClient(livySession: InteractiveSession) extends Logging {
       statementId,
       statement,
       defaultIncrementalCollect,
-      s"spark.${LivyConf.THRIFT_INCR_COLLECT_ENABLED}"))
+      s"spark.${RSCConf.Entry.THRIFT_COLLECT_RDD_BATCH_ENABLED}",
+      livySession.livyConf.getInt(RSCConf.Entry.THRIFT_COLLECT_RDD_BATCH_SIZE)));
   }
 
   @throws[Exception]

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/rpc/RpcClient.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/rpc/RpcClient.scala
@@ -41,7 +41,6 @@ class RpcClient(livySession: InteractiveSession) extends Logging {
       sessionHandle: SessionHandle,
       statementId: String,
       statement: String): JobHandle[_] = {
-    val batchSize = livySession.livyConf.getInt(RSCConf.Entry.THRIFT_COLLECT_RDD_BATCH_SIZE)
     info(s"RSC client is executing SQL query: $statement, statementId = $statementId, session = " +
       sessionHandle)
     require(null != statementId, s"Invalid statementId specified. StatementId = $statementId")

--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/RDDStreamIterator.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/RDDStreamIterator.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.thriftserver.session;
+
+import java.io.Serializable;
+import java.util.*;
+
+import scala.collection.JavaConversions;
+import scala.runtime.AbstractFunction1;
+
+import org.apache.spark.api.java.JavaRDD;
+
+class PartitionSampleFunction<T> extends AbstractFunction1<scala.collection.Iterator<T>, List<T>>
+        implements Serializable {
+    private int startIndex;
+    private int endIndex;
+
+    PartitionSampleFunction(int startIndex, int endIndex) {
+        this.startIndex = startIndex;
+        this.endIndex = endIndex;
+    }
+
+    @Override
+    public List<T> apply(scala.collection.Iterator<T> iterator) {
+        List<T> list = new ArrayList<>();
+        int index = 0;
+        T element = null;
+        while (iterator.hasNext()) {
+            element = iterator.next();
+            if (index >= startIndex && index < endIndex) {
+                list.add(element);
+            }
+            index++;
+            if (index > endIndex) {
+                break;
+            }
+        }
+
+        return list;
+    }
+}
+
+public class RDDStreamIterator<T> implements Iterator<T> {
+    private JavaRDD<T> rdd;
+    private Integer batchSize;
+    private Integer curPartitionIndex;
+    private Integer maxPartitionIndex;
+    private Integer curRowIndex;
+    private List<Integer> partitionSizeList;
+    private Iterator<T> iter;
+
+    public RDDStreamIterator(JavaRDD<T> rdd, Integer batchSize) {
+        this.rdd = rdd;
+        this.batchSize = batchSize;
+        this.curPartitionIndex = 0;
+        this.maxPartitionIndex = this.rdd.getNumPartitions() - 1;
+        this.curRowIndex = 0;
+        this.partitionSizeList = this.rdd.mapPartitions(iter -> {
+            int count = 0;
+            while(iter.hasNext()) {
+                iter.next();
+                count ++;
+            }
+            return Collections.singleton(count).iterator();
+        }).collect();
+        iter = (new ArrayList<T>()).iterator();
+    }
+
+    private Iterator<T> collectPartitionByBatch() {
+        List<Integer> partitions = Arrays.asList(curPartitionIndex);
+        List<T>[] batches = (List<T>[])rdd.context().runJob(rdd.rdd(),
+                new PartitionSampleFunction<T>(curRowIndex, curRowIndex + batchSize),
+                (scala.collection.Seq) JavaConversions.asScalaBuffer(partitions),
+                scala.reflect.ClassTag$.MODULE$.apply(List.class));
+        if (batches.length == 0) {
+            return (new ArrayList<T>()).iterator();
+        }
+        return batches[0].iterator();
+    }
+
+    public boolean hasNext() {
+        if(iter.hasNext()) {
+            return true;
+        }
+        if (curPartitionIndex > maxPartitionIndex) {
+            return false;
+        }
+
+        iter = collectPartitionByBatch();
+        if (curRowIndex + batchSize >= partitionSizeList.get(curPartitionIndex)) {
+            curPartitionIndex = curPartitionIndex + 1;
+            curRowIndex = 0;
+        } else {
+            curRowIndex = curRowIndex + batchSize;
+        }
+
+        return iter.hasNext();
+    }
+
+    public T next() {
+        return iter.next();
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/RDDStreamIterator.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/RDDStreamIterator.java
@@ -94,11 +94,34 @@ public class RDDStreamIterator<T> implements Iterator<T> {
     }
 
     public boolean hasNext() {
-        if(iter.hasNext()) {
+        if (iter.hasNext()) {
             return true;
         }
+
+        if (curPartitionIndex < maxPartitionIndex) {
+            return true;
+        }
+
+        if (curPartitionIndex == maxPartitionIndex &&
+                curRowIndex < partitionSizeList.get(curPartitionIndex)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public T next() {
+        if (iter.hasNext()) {
+            return iter.next();
+        }
+
         if (curPartitionIndex > maxPartitionIndex) {
-            return false;
+            return null;
+        }
+
+        if (curPartitionIndex == maxPartitionIndex &&
+                curRowIndex >= partitionSizeList.get(curPartitionIndex)) {
+            return null;
         }
 
         iter = collectPartitionByBatch();
@@ -109,10 +132,6 @@ public class RDDStreamIterator<T> implements Iterator<T> {
             curRowIndex = curRowIndex + batchSize;
         }
 
-        return iter.hasNext();
-    }
-
-    public T next() {
         return iter.next();
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Collecting a part of partition to the driver by batch to avoid OOM

Background:
1.When enable livy.server.thrift.incrementalCollect, thrift use "toLocalIterator" to load one partition at each time instead of the whole rdd to avoid OutOfMemory. However, if the largest partition is too big, the OutOfMemory still occurs.

2.This PR collect a part of partition to the driver by batch at each time to avoid OOM.

## How was this patch tested?

create a big size of data into one partition and query them all.
