### PR TITLE
[LIVY-666] Support named interpreter groups

### DIFF
--- a/core/src/main/scala/org/apache/livy/msgs.scala
+++ b/core/src/main/scala/org/apache/livy/msgs.scala
@@ -28,7 +28,8 @@ case class Msg[T <: Content](msg_type: MsgType, content: T)
 
 sealed trait Content
 
-case class ExecuteRequest(code: String, kind: Option[String]) extends Content {
+case class ExecuteRequest(code: String, kind: Option[String],
+ interpreterGroup: Option[String] = None) extends Content {
   val msg_type = MsgType.execute_request
 }
 

--- a/repl/scala-2.11/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -21,7 +21,6 @@ import java.io.File
 import java.net.URLClassLoader
 import java.nio.file.{Files, Paths}
 
-import scala.collection.JavaConversions._
 import scala.tools.nsc.Settings
 import scala.tools.nsc.interpreter.Completion.ScalaCompleter
 import scala.tools.nsc.interpreter.IMain
@@ -61,7 +60,7 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
     settings.usejavacp.value = true
     settings.embeddedDefaults(Thread.currentThread().getContextClassLoader())
 
-    System.setProperty("scala.repl.name.line", "$line"+this.hashCode().toString());
+    System.setProperty("scala.repl.name.line", "$line" + this.hashCode().toString());
     sparkILoop = new SparkILoop(None, new JPrintWriter(outputStream, true))
     sparkILoop.settings = settings
     sparkILoop.createInterpreter()

--- a/repl/src/main/scala/org/apache/livy/repl/ReplDriver.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/ReplDriver.scala
@@ -55,7 +55,7 @@ class ReplDriver(conf: SparkConf, livyConf: RSCConf)
   }
 
   def handle(ctx: ChannelHandlerContext, msg: BaseProtocol.ReplJobRequest): Int = {
-    session.execute(EOLUtils.convertToSystemEOL(msg.code), msg.codeType)
+    session.execute(EOLUtils.convertToSystemEOL(msg.code), msg.codeType, msg.interpreterGroup)
   }
 
   def handle(ctx: ChannelHandlerContext, msg: BaseProtocol.CancelReplJobRequest): Unit = {

--- a/repl/src/test/scala/org/apache/livy/repl/ReplDriverSuite.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/ReplDriverSuite.scala
@@ -53,7 +53,7 @@ class ReplDriverSuite extends FunSuite with LivyBaseUnitTestSuite {
       // This is sort of what InteractiveSession.scala does to detect an idle session.
       client.submit(new PingJob()).get(60, TimeUnit.SECONDS)
 
-      val statementId = client.submitReplCode("1 + 1", "spark").get
+      val statementId = client.submitReplCode("1 + 1", "spark", null).get
       eventually(timeout(30 seconds), interval(100 millis)) {
         val rawResult =
           client.getReplJobResults(statementId, 1).get(10, TimeUnit.SECONDS).statements(0)

--- a/rsc/src/main/java/org/apache/livy/rsc/BaseProtocol.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/BaseProtocol.java
@@ -174,14 +174,16 @@ public abstract class BaseProtocol extends RpcDispatcher {
 
     public final String code;
     public final String codeType;
+    public final String interpreterGroup;
 
-    public ReplJobRequest(String code, String codeType) {
+    public ReplJobRequest(String code, String codeType, String interpreterGroup) {
       this.code = code;
       this.codeType = codeType;
+      this.interpreterGroup = interpreterGroup;
     }
 
     public ReplJobRequest() {
-      this(null, null);
+      this(null, null, null);
     }
   }
 

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
@@ -289,8 +289,10 @@ public class RSCClient implements LivyClient {
     return contextInfo;
   }
 
-  public Future<Integer> submitReplCode(String code, String codeType) throws Exception {
-    return deferredCall(new BaseProtocol.ReplJobRequest(code, codeType), Integer.class);
+  public Future<Integer> submitReplCode(String code, String codeType,
+   String interpreterGroup) throws Exception {
+    return deferredCall(new BaseProtocol.ReplJobRequest(code, codeType, interpreterGroup),
+     Integer.class);
   }
 
   public void cancelReplCode(int statementId) throws Exception {

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -509,7 +509,8 @@ class InteractiveSession(
     ensureRunning()
     recordActivity()
 
-    val id = client.get.submitReplCode(content.code, content.kind.orNull).get
+    val id = client.get.submitReplCode(content.code, content.kind.orNull,
+     content.interpreterGroup.orNull).get
     client.get.getReplJobResults(id, 1).get().statements(0)
   }
 

--- a/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionServletSpec.scala
@@ -129,6 +129,15 @@ class InteractiveSessionServletSpec extends BaseInteractiveServletSpec {
       data("code") shouldBe "1+1"
       data("progress") should be (0.0)
       data("output") shouldBe 1
+      data("interpreterGroup") shouldBe "default"
+    }
+
+    jpost[Map[String, Any]]("/0/statements", ExecuteRequest("foo", Some("spark"), Some("foo-group"))) { data =>
+      data("id") should be (0)
+      data("code") shouldBe "1+1"
+      data("progress") should be (0.0)
+      data("output") shouldBe 1
+      data("interpreterGroup") shouldBe "foo-group"
     }
 
     jget[Map[String, Any]]("/0/statements") { data =>

--- a/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionServletSpec.scala
@@ -132,7 +132,8 @@ class InteractiveSessionServletSpec extends BaseInteractiveServletSpec {
       data("interpreterGroup") shouldBe "default"
     }
 
-    jpost[Map[String, Any]]("/0/statements", ExecuteRequest("foo", Some("spark"), Some("foo-group"))) { data =>
+    jpost[Map[String, Any]]("/0/statements", ExecuteRequest("foo", Some("spark"),
+     Some("foo-group"))) { data =>
       data("id") should be (0)
       data("code") shouldBe "1+1"
       data("progress") should be (0.0)

--- a/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
@@ -74,8 +74,9 @@ class InteractiveSessionSpec extends FunSpec
       sessionStore, mockApp)
   }
 
-  private def executeStatement(code: String, codeType: Option[String] = None): JValue = {
-    val id = session.executeStatement(ExecuteRequest(code, codeType)).id
+  private def executeStatement(code: String, codeType: Option[String] = None, interpreterGroup:
+   Option[String] = None): JValue = {
+    val id = session.executeStatement(ExecuteRequest(code, codeType, interpreterGroup)).id
     eventually(timeout(30 seconds), interval(100 millis)) {
       val s = session.getStatement(id).get
       s.state.get() shouldBe StatementState.Available
@@ -260,6 +261,27 @@ class InteractiveSessionSpec extends FunSpec
         session.state should be(SessionState.Idle)
         session.lastActivity should be > executionBeginTime
       }
+    }
+
+    withSession("should scope the execution to the interpreter group") { session =>
+      val resultFromGroup1 = executeStatement("val a=10\nprint(a)", Some("spark"), Some("intpGroup1"))
+      resultFromGroup1 should equal (Extraction.decompose(Map(
+        "status" -> "ok",
+        "execution_count" -> 5,
+        "data" -> Map("text/plain" -> "res0: Int = 10\n")))
+      )
+
+      val resultFromGroup2 = executeStatement("print(a)", Some("spark"), Some("intpGroup2"))
+      resultFromGroup2 should equal (Extraction.decompose(Map(
+        "status" -> "error",
+        "execution_count" -> 6,
+        "ename" -> "NameError",
+        "evalue" -> "name 'a' is not defined",
+        "traceback" -> List(
+          "Traceback (most recent call last):\n",
+          "NameError: name 'a' is not defined\n"
+        )
+      )))
     }
 
     withSession("should error out the session if the interpreter dies") { session =>

--- a/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
@@ -264,7 +264,8 @@ class InteractiveSessionSpec extends FunSpec
     }
 
     withSession("should scope the execution to the interpreter group") { session =>
-      val resultFromGroup1 = executeStatement("val a=10\nprint(a)", Some("spark"), Some("intpGroup1"))
+      val resultFromGroup1 = executeStatement("val a=10\nprint(a)", Some("spark"),
+       Some("intpGroup1"))
       resultFromGroup1 should equal (Extraction.decompose(Map(
         "status" -> "ok",
         "execution_count" -> 5,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, a session contains only one interpreter group. For a new REPL of the same type, a new session has to be created. In order to support use case of multiple REPLs attached to the same spark application with separate variable scoping (similar to scoped interpreter mode in Zeppelin: https://zeppelin.apache.org/docs/0.8.0/usage/interpreter/interpreter_binding_mode.html#scoped-mode), this change adds support for having multiple interpreter groups in a session. The interpreter group on which the execution has to done can be specified via the statement execution API.

The detailed proposal is on the Jira: https://issues.apache.org/jira/browse/LIVY-666

The changes are backward compatible.

## How was this patch tested?
Tested manually on laptop by running Livy standalone. Tried running a few commands and verified the functionality.
Created a scala session:
`curl -i -X POST -H "Content-Type: application/json" -d '{"name":"test", "kind":"scala"}' localhost:8998/sessions`

`curl localhost:8998/sessions/0/statements -X POST -H 'Content-Type: application/json' -d '{"code":"val a=5", "interpreterGroup":"g1"}'`
`curl localhost:8998/sessions/0/statements -X POST -H 'Content-Type: application/json' -d '{"code":"print(a)", "interpreterGroup":"g1"}'`
prints 5
`curl localhost:8998/sessions/0/statements -X POST -H 'Content-Type: application/json' -d '{"code":"print(a)", "interpreterGroup":"g2"}'`
'a' is not defined

I have added a few unit tests but couldn't run those since other tests are failing. Verifying that the tests work as expected is in progress.
