### PR TITLE
[LIVY-711][TEST] Fix Travis fails to build on Ubuntu16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@
 #
 
 sudo: required
-dist: xenial
+dist: trusty
 language: scala
   - 2.11.12
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix Travis fails to build on Ubuntu16.04

## How was this patch tested?

1. Previously the `dist `of .travis.yml is `xenial ` which points to Ubuntu 14.04.5 LTS. Travis build successfully.
![image](https://user-images.githubusercontent.com/51938049/68647534-10c81e00-0559-11ea-9152-362711b30946.png)

![image](https://user-images.githubusercontent.com/51938049/68647646-669cc600-0559-11ea-9413-9c29860d63f5.png)

2. However, recently `xenial ` points Ubuntu 16.04.6 LTS which needs jdk > 8, but 8 is needed by Livy, so travis build failed.
![image](https://user-images.githubusercontent.com/51938049/68647880-edea3980-0559-11ea-8135-f5a68b3d303d.png)
![image](https://user-images.githubusercontent.com/51938049/68648187-baf47580-055a-11ea-90cf-8592e628a32c.png)
![image](https://user-images.githubusercontent.com/51938049/68647919-0e19f880-055a-11ea-94b9-4f19099654cb.png)

3. So I change the dist to `trusty` which points to Ubuntu 14.04.5 LTS according to the travis doc, and travis build successfully.
![image](https://user-images.githubusercontent.com/51938049/68648018-4d484980-055a-11ea-8358-c4234d7cf56c.png)
![image](https://user-images.githubusercontent.com/51938049/68648028-5507ee00-055a-11ea-8f6e-7c7efcbc6390.png)

