### PR TITLE
[LIVY-715][DOC] The configuration in the template is inconsistent with LivyConf.scala

### DIFF
--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -62,7 +62,7 @@
 # livy.server.session.state-retain.sec = 600s
 
 # If livy should impersonate the requesting users when creating a new session.
-# livy.impersonation.enabled = true
+# livy.impersonation.enabled = false
 
 # Logs size livy can cache for each session/batch. 0 means don't cache the logs.
 # livy.cache-log.size = 200


### PR DESCRIPTION
## What changes were proposed in this pull request?

    When I test livy impersonation found that, in livy.conf.template the value of livy.impersonation.enabled is true. So I thought impersonation was enabled by default.             
    However, impersonation was not turned on when we test. I found that the real configuration in LivyConf. scala is false. 
    This can mislead users.

## How was this patch tested?

no need
