### PR TITLE
[LIVY-717] introduce maven property to set ZooKeeper version

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -100,6 +100,16 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <classifier>tests</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>curator-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -128,6 +138,13 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-server-tests</artifactId>
       <classifier>tests</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+      </exclusions>
+
     </dependency>
 
     <dependency>
@@ -169,6 +186,26 @@
     <dependency>
       <groupId>org.scalatra</groupId>
       <artifactId>scalatra-test_${scala.binary.version}</artifactId>
+    </dependency>
+
+    <!-- hadoop-common in test scope needs curator-client, but we want to use the proper version -->
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-client</artifactId>
+      <version>${curator.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- hadoop-common, hadoop-yarn-server-tests and curator needs zookeeper, but we want to use the proper version -->
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+      <version>${zookeeper.version}</version>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,9 @@
     <!-- Required for testing LDAP integration -->
     <apacheds.version>2.0.0-M21</apacheds.version>
     <ldap-api.version>1.0.0-M33</ldap-api.version>
+
     <curator.version>2.7.1</curator.version>
+    <zookeeper.version>3.4.6</zookeeper.version>
 
     <!--
       Properties for the copyright header style checks. Modules that use the ASF header

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -98,6 +98,14 @@
           <groupId>jline</groupId>
           <artifactId>jline</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>curator-framework</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -121,6 +129,26 @@
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-recipes</artifactId>
       <version>${curator.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- hadoop-auth needs curator-framework, but we want to use the proper version -->
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-framework</artifactId>
+      <version>${curator.version}</version>
+    </dependency>
+
+    <!-- hadoop-auth and curator needs zookeeper, but we want to use the proper version -->
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+      <version>${zookeeper.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
When we want to use Livy in a cluster where a newer ZooKeeper server version is used, we might run into run-time errors if we compile Livy using the current Curator / Hadoop versions. The Curator version can already explicitly set with the `curator.version` maven property in build time, but we were still missed the same parameter for ZooKeeper. 

In this PR I added a new maven parameter called `zookeeper.version` and after analyzing the maven dependency tree, I made sure that the Curator and ZooKeeper versions used in compile time are always harmonized and controlled by the maven parameters.

I set the `zookeeper.version` in maven to `3.4.6` to be backward compatible with the current Livy dependencies.

see https://issues.apache.org/jira/browse/LIVY-717

