### PR TITLE
support using hadoop native methods in local file system

### DIFF
--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -199,6 +199,9 @@ object LivyConf {
    */
   val RECOVERY_STATE_STORE_URL = Entry("livy.server.recovery.state-store.url", "")
 
+  // Whether use hadoop native methods in local file system
+  val USE_HADOOP_NATIVE_ENABLED = Entry("livy.server.use.hadoop.native.enabled", false)
+
   // Livy will cache the max no of logs specified. 0 means don't cache the logs.
   val SPARK_LOGS_SIZE = Entry("livy.cache-log.size", 200)
 

--- a/server/src/main/scala/org/apache/livy/server/recovery/FileSystemStateStore.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/FileSystemStateStore.scala
@@ -53,6 +53,10 @@ class FileSystemStateStore(
   }
 
   {
+    if(livyConf.getBoolean(LivyConf.USE_HADOOP_NATIVE_ENABLED)) {
+      RawLocalFileSystem.useStatIfAvailable()
+    }
+
     // Only Livy user should have access to state files.
     fileContext.setUMask(new FsPermission("077"))
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

support using hadoop native methods while choosing local file system to store sessionMetadata and session nextId, using native methods prevent to create new process. which costs time and may lead to nextId method retain object lock of sessionManager for long time and may cause throughput decreased or create/delete thread hanged

and also a param is suggested to set in livy-env.sh：
`export LD_LIBRARY_PATH=/usr/local/hadoop-current/lib/native`

## How was this patch tested?
manual tests and debug
