### PR TITLE
[LIVY-688] Error message of BypassJobStatus should contains cause information of Exception

### DIFF
--- a/rsc/src/main/java/org/apache/livy/rsc/Utils.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/Utils.java
@@ -20,6 +20,7 @@ package org.apache.livy.rsc;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.google.common.base.Throwables;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 
@@ -91,13 +92,7 @@ public class Utils {
   }
 
   public static String stackTraceAsString(Throwable t) {
-    StringBuilder sb = new StringBuilder();
-    sb.append(t.getClass().getName()).append(": ").append(t.getMessage());
-    for (StackTraceElement e : t.getStackTrace()) {
-      sb.append("\n");
-      sb.append(e.toString());
-    }
-    return sb.toString();
+    return Throwables.getStackTraceAsString(t);
   }
 
   public static <T> void addListener(Future<T> future, final FutureListener<T> lsnr) {

--- a/rsc/src/main/java/org/apache/livy/rsc/Utils.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/Utils.java
@@ -17,10 +17,11 @@
 
 package org.apache.livy.rsc;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.google.common.base.Throwables;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 
@@ -92,7 +93,9 @@ public class Utils {
   }
 
   public static String stackTraceAsString(Throwable t) {
-    return Throwables.getStackTraceAsString(t);
+    StringWriter stringWriter = new StringWriter();
+    t.printStackTrace(new PrintWriter(stringWriter));
+    return stringWriter.toString();
   }
 
   public static <T> void addListener(Future<T> future, final FutureListener<T> lsnr) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Change the implement of org.apache.livy.rsc.Utils.stackTraceAsString to guava Throwables.getStackTraceAsString, so that user can receive details of error message by calling org.apache.livy.client.http.JobHandleImpl.get.

https://issues.apache.org/jira/browse/LIVY-688
