### PR TITLE
[LIVY-693] Upgrade jackson to 2.9.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <commons-codec.version>1.9</commons-codec.version>
     <httpclient.version>4.5.3</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>
-    <jackson.version>2.9.9</jackson.version>
+    <jackson.version>2.9.10</jackson.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <jetty.version>9.3.24.v20180605</jetty.version>
     <json4s.version>3.2.11</json4s.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade Jackson to 2.9.10 which fixes many CVEs: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.10

## How was this patch tested?

Existing UTs.
