### PR TITLE
[LIVY-541][WIP] Generate the unqiue session id when multiple livy servers work at the same time

### DIFF
--- a/client-http/src/test/scala/org/apache/livy/client/http/HttpClientSpec.scala
+++ b/client-http/src/test/scala/org/apache/livy/client/http/HttpClientSpec.scala
@@ -266,7 +266,7 @@ private class HttpClientTestBootstrap extends LifeCycle {
   override def init(context: ServletContext): Unit = {
     val conf = new LivyConf()
     val stateStore = mock(classOf[SessionStore])
-    val sessionManager = new InteractiveSessionManager(conf, stateStore, Some(Seq.empty))
+    val sessionManager = new InteractiveSessionManager(conf, stateStore, None, Some(Seq.empty))
     val accessManager = new AccessManager(conf)
     val servlet = new InteractiveSessionServlet(sessionManager, stateStore, conf, accessManager) {
       override protected def createSession(req: HttpServletRequest): InteractiveSession = {

--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -107,6 +107,11 @@
 # Must set livy.server.recovery.state-store and livy.server.recovery.state-store.url to
 # configure the state store.
 # livy.server.recovery.mode = off
+# Whether to enable HA with multi-active mode, by default it is false.
+# If it is enabled, must set livy.server.zookeeper.url
+# livy.server.ha.multi-active.enabled = false
+# Zookeeper address used for HA and state store. e.g. host1:port1, host2:port2
+# livy.server.zookeeper.url =
 
 # Where Livy should store state to for recovery. Possible values:
 # <empty>: Default. State store disabled.
@@ -116,7 +121,7 @@
 
 # For filesystem state store, the path of the state store directory. Please don't use a filesystem
 # that doesn't support atomic rename (e.g. S3). e.g. file:///tmp/livy or hdfs:///.
-# For zookeeper, the address to the Zookeeper servers. e.g. host1:port1,host2:port2
+# For zookeeper, please set livy.server.zookeeper.url
 # livy.server.recovery.state-store.url =
 
 # If Livy can't find the yarn app within this time, consider it lost.

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -177,6 +177,16 @@ object LivyConf {
    * configure the state store.
    */
   val RECOVERY_MODE = Entry("livy.server.recovery.mode", "off")
+
+  /**
+    * Whether to enable HA with multi-active mode, by default it is false.
+    * If it is enabled, must set livy.server.zookeeper.url.
+    */
+  val HA_MULTI_ACTIVE_ENABLED = Entry("livy.server.ha.multi-active.enabled", false)
+
+  // Zookeeper address used for HA and state store. e.g. host1:port1, host2:port2
+  val ZOOKEEPER_URL = Entry("livy.server.zookeeper.url", "")
+
   /**
    * Where Livy should store state to for recovery. Possible values:
    * <empty>: Default. State store disabled.
@@ -187,7 +197,7 @@ object LivyConf {
   /**
    * For filesystem state store, the path of the state store directory. Please don't use a
    * filesystem that doesn't support atomic rename (e.g. S3). e.g. file:///tmp/livy or hdfs:///.
-   * For zookeeper, the address to the Zookeeper servers. e.g. host1:port1,host2:port2
+   * For zookeeper, please set livy.server.zookeeper.url
    */
   val RECOVERY_STATE_STORE_URL = Entry("livy.server.recovery.state-store.url", "")
 

--- a/server/src/main/scala/org/apache/livy/server/recovery/SessionStore.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/SessionStore.scala
@@ -50,6 +50,8 @@ class SessionStore(
     store.set(sessionManagerPath(sessionType), SessionManagerState(id))
   }
 
+  def getStore: StateStore = store
+
   /**
    * Return all sessions stored in the store with specified session type.
    */

--- a/server/src/main/scala/org/apache/livy/server/recovery/StateStore.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/StateStore.scala
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 
 import org.apache.livy.{LivyConf, Logging}
+import org.apache.livy.server.recovery.ZooKeeperManager
 import org.apache.livy.sessions.SessionKindModule
 import org.apache.livy.sessions.SessionManager._
 
@@ -78,11 +79,17 @@ abstract class StateStore(livyConf: LivyConf) extends JsonMapper {
 object StateStore extends Logging {
   private[this] var stateStore: Option[StateStore] = None
 
-  def init(livyConf: LivyConf): Unit = synchronized {
+  def init(livyConf: LivyConf, zkManager: Option[ZooKeeperManager] = None): Unit = synchronized {
     if (stateStore.isEmpty) {
       val fileStateStoreClassTag = pickStateStore(livyConf)
-      stateStore = Option(fileStateStoreClassTag.getDeclaredConstructor(classOf[LivyConf])
-        .newInstance(livyConf).asInstanceOf[StateStore])
+      if (fileStateStoreClassTag == classOf[ZooKeeperStateStore]) {
+        stateStore = Option(fileStateStoreClassTag.
+          getDeclaredConstructor(classOf[LivyConf], classOf[ZooKeeperManager]).
+          newInstance(livyConf, zkManager.get).asInstanceOf[StateStore])
+      } else {
+        stateStore = Option(fileStateStoreClassTag.getDeclaredConstructor(classOf[LivyConf])
+          .newInstance(livyConf).asInstanceOf[StateStore])
+      }
       info(s"Using ${stateStore.get.getClass.getSimpleName} for recovery.")
     }
   }

--- a/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperManager.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperManager.scala
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.server.recovery
+
+import scala.collection.JavaConverters._
+import scala.reflect.ClassTag
+
+import org.apache.curator.framework.api.UnhandledErrorListener
+import org.apache.curator.framework.CuratorFramework
+import org.apache.curator.framework.CuratorFrameworkFactory
+import org.apache.curator.framework.recipes.locks.InterProcessSemaphoreMutex
+import org.apache.curator.retry.RetryNTimes
+import org.apache.zookeeper.KeeperException.NoNodeException
+
+import org.apache.livy.LivyConf
+import org.apache.livy.LivyConf.Entry
+
+object ZooKeeperManager {
+  val ZK_KEY_PREFIX_CONF = Entry("livy.server.recovery.zk-state-store.key-prefix", "livy")
+  val ZK_RETRY_CONF = Entry("livy.server.recovery.zk-state-store.retry-policy", "5,100")
+}
+
+class ZooKeeperManager(
+    livyConf: LivyConf,
+    mockCuratorClient: Option[CuratorFramework] = None,
+    mockDistributedLock: Option[InterProcessSemaphoreMutex] = None) extends JsonMapper{
+
+  import ZooKeeperManager._
+
+  // Constructor defined for StateStore factory to new this class using reflection.
+  def this(livyConf: LivyConf) {
+    this(livyConf, None)
+  }
+
+  private val zkAddress = livyConf.get(LivyConf.ZOOKEEPER_URL)
+  require(!zkAddress.isEmpty, s"Please config ${LivyConf.RECOVERY_STATE_STORE_URL.key}.")
+  private val zkKeyPrefix = livyConf.get(ZK_KEY_PREFIX_CONF)
+  private val retryValue = livyConf.get(ZK_RETRY_CONF)
+  // a regex to match patterns like "m, n" where m and n both are integer values
+  private val retryPattern = """\s*(\d+)\s*,\s*(\d+)\s*""".r
+  private[recovery] val retryPolicy = retryValue match {
+    case retryPattern(n, sleepMs) => new RetryNTimes(n.toInt, sleepMs.toInt)
+    case _ => throw new IllegalArgumentException(
+      s"$ZK_KEY_PREFIX_CONF contains bad value: $retryValue. " +
+        "Correct format is <max retry count>,<sleep ms between retry>. e.g. 5,100")
+  }
+
+  private val curatorClient = mockCuratorClient.getOrElse {
+    CuratorFrameworkFactory.newClient(zkAddress, retryPolicy)
+  }
+
+  private val lockPath = prefixKey("distributedLock")
+  private[recovery] val distributedLock = mockDistributedLock.getOrElse {
+    new InterProcessSemaphoreMutex(curatorClient, lockPath)
+  }
+
+  Runtime.getRuntime.addShutdownHook(new Thread(new Runnable {
+    override def run(): Unit = {
+      curatorClient.close()
+    }
+  }))
+
+  curatorClient.getUnhandledErrorListenable().addListener(new UnhandledErrorListener {
+    def unhandledError(message: String, e: Throwable): Unit = {
+      error(s"Fatal Zookeeper error. Shutting down Livy server.")
+      System.exit(1)
+    }
+  })
+  curatorClient.start()
+  // TODO Make sure ZK path has proper secure permissions so that other users cannot read its
+  // contents.
+
+  def set(key: String, value: Object): Unit = {
+    val prefixedKey = prefixKey(key)
+    val data = serializeToBytes(value)
+    if (curatorClient.checkExists().forPath(prefixedKey) == null) {
+      curatorClient.create().creatingParentsIfNeeded().forPath(prefixedKey, data)
+    } else {
+      curatorClient.setData().forPath(prefixedKey, data)
+    }
+  }
+
+  def get[T: ClassTag](key: String): Option[T] = {
+    val prefixedKey = prefixKey(key)
+    if (curatorClient.checkExists().forPath(prefixedKey) == null) {
+      None
+    } else {
+      Option(deserialize[T](curatorClient.getData().forPath(prefixedKey)))
+    }
+  }
+
+  def getChildren(key: String): Seq[String] = {
+    val prefixedKey = prefixKey(key)
+    if (curatorClient.checkExists().forPath(prefixedKey) == null) {
+      Seq.empty[String]
+    } else {
+      curatorClient.getChildren.forPath(prefixedKey).asScala
+    }
+  }
+
+  def remove(key: String): Unit = {
+    try {
+      curatorClient.delete().guaranteed().forPath(prefixKey(key))
+    } catch {
+      case _: NoNodeException =>
+    }
+  }
+
+  def lock(): Unit = {
+    distributedLock.acquire()
+  }
+
+  def unlock(): Unit = {
+    distributedLock.release()
+  }
+
+  private def prefixKey(key: String) = s"/$zkKeyPrefix/$key"
+}

--- a/server/src/main/scala/org/apache/livy/sessions/SessionIdGenerator.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/SessionIdGenerator.scala
@@ -14,34 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.livy.server.recovery
 
-import scala.reflect.ClassTag
+package org.apache.livy.sessions
 
-import org.apache.livy.{LivyConf, Logging}
+/**
+  * Interface of session id generator.
+  */
+abstract class SessionIdGenerator {
+  /**
+    * Get next session id, then increase next session id and save it in store.
+    */
+  def getNextSessionId(): Int
 
-class ZooKeeperStateStore(
-    livyConf: LivyConf,
-    zkManager: ZooKeeperManager)
-  extends StateStore(livyConf) with Logging {
-
-  override def set(key: String, value: Object): Unit = {
-    zkManager.set(key, value)
-  }
-
-  override def get[T: ClassTag](key: String): Option[T] = {
-    zkManager.get(key)
-  }
-
-  override def getChildren(key: String): Seq[String] = {
-    zkManager.getChildren(key)
-  }
-
-  override def remove(key: String): Unit = {
-    zkManager.remove(key)
-  }
-
-  def getZooKeeperManager(): ZooKeeperManager = {
-    return zkManager
-  }
+  /**
+    * recover next session id from store.
+    */
+  def recover(): Unit
 }

--- a/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
@@ -55,6 +55,7 @@ object SessionServletSpec {
       { _ => assert(false).asInstanceOf[Session] },
       mock[SessionStore],
       "test",
+      None,
       Some(Seq.empty))
 
     val accessManager = new AccessManager(conf)

--- a/server/src/test/scala/org/apache/livy/server/batch/BatchServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/BatchServletSpec.scala
@@ -56,7 +56,7 @@ class BatchServletSpec extends BaseSessionServletSpec[BatchSession, BatchRecover
     val sessionStore = mock[SessionStore]
     val accessManager = new AccessManager(livyConf)
     new BatchSessionServlet(
-      new BatchSessionManager(livyConf, sessionStore, Some(Seq.empty)),
+      new BatchSessionManager(livyConf, sessionStore, None, Some(Seq.empty)),
       sessionStore,
       livyConf,
       accessManager)

--- a/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionServletSpec.scala
@@ -98,7 +98,8 @@ class InteractiveSessionServletSpec extends BaseInteractiveServletSpec {
 
   override def createServlet(): InteractiveSessionServlet = {
     val conf = createConf()
-    val sessionManager = new InteractiveSessionManager(conf, mock[SessionStore], Some(Seq.empty))
+    val sessionManager = new InteractiveSessionManager(conf,
+      mock[SessionStore], None, Some(Seq.empty))
     val accessManager = new AccessManager(conf)
     new MockInteractiveSessionServlet(sessionManager, conf, accessManager)
   }

--- a/server/src/test/scala/org/apache/livy/server/interactive/JobApiSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/JobApiSpec.scala
@@ -48,7 +48,7 @@ class JobApiSpec extends BaseInteractiveServletSpec {
   override def createServlet(): InteractiveSessionServlet = {
     val conf = createConf()
     val sessionStore = mock[SessionStore]
-    val sessionManager = new InteractiveSessionManager(conf, sessionStore, Some(Seq.empty))
+    val sessionManager = new InteractiveSessionManager(conf, sessionStore, None, Some(Seq.empty))
     val accessManager = new AccessManager(conf)
     new InteractiveSessionServlet(sessionManager, sessionStore, conf, accessManager)
       with RemoteUserOverride

--- a/server/src/test/scala/org/apache/livy/server/interactive/SessionHeartbeatSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/SessionHeartbeatSpec.scala
@@ -64,6 +64,7 @@ class SessionHeartbeatSpec extends FunSpec with Matchers {
         { _ => assert(false).asInstanceOf[TestSession] },
         mock[SessionStore],
         "test",
+        None,
         Some(Seq.empty))
         with SessionHeartbeatWatchdog[TestSession, RecoveryMetadata] {}
 

--- a/server/src/test/scala/org/apache/livy/sessions/SessionManagerSpec.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/SessionManagerSpec.scala
@@ -44,6 +44,7 @@ class SessionManagerSpec extends FunSpec with Matchers with LivyBaseUnitTestSuit
       { _ => assert(false).asInstanceOf[MockSession] },
       mock[SessionStore],
       "test",
+      None,
       Some(Seq.empty))
     (livyConf, manager)
   }
@@ -247,7 +248,7 @@ class SessionManagerSpec extends FunSpec with Matchers with LivyBaseUnitTestSuit
       val sessionStore = mock[SessionStore]
       val session = mockSession(sessionId)
 
-      val sm = new BatchSessionManager(conf, sessionStore, Some(Seq(session)))
+      val sm = new BatchSessionManager(conf, sessionStore, None, Some(Seq(session)))
       sm.get(sessionId) shouldBe defined
 
       Await.ready(sm.delete(sessionId).get, 30 seconds)
@@ -262,7 +263,7 @@ class SessionManagerSpec extends FunSpec with Matchers with LivyBaseUnitTestSuit
       val sessionStore = mock[SessionStore]
       val session = mockSession(sessionId)
 
-      val sm = new BatchSessionManager(conf, sessionStore, Some(Seq(session)))
+      val sm = new BatchSessionManager(conf, sessionStore, None, Some(Seq(session)))
       sm.get(sessionId) shouldBe defined
       sm.shutdown()
 
@@ -277,7 +278,7 @@ class SessionManagerSpec extends FunSpec with Matchers with LivyBaseUnitTestSuit
       val sessionStore = mock[SessionStore]
       val session = mockSession(sessionId)
 
-      val sm = new BatchSessionManager(conf, sessionStore, Some(Seq(session)))
+      val sm = new BatchSessionManager(conf, sessionStore, None, Some(Seq(session)))
       sm.get(sessionId) shouldBe defined
       sm.shutdown()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

[LIVY-541] Generate the unqiue session id when multiple livy servers work at the same time

1. When generate unique session id with multiple livy servers working. First, get the distributed lock,
  Second, get the session id from the filesystem or zookeeper. Third, increase the sessionid and save it in  the filesystem or zookeeper. Forth, release the distributed lock.

2.  ZooKeeperManager provides the distributed lock to generate the unique session id.

3. If set recovery.mode = off, i.e. generate session id in BlackholeStateStore,  and set multi-active.enabled = true, store the session id in zookeeper.
If set recovery.mode = off, and set multi-active.enabled = false, store the session id in memory, i.e. stateMap


## How was this patch tested?

1. Start multiple livy servers and set multi-active.enabled = true.
2. Set zookeeper.url or state-store.url to save session id.
3. Create session in different livy servers at the same time.
4. Check the session id without duplicating. 
