### PR TITLE
[LIVY-690][Thrift] Exclude curator in thrift server pom to avoid conflict jars

### DIFF
--- a/thriftserver/server/pom.xml
+++ b/thriftserver/server/pom.xml
@@ -58,6 +58,10 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, thrift server has a dependency of curator-client:2.12.0 through the hive service. After the build, a `curator-client-2.12.0.jar` file will be generated in the `jars` folder. It is conflicted with the `curator-client-2.7.1.jar` file, which is used by livy server.

We observed that in some JDK, the `curator-client-2.12.0.jar` is loaded before the `curator-client-2.7.1.jar`, and will crash the recovery enabled livy server.

In this patch, we exclude the `org.apache.curator` modules from the hive dependency. 

## How was this patch tested?
Manual test and existing UT/ITs
