### PR TITLE
[LIVY-336][SERVER] Livy should not spawn one thread per job to track the job on Yarn

### DIFF
--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -119,8 +119,13 @@
 # For zookeeper, the address to the Zookeeper servers. e.g. host1:port1,host2:port2
 # livy.server.recovery.state-store.url =
 
+# If Livy can't find the yarn app within this time, consider it lost.
+# livy.server.yarn.app-lookup-timeout = 120s
 # If Livy can't find the yarn app within this max times, consider it lost.
-# livy.server.yarn.app-lookup.max-failed.times = 120
+# livy.server.yarn.app-lookup.max-failed.times = 30
+# The size of thread pool to monitor all yarn apps.
+# livy.server.yarn.app-lookup.thread-pool.size = 4
+
 # When the cluster is busy, we may fail to launch yarn app in app-lookup-timeout, then it would
 # cause session leakage, so we need to check session leakage.
 # How long to check livy session leakage.
@@ -128,18 +133,9 @@
 # How often to check livy session leakage.
 # livy.server.yarn.app-leakage.check-interval = 60s
 
-# The size of thread pool to monitor all yarn apps.
-# livy.server.yarn.app-monitor.thread-pool.size = 4
-# How often thread monitor the YARN app.
-# livy.server.yarn.app-monitor.thread-interval = 5s
-# How often to check monitor thread block
-# livy.server.yarn.app-monitor.thread-block.check-interval = 10s
-# If some thread cost more than this config to monitor one app,
-# stop the monitor of the app which considered blocked.
-# livy.server.yarn.app-monitor.thread-block-timeout = 60s
-# If Livy can't monitor the yarn app successfully within this max times, consider the app failed.
-# livy.server.yarn.app-monitor.max-failed.times = 12
-
+# How often Livy polls YARN to refresh YARN app state.
+# livy.server.yarn.poll-interval = 5s
+#
 # Days to keep Livy server request logs.
 # livy.server.request-log-retain.days = 5
 

--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -121,20 +121,25 @@
 
 # If Livy can't find the yarn app within this max times, consider it lost.
 # livy.server.yarn.app-lookup.max-failed.times = 120
-# How often to poll yarn for the app id.
-# livy.server.yarn.app-lookup-interval = 1s
 # When the cluster is busy, we may fail to launch yarn app in app-lookup-timeout, then it would
 # cause session leakage, so we need to check session leakage.
 # How long to check livy session leakage.
 # livy.server.yarn.app-leakage.check-timeout = 600s
 # How often to check livy session leakage.
 # livy.server.yarn.app-leakage.check-interval = 60s
+
 # The size of thread pool to monitor all yarn apps.
 # livy.server.yarn.app-monitor.thread-pool.size = 4
+# How often thread monitor the YARN app.
+# livy.server.yarn.app-monitor.thread-interval = 5s
+# How often to check monitor thread block
+# livy.server.yarn.app-monitor.thread-block.check-interval = 10s
+# If some thread cost more than this config to monitor one app,
+# stop the monitor of the app which considered blocked.
+# livy.server.yarn.app-monitor.thread-block-timeout = 60s
+# If Livy can't monitor the yarn app successfully within this max times, consider the app failed.
+# livy.server.yarn.app-monitor.max-failed.times = 12
 
-# How often Livy polls YARN to refresh YARN app state.
-# livy.server.yarn.poll-interval = 5s
-#
 # Days to keep Livy server request logs.
 # livy.server.request-log-retain.days = 5
 

--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -122,7 +122,7 @@
 # If Livy can't find the yarn app within this time, consider it lost.
 # livy.server.yarn.app-lookup-timeout = 120s
 # If Livy can't find the yarn app within this max times, consider it lost.
-# livy.server.yarn.app-lookup.max-failed.times = 30
+# livy.server.yarn.app-lookup.max-failed.times = 120
 # The size of thread pool to monitor all yarn apps.
 # livy.server.yarn.app-lookup.thread-pool.size = 4
 

--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -133,6 +133,8 @@
 # livy.server.yarn.app-monitor.timeout = 10s
 # If Livy can't monitor the yarn app successfully within this max times, consider the app failed.
 # livy.server.yarn.app-monitor.max-failed.times = 12
+# The size of thread pool to monitor all yarn apps.
+# livy.server.yarn.app-monitor.thread-pool.size = 4
 
 # How often Livy polls YARN to refresh YARN app state.
 # livy.server.yarn.poll-interval = 5s

--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -121,15 +121,21 @@
 
 # If Livy can't find the yarn app within this time, consider it lost.
 # livy.server.yarn.app-lookup-timeout = 120s
+# How long to find the yarn app
+# livy.server.yarn.app-lookup-interval = 1s
 # When the cluster is busy, we may fail to launch yarn app in app-lookup-timeout, then it would
 # cause session leakage, so we need to check session leakage.
 # How long to check livy session leakage
 # livy.server.yarn.app-leakage.check-timeout = 600s
 # how often to check livy session leakage
 # livy.server.yarn.app-leakage.check-interval = 60s
+# how long to monitor the yarn app
+# livy.server.yarn.app-monitor.timeout = 10000ms
+# If Livy can't monitor the yarn app successfully within this max times, consider the app failed.
+# livy.server.yarn.app-monitor.max-failed.times = 120
 
 # How often Livy polls YARN to refresh YARN app state.
-# livy.server.yarn.poll-interval = 5s
+# livy.server.yarn.poll-interval = 500ms
 #
 # Days to keep Livy server request logs.
 # livy.server.request-log-retain.days = 5

--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -121,18 +121,18 @@
 
 # If Livy can't find the yarn app within this time, consider it lost.
 # livy.server.yarn.app-lookup-timeout = 120s
-# How long to find the yarn app
+# How often to poll yarn for the app id.
 # livy.server.yarn.app-lookup-interval = 1s
 # When the cluster is busy, we may fail to launch yarn app in app-lookup-timeout, then it would
 # cause session leakage, so we need to check session leakage.
-# How long to check livy session leakage
+# How long to check livy session leakage.
 # livy.server.yarn.app-leakage.check-timeout = 600s
-# how often to check livy session leakage
+# How often to check livy session leakage.
 # livy.server.yarn.app-leakage.check-interval = 60s
-# how long to monitor the yarn app
-# livy.server.yarn.app-monitor.timeout = 10000ms
+# If Livy can't monitor yarn app successfully within this time, consider the monitoring failed.
+# livy.server.yarn.app-monitor.timeout = 10s
 # If Livy can't monitor the yarn app successfully within this max times, consider the app failed.
-# livy.server.yarn.app-monitor.max-failed.times = 120
+# livy.server.yarn.app-monitor.max-failed.times = 12
 
 # How often Livy polls YARN to refresh YARN app state.
 # livy.server.yarn.poll-interval = 5s

--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -119,8 +119,8 @@
 # For zookeeper, the address to the Zookeeper servers. e.g. host1:port1,host2:port2
 # livy.server.recovery.state-store.url =
 
-# If Livy can't find the yarn app within this time, consider it lost.
-# livy.server.yarn.app-lookup-timeout = 120s
+# If Livy can't find the yarn app within this max times, consider it lost.
+# livy.server.yarn.app-lookup.max-failed.times = 120
 # How often to poll yarn for the app id.
 # livy.server.yarn.app-lookup-interval = 1s
 # When the cluster is busy, we may fail to launch yarn app in app-lookup-timeout, then it would
@@ -129,10 +129,6 @@
 # livy.server.yarn.app-leakage.check-timeout = 600s
 # How often to check livy session leakage.
 # livy.server.yarn.app-leakage.check-interval = 60s
-# If Livy can't monitor yarn app successfully within this time, consider the monitoring failed.
-# livy.server.yarn.app-monitor.timeout = 10s
-# If Livy can't monitor the yarn app successfully within this max times, consider the app failed.
-# livy.server.yarn.app-monitor.max-failed.times = 12
 # The size of thread pool to monitor all yarn apps.
 # livy.server.yarn.app-monitor.thread-pool.size = 4
 

--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -135,7 +135,7 @@
 # livy.server.yarn.app-monitor.max-failed.times = 120
 
 # How often Livy polls YARN to refresh YARN app state.
-# livy.server.yarn.poll-interval = 500ms
+# livy.server.yarn.poll-interval = 5s
 #
 # Days to keep Livy server request logs.
 # livy.server.request-log-retain.days = 5

--- a/integration-test/src/main/scala/org/apache/livy/test/framework/MiniCluster.scala
+++ b/integration-test/src/main/scala/org/apache/livy/test/framework/MiniCluster.scala
@@ -132,7 +132,7 @@ object MiniLivyMain extends MiniClusterBase {
       LivyConf.LIVY_SPARK_MASTER.key -> "yarn",
       LivyConf.LIVY_SPARK_DEPLOY_MODE.key -> "cluster",
       LivyConf.HEARTBEAT_WATCHDOG_INTERVAL.key -> "1s",
-      LivyConf.YARN_APP_MONITOR_THREAD_INTERVAL.key -> "500ms",
+      LivyConf.YARN_POLL_INTERVAL.key -> "500ms",
       LivyConf.RECOVERY_MODE.key -> "recovery",
       LivyConf.RECOVERY_STATE_STORE.key -> "filesystem",
       LivyConf.RECOVERY_STATE_STORE_URL.key -> s"file://$configPath/state-store")

--- a/integration-test/src/main/scala/org/apache/livy/test/framework/MiniCluster.scala
+++ b/integration-test/src/main/scala/org/apache/livy/test/framework/MiniCluster.scala
@@ -132,7 +132,7 @@ object MiniLivyMain extends MiniClusterBase {
       LivyConf.LIVY_SPARK_MASTER.key -> "yarn",
       LivyConf.LIVY_SPARK_DEPLOY_MODE.key -> "cluster",
       LivyConf.HEARTBEAT_WATCHDOG_INTERVAL.key -> "1s",
-      LivyConf.YARN_POLL_INTERVAL.key -> "500ms",
+      LivyConf.YARN_APP_MONITOR_THREAD_INTERVAL.key -> "500ms",
       LivyConf.RECOVERY_MODE.key -> "recovery",
       LivyConf.RECOVERY_STATE_STORE.key -> "filesystem",
       LivyConf.RECOVERY_STATE_STORE_URL.key -> s"file://$configPath/state-store")

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -202,8 +202,18 @@ object LivyConf {
   // Livy will cache the max no of logs specified. 0 means don't cache the logs.
   val SPARK_LOGS_SIZE = Entry("livy.cache-log.size", 200)
 
+  // If Livy can't find the yarn app within this time, consider it lost.
+  val YARN_APP_LOOKUP_TIMEOUT = Entry("livy.server.yarn.app-lookup-timeout", "120s")
+
   // If Livy can't find the yarn app within this max times, consider it lost.
   val YARN_APP_LOOKUP_MAX_FAILED_TIMES = Entry("livy.server.yarn.app-lookup.max-failed.times", 120)
+
+  // The size of thread pool to monitor all yarn apps.
+  val YARN_APP_LOOKUP_THREAD_POOL_SIZE =
+    Entry("livy.server.yarn.app-lookup.thread-pool.size", 4)
+
+  // How often Livy polls YARN to refresh YARN app state.
+  val YARN_POLL_INTERVAL = Entry("livy.server.yarn.poll-interval", "5s")
 
   // Days to keep Livy server request logs.
   val REQUEST_LOG_RETAIN_DAYS = Entry("livy.server.request-log-retain.days", 5)
@@ -217,22 +227,6 @@ object LivyConf {
   val YARN_APP_LEAKAGE_CHECK_TIMEOUT = Entry("livy.server.yarn.app-leakage.check-timeout", "600s")
   // How often to check livy session leakage.
   val YARN_APP_LEAKAGE_CHECK_INTERVAL = Entry("livy.server.yarn.app-leakage.check-interval", "60s")
-
-  // The size of thread pool to monitor all yarn apps.
-  val YARN_APP_MONITOR_THREAD_POOL_SIZE =
-    Entry("livy.server.yarn.app-monitor.thread-pool.size", 4)
-  // How often thread monitor the YARN app.
-  val YARN_APP_MONITOR_THREAD_INTERVAL = Entry("livy.server.yarn.app-monitor.thread-interval", "5s")
-  // How often to check monitor thread block
-  val YARN_APP_MONITOR_THREAD_BLOCK_CHECK_INTERVAL =
-    Entry("livy.server.yarn.app-monitor.thread-block.check-interval", "10s")
-  // If some thread cost more than this config to monitor one app,
-  // stop the monitor of the app which considered blocked.
-  val YARN_APP_MONITOR_THREAD_BLOCK_TIMEOUT =
-    Entry("livy.server.yarn.app-monitor.thread-block-timeout", "60s")
-  // If Livy can't monitor the yarn app successfully within this max times, consider the app failed.
-  val YARN_APP_MONITOR_MAX_FAILED_TIMES =
-    Entry("livy.server.yarn.app-monitor.max-failed.times", 12)
 
   // Whether session timeout should be checked, by default it will be checked, which means inactive
   // session will be stopped after "livy.server.session.timeout"

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -204,7 +204,7 @@ object LivyConf {
 
   // If Livy can't find the yarn app within this time, consider it lost.
   val YARN_APP_LOOKUP_TIMEOUT = Entry("livy.server.yarn.app-lookup-timeout", "120s")
-  // How long to find the yarn app.
+  // How often to poll yarn for the app id.
   val YARN_APP_LOOKUP_INTERVAL = Entry("livy.server.yarn.app-lookup-interval", "1s")
 
   // How often Livy polls YARN to refresh YARN app state.
@@ -218,15 +218,15 @@ object LivyConf {
   // RSC related jars separated with comma.
   val RSC_JARS = Entry("livy.rsc.jars", null)
 
-  // How long to check livy session leakage
+  // How long to check livy session leakage.
   val YARN_APP_LEAKAGE_CHECK_TIMEOUT = Entry("livy.server.yarn.app-leakage.check-timeout", "600s")
-  // how often to check livy session leakage
+  // How often to check livy session leakage.
   val YARN_APP_LEAKAGE_CHECK_INTERVAL = Entry("livy.server.yarn.app-leakage.check-interval", "60s")
-  // how long to monitor the yarn app
-  val YARN_APP_MONITOR_TIMEOUT = Entry("livy.server.yarn.app-monitor.timeout", "10000ms")
+  // If Livy can't monitor yarn app successfully within this time, consider the monitoring failed.
+  val YARN_APP_MONITOR_TIMEOUT = Entry("livy.server.yarn.app-monitor.timeout", "10s")
   // If Livy can't monitor the yarn app successfully within this max times, consider the app failed.
   val YARN_APP_MONITOR_MAX_FAILED_TIMES =
-    Entry("livy.server.yarn.app-monitor.max-failed.times", "120")
+    Entry("livy.server.yarn.app-monitor.max-failed.times", "12")
 
   // Whether session timeout should be checked, by default it will be checked, which means inactive
   // session will be stopped after "livy.server.session.timeout"

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -228,7 +228,8 @@ object LivyConf {
   val YARN_APP_MONITOR_MAX_FAILED_TIMES =
     Entry("livy.server.yarn.app-monitor.max-failed.times", "12")
   // The size of thread pool to monitor all yarn apps.
-  val YARN_APP_MONITOR_THREAD_POOL_SIZE = Entry("livy.server.yarn.app-monitor.thread-pool.size", "4")
+  val YARN_APP_MONITOR_THREAD_POOL_SIZE =
+    Entry("livy.server.yarn.app-monitor.thread-pool.size", "4")
 
   // Whether session timeout should be checked, by default it will be checked, which means inactive
   // session will be stopped after "livy.server.session.timeout"

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -205,9 +205,6 @@ object LivyConf {
   // If Livy can't find the yarn app within this max times, consider it lost.
   val YARN_APP_LOOKUP_MAX_FAILED_TIMES = Entry("livy.server.yarn.app-lookup.max-failed.times", 120)
 
-  // How often Livy polls YARN to refresh YARN app state.
-  val YARN_POLL_INTERVAL = Entry("livy.server.yarn.poll-interval", "5s")
-
   // Days to keep Livy server request logs.
   val REQUEST_LOG_RETAIN_DAYS = Entry("livy.server.request-log-retain.days", 5)
 
@@ -220,9 +217,22 @@ object LivyConf {
   val YARN_APP_LEAKAGE_CHECK_TIMEOUT = Entry("livy.server.yarn.app-leakage.check-timeout", "600s")
   // How often to check livy session leakage.
   val YARN_APP_LEAKAGE_CHECK_INTERVAL = Entry("livy.server.yarn.app-leakage.check-interval", "60s")
+
   // The size of thread pool to monitor all yarn apps.
   val YARN_APP_MONITOR_THREAD_POOL_SIZE =
     Entry("livy.server.yarn.app-monitor.thread-pool.size", 4)
+  // How often thread monitor the YARN app.
+  val YARN_APP_MONITOR_THREAD_INTERVAL = Entry("livy.server.yarn.app-monitor.thread-interval", "5s")
+  // How often to check monitor thread block
+  val YARN_APP_MONITOR_THREAD_BLOCK_CHECK_INTERVAL =
+    Entry("livy.server.yarn.app-monitor.thread-block.check-interval", "10s")
+  // If some thread cost more than this config to monitor one app,
+  // stop the monitor of the app which considered blocked.
+  val YARN_APP_MONITOR_THREAD_BLOCK_TIMEOUT =
+    Entry("livy.server.yarn.app-monitor.thread-block-timeout", "60s")
+  // If Livy can't monitor the yarn app successfully within this max times, consider the app failed.
+  val YARN_APP_MONITOR_MAX_FAILED_TIMES =
+    Entry("livy.server.yarn.app-monitor.max-failed.times", 12)
 
   // Whether session timeout should be checked, by default it will be checked, which means inactive
   // session will be stopped after "livy.server.session.timeout"

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -204,9 +204,11 @@ object LivyConf {
 
   // If Livy can't find the yarn app within this time, consider it lost.
   val YARN_APP_LOOKUP_TIMEOUT = Entry("livy.server.yarn.app-lookup-timeout", "120s")
+  // How long to find the yarn app.
+  val YARN_APP_LOOKUP_INTERVAL = Entry("livy.server.yarn.app-lookup-interval", "1s")
 
   // How often Livy polls YARN to refresh YARN app state.
-  val YARN_POLL_INTERVAL = Entry("livy.server.yarn.poll-interval", "5s")
+  val YARN_POLL_INTERVAL = Entry("livy.server.yarn.poll-interval", "500ms")
 
   // Days to keep Livy server request logs.
   val REQUEST_LOG_RETAIN_DAYS = Entry("livy.server.request-log-retain.days", 5)
@@ -220,6 +222,11 @@ object LivyConf {
   val YARN_APP_LEAKAGE_CHECK_TIMEOUT = Entry("livy.server.yarn.app-leakage.check-timeout", "600s")
   // how often to check livy session leakage
   val YARN_APP_LEAKAGE_CHECK_INTERVAL = Entry("livy.server.yarn.app-leakage.check-interval", "60s")
+  // how long to monitor the yarn app
+  val YARN_APP_MONITOR_TIMEOUT = Entry("livy.server.yarn.app-monitor.timeout", "10000ms")
+  // If Livy can't monitor the yarn app successfully within this max times, consider the app failed.
+  val YARN_APP_MONITOR_MAX_FAILED_TIMES =
+    Entry("livy.server.yarn.app-monitor.max-failed.times", "120")
 
   // Whether session timeout should be checked, by default it will be checked, which means inactive
   // session will be stopped after "livy.server.session.timeout"

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -227,6 +227,8 @@ object LivyConf {
   // If Livy can't monitor the yarn app successfully within this max times, consider the app failed.
   val YARN_APP_MONITOR_MAX_FAILED_TIMES =
     Entry("livy.server.yarn.app-monitor.max-failed.times", "12")
+  // The size of thread pool to monitor all yarn apps.
+  val YARN_APP_MONITOR_THREAD_POOL_SIZE = Entry("livy.server.yarn.app-monitor.thread-pool.size", "4")
 
   // Whether session timeout should be checked, by default it will be checked, which means inactive
   // session will be stopped after "livy.server.session.timeout"

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -208,7 +208,7 @@ object LivyConf {
   val YARN_APP_LOOKUP_INTERVAL = Entry("livy.server.yarn.app-lookup-interval", "1s")
 
   // How often Livy polls YARN to refresh YARN app state.
-  val YARN_POLL_INTERVAL = Entry("livy.server.yarn.poll-interval", "500ms")
+  val YARN_POLL_INTERVAL = Entry("livy.server.yarn.poll-interval", "5s")
 
   // Days to keep Livy server request logs.
   val REQUEST_LOG_RETAIN_DAYS = Entry("livy.server.request-log-retain.days", 5)

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -202,10 +202,8 @@ object LivyConf {
   // Livy will cache the max no of logs specified. 0 means don't cache the logs.
   val SPARK_LOGS_SIZE = Entry("livy.cache-log.size", 200)
 
-  // If Livy can't find the yarn app within this time, consider it lost.
-  val YARN_APP_LOOKUP_TIMEOUT = Entry("livy.server.yarn.app-lookup-timeout", "120s")
-  // How often to poll yarn for the app id.
-  val YARN_APP_LOOKUP_INTERVAL = Entry("livy.server.yarn.app-lookup-interval", "1s")
+  // If Livy can't find the yarn app within this max times, consider it lost.
+  val YARN_APP_LOOKUP_MAX_FAILED_TIMES = Entry("livy.server.yarn.app-lookup.max-failed.times", 120)
 
   // How often Livy polls YARN to refresh YARN app state.
   val YARN_POLL_INTERVAL = Entry("livy.server.yarn.poll-interval", "5s")
@@ -222,14 +220,9 @@ object LivyConf {
   val YARN_APP_LEAKAGE_CHECK_TIMEOUT = Entry("livy.server.yarn.app-leakage.check-timeout", "600s")
   // How often to check livy session leakage.
   val YARN_APP_LEAKAGE_CHECK_INTERVAL = Entry("livy.server.yarn.app-leakage.check-interval", "60s")
-  // If Livy can't monitor yarn app successfully within this time, consider the monitoring failed.
-  val YARN_APP_MONITOR_TIMEOUT = Entry("livy.server.yarn.app-monitor.timeout", "10s")
-  // If Livy can't monitor the yarn app successfully within this max times, consider the app failed.
-  val YARN_APP_MONITOR_MAX_FAILED_TIMES =
-    Entry("livy.server.yarn.app-monitor.max-failed.times", "12")
   // The size of thread pool to monitor all yarn apps.
   val YARN_APP_MONITOR_THREAD_POOL_SIZE =
-    Entry("livy.server.yarn.app-monitor.thread-pool.size", "4")
+    Entry("livy.server.yarn.app-monitor.thread-pool.size", 4)
 
   // Whether session timeout should be checked, by default it will be checked, which means inactive
   // session will be stopped after "livy.server.session.timeout"

--- a/server/src/main/scala/org/apache/livy/utils/SparkYarnApp.scala
+++ b/server/src/main/scala/org/apache/livy/utils/SparkYarnApp.scala
@@ -105,7 +105,7 @@ object SparkYarnApp extends Logging {
         } catch {
           case e: InterruptedException =>
             loop = false
-            error(s"checkMonitorAppTimeoutThread Interrupt whiling monitor", e)
+            error("Apps timeout monitoring thread was interrupted.", e)
         }
       }
     }
@@ -174,7 +174,7 @@ object SparkYarnApp extends Logging {
         } catch {
           case e: InterruptedException =>
             loop = false
-            error(s"YarnAppMonitorRunnable Exception whiling monitor", e)
+            error(s"Yarn app monitoring was interrupted.", e)
         }
       }
     }
@@ -186,14 +186,14 @@ object SparkYarnApp extends Logging {
       Executors.newFixedThreadPool(poolSize)
 
     val runnable = new YarnAppMonitorRunnable()
-    for (i <- 0 until poolSize) {
+    for (_ <- 0 until poolSize) {
       yarnAppMonitorThreadPool.execute(runnable)
     }
   }
 
   def getAppSize: Int = appQueue.size()
 
-  def clearApps: Unit = appQueue.clear()
+  def clearApps(): Unit = appQueue.clear()
 }
 
 /**
@@ -324,12 +324,12 @@ class SparkYarnApp private[utils] (
     yarnTagToAppIdFailedTimes += 1
     if (yarnTagToAppIdFailedTimes > yarnAppLookupMaxFailedTimes) {
       val msg = "No YARN application is found with tag " +
-        "$appTagLowerCase. This may be because " +
+        s"${appTag.toLowerCase}. This may be because " +
         "1) spark-submit fail to submit application to YARN; " +
         "or 2) YARN cluster doesn't have enough resource to start the application in time. " +
         "Please check Livy log and YARN log to know the details."
 
-      error(s"Exception whiling monitor $appTag " + msg)
+      error(s"Failed monitoring the app $appTag: $msg")
       yarnDiagnostics = ArrayBuffer(msg)
       failToMonitor()
     }
@@ -397,12 +397,12 @@ class SparkYarnApp private[utils] (
       case e: InterruptedException =>
         yarnAppMonitorFailedTimes += 1
         if (yarnAppMonitorFailedTimes > yarnAppLookupMaxFailedTimes) {
-          error(s"Exception whiling monitor $appTag", e)
+          error(s"Monitoring of the app $appTag was interrupted.", e)
           yarnDiagnostics = ArrayBuffer(e.getMessage)
           failToMonitor()
         }
       case NonFatal(e) =>
-        error(s"Error whiling monitor $appTag", e)
+        error(s"Failed monitoring the app $appTag.", e)
         yarnDiagnostics = ArrayBuffer(e.getMessage)
         failToMonitor()
     }

--- a/server/src/main/scala/org/apache/livy/utils/SparkYarnApp.scala
+++ b/server/src/main/scala/org/apache/livy/utils/SparkYarnApp.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.livy.utils
 
-import java.util.concurrent.{ConcurrentLinkedQueue, ExecutorService, Executors}
+import java.util.concurrent.{ConcurrentLinkedQueue, Executors, ExecutorService}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
@@ -125,7 +125,8 @@ object SparkYarnApp extends Logging {
     }
   }
 
-  val yarnAppMonitorThreadPool: ExecutorService = Executors.newFixedThreadPool(yarnAppMonitorThreadPoolSize)
+  val yarnAppMonitorThreadPool: ExecutorService =
+    Executors.newFixedThreadPool(yarnAppMonitorThreadPoolSize)
 
   for (i <- 0 until yarnAppMonitorThreadPoolSize) {
     yarnAppMonitorThreadPool.execute(new Runnable {
@@ -152,6 +153,8 @@ object SparkYarnApp extends Logging {
   }
 
   def getAppSize: Int = appQueue.size()
+
+  def clearApps: Unit = appQueue.clear()
 }
 
 /**

--- a/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
@@ -50,7 +50,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
   override def beforeAll(): Unit = {
     super.beforeAll()
     val livyConf = new LivyConf()
-    livyConf.set(LivyConf.YARN_APP_MONITOR_THREAD_INTERVAL, "500ms")
+    livyConf.set(LivyConf.YARN_POLL_INTERVAL, "500ms")
     livyConf.set(LivyConf.YARN_APP_LEAKAGE_CHECK_INTERVAL, "100ms")
     livyConf.set(LivyConf.YARN_APP_LEAKAGE_CHECK_TIMEOUT, "1000ms")
 

--- a/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
@@ -52,7 +52,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
     val livyConf = new LivyConf()
     livyConf.set("livy.server.yarn.poll-interval", "500ms")
     SparkYarnApp.init(livyConf)
-    SparkYarnApp.appQueue.clear()
+    SparkYarnApp.clearApps
   }
 
   override def afterAll(): Unit = {

--- a/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
@@ -66,7 +66,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
     val appIdOption = Some(appId.toString)
     val appTag = "fakeTag"
     val livyConf = new LivyConf()
-    livyConf.set(LivyConf.YARN_APP_LOOKUP_TIMEOUT, "30s")
+    livyConf.set(LivyConf.YARN_APP_LOOKUP_MAX_FAILED_TIMES, 30)
 
     it("should poll YARN state and terminate") {
       Clock.withSleepMethod(mockSleep) {
@@ -216,7 +216,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
       Clock.withSleepMethod(mockSleep) {
         val diag = "DIAG"
         val livyConf = new LivyConf()
-        livyConf.set(LivyConf.YARN_APP_LOOKUP_TIMEOUT, "0")
+        livyConf.set(LivyConf.YARN_APP_LOOKUP_MAX_FAILED_TIMES, 0)
 
         val mockAppReport = mock[ApplicationReport]
         when(mockAppReport.getApplicationId).thenReturn(appId)

--- a/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
@@ -52,12 +52,12 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
     val livyConf = new LivyConf()
     livyConf.set("livy.server.yarn.poll-interval", "500ms")
     SparkYarnApp.init(livyConf)
-    SparkYarnApp.appMap.clear()
+    SparkYarnApp.appQueue.clear()
   }
 
   override def afterAll(): Unit = {
     super.afterAll()
-    assertEquals(SparkYarnApp.appMap.size, 0)
+    assertEquals(SparkYarnApp.getAppSize, 0)
   }
 
   describe("SparkYarnApp") {
@@ -127,7 +127,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
 
         Eventually.eventually(Eventually.timeout(TEST_TIMEOUT), Eventually.interval(100 millis)) {
           assertFalse(app.isRunning)
-          assertEquals(SparkYarnApp.appMap.size, 0)
+          assertEquals(SparkYarnApp.getAppSize, 0)
           verify(mockYarnClient, atLeast(1)).getApplicationReport(appId)
           verify(mockAppListener).stateChanged(State.STARTING, State.RUNNING)
           verify(mockAppListener).stateChanged(State.RUNNING, State.FINISHED)
@@ -162,7 +162,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
 
         Eventually.eventually(Eventually.timeout(TEST_TIMEOUT), Eventually.interval(100 millis)) {
           assertFalse(app.isRunning)
-          assertEquals(SparkYarnApp.appMap.size, 0)
+          assertEquals(SparkYarnApp.getAppSize, 0)
           verify(mockYarnClient).killApplication(appId)
         }
       }
@@ -207,7 +207,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
 
         Eventually.eventually(Eventually.timeout(TEST_TIMEOUT), Eventually.interval(100 millis)) {
           assertFalse(app.isRunning)
-          assertEquals(SparkYarnApp.appMap.size, 0)
+          assertEquals(SparkYarnApp.getAppSize, 0)
         }
       }
     }
@@ -256,7 +256,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
           verify(mockSparkSubmit, times(1)).destroy()
           sparkSubmitRunningLatch.countDown()
           assertFalse(app.isRunning)
-          assertEquals(SparkYarnApp.appMap.size, 0)
+          assertEquals(SparkYarnApp.getAppSize, 0)
         }
       }
     }
@@ -291,7 +291,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
           assert(app.state == SparkApp.State.FAILED,
             "SparkYarnApp should end with state failed when spark submit start failed")
           assertFalse(app.isRunning)
-          assertEquals(SparkYarnApp.appMap.size, 0)
+          assertEquals(SparkYarnApp.getAppSize, 0)
         }
       }
     }
@@ -333,7 +333,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
 
       Eventually.eventually(Eventually.timeout(TEST_TIMEOUT), Eventually.interval(100 millis)) {
         assertFalse(app.isRunning)
-        assertEquals(SparkYarnApp.appMap.size, 0)
+        assertEquals(SparkYarnApp.getAppSize, 0)
       }
     }
 
@@ -357,7 +357,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
 
         Eventually.eventually(Eventually.timeout(TEST_TIMEOUT), Eventually.interval(100 millis)) {
           assertFalse(app.isRunning)
-          assertEquals(SparkYarnApp.appMap.size, 0)
+          assertEquals(SparkYarnApp.getAppSize, 0)
           verify(mockYarnClient, atLeast(1)).getApplicationReport(appId)
           verify(mockListener).appIdKnown(appId.toString)
         }
@@ -416,7 +416,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
 
         Eventually.eventually(Eventually.timeout(TEST_TIMEOUT), Eventually.interval(100 millis)) {
           assertFalse(app.isRunning)
-          assertEquals(SparkYarnApp.appMap.size, 0)
+          assertEquals(SparkYarnApp.getAppSize, 0)
           verify(mockYarnClient, atLeast(1)).getApplicationReport(appId)
           verify(mockAppReport, atLeast(1)).getTrackingUrl()
           verify(mockContainerReport, atLeast(1)).getLogUrl()
@@ -449,7 +449,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
 
         Eventually.eventually(Eventually.timeout(TEST_TIMEOUT), Eventually.interval(100 millis)) {
           assertFalse(app.isRunning)
-          assertEquals(SparkYarnApp.appMap.size, 0)
+          assertEquals(SparkYarnApp.getAppSize, 0)
         }
       }
     }
@@ -505,7 +505,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
 
         Eventually.eventually(Eventually.timeout(TEST_TIMEOUT), Eventually.interval(100 millis)) {
           assertFalse(app.isRunning)
-          assertEquals(SparkYarnApp.appMap.size, 0)
+          assertEquals(SparkYarnApp.getAppSize, 0)
         }
       }
     }

--- a/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
@@ -52,12 +52,12 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
     val livyConf = new LivyConf()
     livyConf.set("livy.server.yarn.poll-interval", "500ms")
     SparkYarnApp.init(livyConf)
-    SparkYarnApp.appList.clear()
+    SparkYarnApp.appMap.clear()
   }
 
   override def afterAll(): Unit = {
     super.afterAll()
-    assertEquals(SparkYarnApp.appList.size, 0)
+    assertEquals(SparkYarnApp.appMap.size, 0)
   }
 
   describe("SparkYarnApp") {
@@ -127,7 +127,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
 
         Eventually.eventually(Eventually.timeout(TEST_TIMEOUT), Eventually.interval(100 millis)) {
           assertFalse(app.isRunning)
-          assertEquals(SparkYarnApp.appList.size, 0)
+          assertEquals(SparkYarnApp.appMap.size, 0)
           verify(mockYarnClient, atLeast(1)).getApplicationReport(appId)
           verify(mockAppListener).stateChanged(State.STARTING, State.RUNNING)
           verify(mockAppListener).stateChanged(State.RUNNING, State.FINISHED)
@@ -162,7 +162,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
 
         Eventually.eventually(Eventually.timeout(TEST_TIMEOUT), Eventually.interval(100 millis)) {
           assertFalse(app.isRunning)
-          assertEquals(SparkYarnApp.appList.size, 0)
+          assertEquals(SparkYarnApp.appMap.size, 0)
           verify(mockYarnClient).killApplication(appId)
         }
       }
@@ -207,7 +207,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
 
         Eventually.eventually(Eventually.timeout(TEST_TIMEOUT), Eventually.interval(100 millis)) {
           assertFalse(app.isRunning)
-          assertEquals(SparkYarnApp.appList.size, 0)
+          assertEquals(SparkYarnApp.appMap.size, 0)
         }
       }
     }
@@ -256,7 +256,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
           verify(mockSparkSubmit, times(1)).destroy()
           sparkSubmitRunningLatch.countDown()
           assertFalse(app.isRunning)
-          assertEquals(SparkYarnApp.appList.size, 0)
+          assertEquals(SparkYarnApp.appMap.size, 0)
         }
       }
     }
@@ -291,7 +291,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
           assert(app.state == SparkApp.State.FAILED,
             "SparkYarnApp should end with state failed when spark submit start failed")
           assertFalse(app.isRunning)
-          assertEquals(SparkYarnApp.appList.size, 0)
+          assertEquals(SparkYarnApp.appMap.size, 0)
         }
       }
     }
@@ -333,7 +333,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
 
       Eventually.eventually(Eventually.timeout(TEST_TIMEOUT), Eventually.interval(100 millis)) {
         assertFalse(app.isRunning)
-        assertEquals(SparkYarnApp.appList.size, 0)
+        assertEquals(SparkYarnApp.appMap.size, 0)
       }
     }
 
@@ -357,7 +357,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
 
         Eventually.eventually(Eventually.timeout(TEST_TIMEOUT), Eventually.interval(100 millis)) {
           assertFalse(app.isRunning)
-          assertEquals(SparkYarnApp.appList.size, 0)
+          assertEquals(SparkYarnApp.appMap.size, 0)
           verify(mockYarnClient, atLeast(1)).getApplicationReport(appId)
           verify(mockListener).appIdKnown(appId.toString)
         }
@@ -416,7 +416,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
 
         Eventually.eventually(Eventually.timeout(TEST_TIMEOUT), Eventually.interval(100 millis)) {
           assertFalse(app.isRunning)
-          assertEquals(SparkYarnApp.appList.size, 0)
+          assertEquals(SparkYarnApp.appMap.size, 0)
           verify(mockYarnClient, atLeast(1)).getApplicationReport(appId)
           verify(mockAppReport, atLeast(1)).getTrackingUrl()
           verify(mockContainerReport, atLeast(1)).getLogUrl()
@@ -449,7 +449,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
 
         Eventually.eventually(Eventually.timeout(TEST_TIMEOUT), Eventually.interval(100 millis)) {
           assertFalse(app.isRunning)
-          assertEquals(SparkYarnApp.appList.size, 0)
+          assertEquals(SparkYarnApp.appMap.size, 0)
         }
       }
     }
@@ -505,7 +505,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite with BeforeAnd
 
         Eventually.eventually(Eventually.timeout(TEST_TIMEOUT), Eventually.interval(100 millis)) {
           assertFalse(app.isRunning)
-          assertEquals(SparkYarnApp.appList.size, 0)
+          assertEquals(SparkYarnApp.appMap.size, 0)
         }
       }
     }


### PR DESCRIPTION


## What changes were proposed in this pull request?

Instead of spawning a monitor thread for every session, create a centralized thread to monitor all apps.

## How was this patch tested?

Existed ITs and UTs.
