### PR TITLE
[LIVY-683] Livy SQLInterpreter get empty array when extract date format rows to json

### DIFF
--- a/repl/src/main/scala/org/apache/livy/repl/SQLInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/SQLInterpreter.scala
@@ -91,6 +91,9 @@ class SQLInterpreter(
             // Convert java BigDecimal type to Scala BigDecimal, because current version of
             // Json4s doesn't support java BigDecimal as a primitive type (LIVY-455).
             case i: java.math.BigDecimal => BigDecimal(i)
+            // Convert java.sql.Date type data to String, because java.sql.Date cannot extracted
+            // correctly with Json4s (LIVY-683).
+            case d: java.sql.Date => d.toString
             case e => e
           }
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The issue link: [LIVY-683](https://issues.apache.org/jira/browse/LIVY-683)
to avoid this situation, we can transform date data to string data in rows, and this time rows can be extracted correctly.

## How was this patch tested?

manual test
