### PR TITLE
[LIVY-708][Server] Align curator jars version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
     <!-- Required for testing LDAP integration -->
     <apacheds.version>2.0.0-M21</apacheds.version>
     <ldap-api.version>1.0.0-M33</ldap-api.version>
+    <curator.version>2.7.1</curator.version>
 
     <!--
       Properties for the copyright header style checks. Modules that use the ASF header

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -118,6 +118,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-recipes</artifactId>
+      <version>${curator.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Livy server has dependency of Apache Curator through hadoop client. However, the versions of the curator jars are not aligned. Here're the curator jars after build

* curator-client-2.7.1.jar
* curator-framework-2.7.1.jar
* curator-recipes-2.6.0.jar
This will cause Method not found issue in some case:
```
Exception in thread "main" java.lang.NoSuchMethodError:
org.apache.curator.utils.PathUtils.validatePath(Ljava/lang/String;)V
```
This patch specify the version of curator-recipes to 2.7.1. 

## How was this patch tested?
Manually test in the env where no such method exception are thrown.
Existing UT/IT
