### PR TITLE
[LIVY-706] ThriftServer does not actually cancel jobs if we Interrupt querys from beeline

### DIFF
--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyExecuteStatementOperation.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyExecuteStatementOperation.scala
@@ -142,6 +142,13 @@ class LivyExecuteStatementOperation(
     } catch {
       case e: Throwable =>
         val currentState = getStatus.state
+        if ((currentState == OperationState.CANCELED)
+          || (currentState == OperationState.TIMEDOUT)
+          || (currentState == OperationState.CLOSED)
+          || (currentState == OperationState.FINISHED)) {
+          warn("Ignore exception in terminal state", e)
+          return
+        }
         info(s"Error executing query, currentState $currentState, ", e)
         setState(OperationState.ERROR)
         throw new HiveSQLException(e)
@@ -177,7 +184,7 @@ class LivyExecuteStatementOperation(
       val cleaned = rpcClient.cleanupStatement(sessionHandle, statementId).get()
       if (!cleaned) {
         warn(s"Fail to cleanup query $statementId (session = ${sessionHandle.getSessionId}), " +
-          "this message can be ignored if the query failed.")
+          "this message can be ignored if the query failed or canceled.")
       }
     }
     setState(state)

--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ThriftSessionState.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ThriftSessionState.java
@@ -103,12 +103,11 @@ class ThriftSessionState {
 
   boolean cleanupStatement(String statementId) {
     checkNotNull(statementId, "No statement ID.");
+    ctx.sc().cancelJobGroup(statementId);
     if (statements.remove(statementId) == null) {
       return false;
-    } else {
-      ctx.sc().cancelJobGroup(statementId);
-      return true;
     }
+    return true;
   }
 
   void dispose() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

If we type `Ctrl + c` to interrupt a query from beeline, it does not cancel itself, the job still can be seen running from spark historyServer.

## How was this patch tested?

Tested in my own environment.
