### PR TITLE
[LIVY-745] Ensure that a single RSCClientFactory gets loaded.

### DIFF
--- a/api/src/main/java/org/apache/livy/LivyClientBuilder.java
+++ b/api/src/main/java/org/apache/livy/LivyClientBuilder.java
@@ -23,11 +23,11 @@ import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.ServiceLoader;
-import java.util.concurrent.CopyOnWriteArrayList;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -41,7 +41,7 @@ public final class LivyClientBuilder {
     ServiceLoader.load(LivyClientFactory.class, classLoader());
 
   private static List<LivyClientFactory> getLivyClientFactories() {
-    List<LivyClientFactory> factories = new CopyOnWriteArrayList<>();
+    List<LivyClientFactory> factories = new ArrayList<>();
     for (LivyClientFactory f : CLIENT_FACTORY_LOADER) {
       factories.add(f);
     }

--- a/api/src/main/java/org/apache/livy/LivyClientBuilder.java
+++ b/api/src/main/java/org/apache/livy/LivyClientBuilder.java
@@ -121,10 +121,12 @@ public final class LivyClientBuilder {
     }
 
     LivyClient client = null;
+    boolean loaded = false;
     // ServiceLoader instances are not safe for use by multiple concurrent threads.
     // Ensure that the ServiceLoader's iterator is called by only one thread at a time.
     synchronized (LivyClientBuilder.class) {
       for (LivyClientFactory factory : CLIENT_FACTORY_LOADER) {
+        loaded = true;
         try {
           client = factory.createClient(uri, config);
         } catch (Exception e) {
@@ -139,6 +141,9 @@ public final class LivyClientBuilder {
       }
     }
 
+    if (!loaded) {
+      throw new IllegalStateException("No LivyClientFactory implementation was found.");
+    }
     if (client == null) {
       // Redact any user information from the URI when throwing user-visible exceptions that might
       // be logged.

--- a/api/src/main/java/org/apache/livy/LivyClientBuilder.java
+++ b/api/src/main/java/org/apache/livy/LivyClientBuilder.java
@@ -124,7 +124,7 @@ public final class LivyClientBuilder {
     boolean loaded = false;
     // ServiceLoader instances are not safe for use by multiple concurrent threads.
     // Ensure that the ServiceLoader's iterator is called by only one thread at a time.
-    synchronized (LivyClientBuilder.class) {
+    synchronized (CLIENT_FACTORY_LOADER) {
       for (LivyClientFactory factory : CLIENT_FACTORY_LOADER) {
         loaded = true;
         try {

--- a/api/src/test/java/org/apache/livy/TestClientFactory.java
+++ b/api/src/test/java/org/apache/livy/TestClientFactory.java
@@ -21,8 +21,18 @@ import java.io.File;
 import java.net.URI;
 import java.util.Properties;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class TestClientFactory implements LivyClientFactory {
+
+  private static AtomicLong instanceCount = new AtomicLong();
+  public static long getInstanceCount() {
+    return instanceCount.get();
+  }
+
+  public TestClientFactory() {
+    instanceCount.incrementAndGet();
+  }
 
   @Override
   public LivyClient createClient(URI uri, Properties config) {
@@ -81,6 +91,6 @@ public class TestClientFactory implements LivyClientFactory {
       throw new UnsupportedOperationException();
     }
 
-}
+  }
 
 }

--- a/api/src/test/java/org/apache/livy/TestLivyClientBuilder.java
+++ b/api/src/test/java/org/apache/livy/TestLivyClientBuilder.java
@@ -78,4 +78,22 @@ public class TestLivyClientBuilder {
     }
   }
 
+  @Test
+  public void testSinglenessOfClientFactory() throws Exception {
+    Runnable r = () -> {
+      try {
+        LivyClient client = new LivyClientBuilder().build();
+        assertTrue(client instanceof TestClientFactory.Client);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    };
+    Thread t1 = new Thread(r);
+    Thread t2 = new Thread(r);
+    t1.start();
+    t2.start();
+    t1.join(1000L);
+    t2.join(1000L);
+    assertEquals(1L, TestClientFactory.getInstanceCount());
+  }
 }

--- a/api/src/test/java/org/apache/livy/TestLivyClientBuilder.java
+++ b/api/src/test/java/org/apache/livy/TestLivyClientBuilder.java
@@ -80,20 +80,10 @@ public class TestLivyClientBuilder {
 
   @Test
   public void testSinglenessOfClientFactory() throws Exception {
-    Runnable r = () -> {
-      try {
-        LivyClient client = new LivyClientBuilder().build();
-        assertTrue(client instanceof TestClientFactory.Client);
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    };
-    Thread t1 = new Thread(r);
-    Thread t2 = new Thread(r);
-    t1.start();
-    t2.start();
-    t1.join(1000L);
-    t2.join(1000L);
+    LivyClient client1 = new LivyClientBuilder().build();
+    assertTrue(client1 instanceof TestClientFactory.Client);
+    LivyClient client2 = new LivyClientBuilder().build();
+    assertTrue(client2 instanceof TestClientFactory.Client);
     assertEquals(1L, TestClientFactory.getInstanceCount());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In LivyClientBuilder, a ServiceLoader is used to load configured LivyClientFactory providers (HttpClientFactory and RSCClientFactory). Correct behavior of RSCClientFactory implicitly depends on there being a single instance of it in the Livy server.
Instead of instantiating a new ServiceLoader every time the build method is called on a LivyClientBuilder, keep a single ServiceLoader in a static field. ServiceLoader instances are not safe for use by multiple concurrent threads, so have the ServiceLoader load the LivyClientFactory implementations into a static List. Then LivyClientBuilder#build will use the single instance of either HttpClientFactory or RSCClientFactory in this List to create a LivyClient.

## How was this patch tested?

Tested by having 20 clients connect to the Livy Thrift server simultaneously. Before the change, the behavior described in https://issues.apache.org/jira/browse/LIVY-745 was encountered. With the change, the problem is not encountered.
Also added a unit test that fails before this change to LivyClientBuilder, and passes with the change.
