### PR TITLE
[LIVY-738][BUILD] Fix Livy third-party library license generating issue

### DIFF
--- a/dev/third-party-missing-license.properties
+++ b/dev/third-party-missing-license.properties
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+commons-beanutils--commons-beanutils--1.7.0=Apache License, Version 2.0
+javax.servlet.jsp--jsp-api--2.1=CDDL 1.1
+javax.transaction--jta--1.1=CDDL 1.1
+org.antlr--antlr-runtime--3.4=BSD License
+org.apache.zookeeper--zookeeper--3.4.6=Apache License, Version 2.0
+oro--oro--2.0.8=Apache License, Version 2.0
+asm--asm--3.1=The BSD 3-Clause license
+org.codehaus.jettison--jettison--1.1=Apache License, Version 2.0
+ldapsdk--ldapsdk--4.1=
+javax.servlet--servlet-api--2.5=CDDL 1.1
+javax.transaction--transaction-api--1.1=CDDL 1.0
+javax.servlet--jsp-api--2.0=CDDL 1.1

--- a/pom.xml
+++ b/pom.xml
@@ -1100,6 +1100,8 @@
               <thirdPartyFilename>THIRD-PARTY</thirdPartyFilename>
               <sortArtifactByName>true</sortArtifactByName>
               <fileTemplate>${execution.root}/dev/third-party-file.ftl</fileTemplate>
+              <useMissingFile>true</useMissingFile>
+              <missingFile>${execution.root}/dev/third-party-missing-license.properties</missingFile>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
Some libraries' license file are missing, so Livy cannot correctly generate the license file, here fixing them manually.