### PR TITLE
[LIVY-705][THRIFT] Support getting keystore password from Hadoop credential provider

### DIFF
--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftBinaryCLIService.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftBinaryCLIService.scala
@@ -22,6 +22,7 @@ import java.util
 import java.util.concurrent._
 import javax.net.ssl.SSLServerSocket
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.hive.service.cli.HiveSQLException
 import org.apache.hive.service.server.ThreadFactoryWithGarbageCleanup
 import org.apache.thrift.TProcessorFactory
@@ -76,9 +77,21 @@ class ThriftBinaryCLIService(override val cliService: LivyCLIService, val oomHoo
           throw new IllegalArgumentException(
             s"${LivyConf.SSL_KEYSTORE.key} Not configured for SSL connection")
         }
-        val keyStorePassword = livyConf.get(LivyConf.SSL_KEYSTORE_PASSWORD)
+        val credentialProviderPath = livyConf.get(LivyConf.HADOOP_CREDENTIAL_PROVIDER_PATH)
+        val hadoopConf = new Configuration()
+        if (credentialProviderPath != null) {
+          hadoopConf.set("hadoop.security.credential.provider.path", credentialProviderPath)
+        }
+        val keyStorePassword = Option(livyConf.get(LivyConf.SSL_KEYSTORE_PASSWORD))
+          .orElse {
+            Option(hadoopConf.getPassword(LivyConf.SSL_KEYSTORE_PASSWORD.key)).map(_.mkString)
+          }
+        if (keyStorePassword.isEmpty) {
+          throw new IllegalArgumentException(
+            "Livy keystore password not configured for SSL connection")
+        }
         val params = new TSSLTransportFactory.TSSLTransportParameters
-        params.setKeyStore(keyStorePath, keyStorePassword)
+        params.setKeyStore(keyStorePath, keyStorePassword.get)
         serverSocket =
           TSSLTransportFactory.getServerSocket(portNum, 0, serverAddress.getAddress, params)
         if (serverSocket.getServerSocket.isInstanceOf[SSLServerSocket]) {

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftCLIService.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftCLIService.scala
@@ -26,6 +26,7 @@ import javax.security.auth.login.LoginException
 import scala.collection.JavaConverters._
 
 import com.google.common.base.Preconditions.checkArgument
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.hadoop.security.authentication.util.KerberosName
 import org.apache.hadoop.security.authorize.ProxyUsers
@@ -81,6 +82,22 @@ abstract class ThriftCLIService(val cliService: LivyCLIService, val serviceName:
     minWorkerThreads = livyConf.getInt(LivyConf.THRIFT_MIN_WORKER_THREADS)
     maxWorkerThreads = livyConf.getInt(LivyConf.THRIFT_MAX_WORKER_THREADS)
     super.init(livyConf)
+  }
+
+  protected def getKeyStorePassword(): String = {
+    val credentialProviderPath = livyConf.get(LivyConf.HADOOP_CREDENTIAL_PROVIDER_PATH)
+    val hadoopConf = new Configuration()
+    if (credentialProviderPath != null) {
+      hadoopConf.set("hadoop.security.credential.provider.path", credentialProviderPath)
+    }
+    Option(livyConf.get(LivyConf.SSL_KEYSTORE_PASSWORD))
+      .orElse {
+        Option(hadoopConf.getPassword(LivyConf.SSL_KEYSTORE_PASSWORD.key)).map(_.mkString)
+      }
+      .getOrElse {
+        throw new IllegalArgumentException(
+          "Livy keystore password not configured for SSL connection")
+      }
   }
 
   protected def initServer(): Unit

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftCLIService.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftCLIService.scala
@@ -84,21 +84,18 @@ abstract class ThriftCLIService(val cliService: LivyCLIService, val serviceName:
     super.init(livyConf)
   }
 
-  protected def getKeyStorePassword(): String = {
-    val credentialProviderPath = livyConf.get(LivyConf.HADOOP_CREDENTIAL_PROVIDER_PATH)
-    val hadoopConf = new Configuration()
-    if (credentialProviderPath != null) {
-      hadoopConf.set("hadoop.security.credential.provider.path", credentialProviderPath)
+  protected def getKeyStorePassword(): String =
+    Option(livyConf.get(LivyConf.SSL_KEYSTORE_PASSWORD)).orElse {
+      val credentialProviderPath = livyConf.get(LivyConf.HADOOP_CREDENTIAL_PROVIDER_PATH)
+      val hadoopConf = new Configuration()
+      if (credentialProviderPath != null) {
+        hadoopConf.set("hadoop.security.credential.provider.path", credentialProviderPath)
+      }
+      Option(hadoopConf.getPassword(LivyConf.SSL_KEYSTORE_PASSWORD.key)).map(_.mkString)
+    }.getOrElse {
+      throw new IllegalArgumentException(
+        "Livy keystore password not configured for SSL connection")
     }
-    Option(livyConf.get(LivyConf.SSL_KEYSTORE_PASSWORD))
-      .orElse {
-        Option(hadoopConf.getPassword(LivyConf.SSL_KEYSTORE_PASSWORD.key)).map(_.mkString)
-      }
-      .getOrElse {
-        throw new IllegalArgumentException(
-          "Livy keystore password not configured for SSL connection")
-      }
-  }
 
   protected def initServer(): Unit
 

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftHttpCLIService.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftHttpCLIService.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.TimeUnit
 import javax.ws.rs.HttpMethod
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.hive.service.rpc.thrift.TCLIService
 import org.apache.hive.service.server.ThreadFactoryWithGarbageCleanup
 import org.apache.thrift.protocol.TBinaryProtocol
@@ -82,11 +83,23 @@ class ThriftHttpCLIService(
       val schemeName = if (useSsl) "https" else "http"
       // Change connector if SSL is used
       val connector = if (useSsl) {
+          val credentialProviderPath = livyConf.get(LivyConf.HADOOP_CREDENTIAL_PROVIDER_PATH)
+          val hadoopConf = new Configuration()
+          if (credentialProviderPath != null) {
+            hadoopConf.set("hadoop.security.credential.provider.path", credentialProviderPath)
+          }
           val keyStorePath = livyConf.get(LivyConf.SSL_KEYSTORE).trim
-          val keyStorePassword = livyConf.get(LivyConf.SSL_KEYSTORE_PASSWORD)
+          val keyStorePassword = Option(livyConf.get(LivyConf.SSL_KEYSTORE_PASSWORD))
+            .orElse {
+              Option(hadoopConf.getPassword(LivyConf.SSL_KEYSTORE_PASSWORD.key)).map(_.mkString)
+            }
           if (keyStorePath.isEmpty) {
             throw new IllegalArgumentException(
               s"${LivyConf.SSL_KEYSTORE.key} Not configured for SSL connection")
+          }
+          if (keyStorePassword.isEmpty) {
+            throw new IllegalArgumentException(
+              "Livy keystore password not configured for SSL connection")
           }
           val sslContextFactory = new SslContextFactory
           val excludedProtocols = livyConf.get(LivyConf.THRIFT_SSL_PROTOCOL_BLACKLIST).split(",")
@@ -95,7 +108,7 @@ class ThriftHttpCLIService(
           info("HTTP Server SSL: SslContextFactory.getExcludeProtocols = " +
             sslContextFactory.getExcludeProtocols)
           sslContextFactory.setKeyStorePath(keyStorePath)
-          sslContextFactory.setKeyStorePassword(keyStorePassword)
+          sslContextFactory.setKeyStorePassword(keyStorePassword.get)
           new ServerConnector(server, sslContextFactory, http)
         } else {
           new ServerConnector(server, http)


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/LIVY-705

LIVY-475 added support for getting the keystore password and key password from a Hadoop credential provider file. The keystore password is also needed for SSL/TLS support in the Thrift server. In this change, we extend the support for getting the keystore password from the Hadoop credential provider to the Thrift server as well.

## How was this patch tested?

Manually tested a Livy Thrift server that has livy.server.thrift.use.SSL=true, using both binary and http mode. Configured keystore password in a Hadoop credential provider file and provided the path to this file in livy.hadoop.security.credential.provider.path.
