### PR TITLE
[LIVY-692][THRIFT] Use configured principal for Kerberos authentication

### DIFF
--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/auth/AuthBridgeServer.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/auth/AuthBridgeServer.scala
@@ -40,12 +40,9 @@ import org.apache.livy.Logging
  * The class is taken from Hive's `HadoopThriftAuthBridge.Server`. It bridges Thrift's SASL
  * transports to Hadoop's SASL callback handlers and authentication classes.
  */
-class AuthBridgeServer(private val secretManager: LivyDelegationTokenSecretManager) {
-  private val ugi = try {
-      UserGroupInformation.getCurrentUser
-    } catch {
-      case ioe: IOException => throw new TTransportException(ioe)
-    }
+class AuthBridgeServer(
+    private val secretManager: LivyDelegationTokenSecretManager,
+    private val ugi: UserGroupInformation) {
 
   /**
    * Create a TTransportFactory that, upon connection of a client socket,


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/LIVY-692
Currently, if Kerberos authentication is used in the Thrift server (livy.server.thrift.authentication=kerberos), the `TTransportFactory` used in the `ThriftCLIService` uses a `UserGroupInformation` for the service (livy) principal; instead it should use a `UserGroupInformation` for the principal specified in livy.server.auth.kerberos.principal.

## How was this patch tested?

Manual testing with both a Livy Thrift server using Kerberos authentication and one using simple authentication.
