### PR TITLE
[LIVY-724] Support Session Lazy Recover

### DIFF
--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -100,7 +100,10 @@
 # on user request and then livy server classpath automatically.
 # livy.repl.enable-hive-context =
 
-# Recovery mode of Livy. Possible values:
+# Recovery mode of Livy. Please use the new config: livy.server.ha.mode.
+# Keep this config for back-compatibility. If both this config and livy.server.ha.mode exist,
+# livy uses livy.server.ha.mode first.
+# Possible values:
 # off: Default. Turn off recovery. Every time Livy shuts down, it stops and forgets all sessions.
 # recovery: Livy persists session info to the state store. When Livy restarts, it recovers
 #           previous sessions from the state store.
@@ -123,6 +126,16 @@
 # so if both this config and livy.server.zookeeper.url exist,
 # livy uses livy.server.zookeeper.url first.
 # livy.server.recovery.state-store.url =
+
+# HA mode of Livy. Possible values:
+# 1. null: Default. livy will use the value of livy.server.recovery.mode.
+# 2. off: Turn off recovery. Every time Livy shuts down, it stops and forgets all sessions.
+# 3. recovery: Livy persists session info to the state store. When Livy restarts, it recovers
+#              previous sessions from the state store.
+#              Must set livy.server.recovery.state-store and
+#              livy.server.recovery.state-store.url to configure the state store.
+# 4. multi-active: HA with multi-active mode.
+# livy.server.ha.mode=
 
 # The policy of curator connecting to zookeeper.
 # For example, m, n means retry m times and the interval of retry is n milliseconds.

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -186,6 +186,21 @@ object LivyConf {
    */
   val RECOVERY_MODE = Entry("livy.server.recovery.mode", "off")
 
+  /**
+   * HA mode of Livy. Possible values:
+   * 1. null: Default. livy will use the value of livy.server.recovery.mode
+   * 2. off: Turn off recovery. Every time Livy shuts down, it stops and forgets all sessions.
+   * 3. recovery: Livy persists session info to the state store. When Livy restarts, it recovers
+   *              previous sessions from the state store.
+   *              Must set livy.server.recovery.state-store and
+   *              livy.server.recovery.state-store.url to configure the state store.
+   * 4. multi-active: HA with multi-active mode.
+   */
+  val HA_MODE = Entry("livy.server.ha.mode", HA_MODE_OFF)
+  val HA_MODE_OFF = "off"
+  val HA_MODE_RECOVERY = "recovery"
+  val HA_MODE_MULTI_ACTIVE = "multi-active"
+
   // Zookeeper address used for HA and state store. e.g. host1:port1, host2:port2
   val ZOOKEEPER_URL = Entry("livy.server.zookeeper.url", null)
 

--- a/server/src/main/scala/org/apache/livy/server/recovery/SessionStore.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/SessionStore.scala
@@ -52,7 +52,7 @@ class SessionStore(
   def get[T <: RecoveryMetadata : ClassTag](sessionType: String, id: Int): Option[T] = {
     try {
       store.get[T](sessionPath(sessionType, id))
-    } catch  {
+    } catch {
       case NonFatal(e) =>
         error(e.getMessage, e.getCause)
         None

--- a/server/src/main/scala/org/apache/livy/server/recovery/SessionStore.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/SessionStore.scala
@@ -46,6 +46,19 @@ class SessionStore(
     store.set(sessionPath(sessionType, m.id), m)
   }
 
+  /**
+   * Get a session from the session state store
+   */
+  def get[T <: RecoveryMetadata : ClassTag](sessionType: String, id: Int): Option[T] = {
+    try {
+      store.get[T](sessionPath(sessionType, id))
+    } catch  {
+      case NonFatal(e) =>
+        error(e.getMessage, e.getCause)
+        None
+    }
+  }
+
   def saveNextSessionId(sessionType: String, id: Int): Unit = {
     store.set(sessionManagerPath(sessionType), SessionManagerState(id))
   }

--- a/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
@@ -84,7 +84,9 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
   private[this] final val sessionStateRetainedInSec =
     TimeUnit.MILLISECONDS.toNanos(livyConf.getTimeAsMs(LivyConf.SESSION_STATE_RETAIN_TIME))
 
-  mockSessions.getOrElse(recover()).foreach(register)
+  if (livyConf.get(LivyConf.HA_MODE) != LivyConf.HA_MODE_MULTI_ACTIVE) {
+    mockSessions.getOrElse(recover()).foreach(register)
+  }
   new GarbageCollector().start()
 
   def nextId(): Int = synchronized {
@@ -113,7 +115,14 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
     session
   }
 
-  def get(id: Int): Option[S] = sessions.get(id)
+  def get(id: Int): Option[S] = {
+    val session = sessions.get(id)
+    if (session.isEmpty && livyConf.get(LivyConf.HA_MODE) == LivyConf.HA_MODE_MULTI_ACTIVE) {
+      recover(id).map(register(_))
+    } else {
+      session
+    }
+  }
 
   def get(sessionName: String): Option[S] = sessionsByName.get(sessionName)
 
@@ -197,6 +206,10 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
     recoveryFailure.foreach(ex => error(ex.getMessage, ex.getCause))
 
     recoveredSessions
+  }
+
+  private def recover(id: Int): Option[S] = {
+    sessionStore.get[R](sessionType, id).map(sessionRecovery)
   }
 
   private class GarbageCollector extends Thread("session gc thread") {

--- a/server/src/test/scala/org/apache/livy/server/recovery/SessionStoreSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/recovery/SessionStoreSpec.scala
@@ -104,5 +104,27 @@ class SessionStoreSpec extends FunSpec with LivyBaseUnitTestSuite {
       sessionStore.remove(sessionType, 1)
       verify(stateStore).remove(s"$sessionPath/$id")
     }
+
+    it("should return specific session") {
+      val stateStore = mock[StateStore]
+      val sessionStore = new SessionStore(conf, stateStore)
+      val id = 5
+
+      when(stateStore.get[TestRecoveryMetadata](s"$sessionPath/$id"))
+        .thenReturn(Some(TestRecoveryMetadata(id)))
+      var s = sessionStore.get[TestRecoveryMetadata](sessionType, id)
+      // Verify normal metadata are retrieved.
+      s.get.id shouldBe 5
+
+      when(stateStore.get[TestRecoveryMetadata](s"$sessionPath/$id"))
+        .thenReturn(None)
+      s = sessionStore.get[TestRecoveryMetadata](sessionType, id)
+      s.isEmpty shouldBe true
+
+      when(stateStore.get[TestRecoveryMetadata](s"$sessionPath/$id"))
+        .thenThrow(new RuntimeException("Test"))
+      s = sessionStore.get[TestRecoveryMetadata](sessionType, id)
+      s.isEmpty shouldBe true
+    }
   }
 }

--- a/server/src/test/scala/org/apache/livy/sessions/SessionManagerSpec.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/SessionManagerSpec.scala
@@ -239,6 +239,27 @@ class SessionManagerSpec extends FunSpec with Matchers with LivyBaseUnitTestSuit
       sm.size shouldBe validMetadata.size
     }
 
+    it("should lazy recover sessions") {
+      val conf = new LivyConf()
+      conf.set(LivyConf.LIVY_SPARK_MASTER.key, "yarn-cluster")
+      conf.set(LivyConf.HA_MODE.key, LivyConf.HA_MODE_MULTI_ACTIVE)
+
+      val sessionType = "batch"
+      val id = 99
+
+      val sessionStore = mock[SessionStore]
+      when(sessionStore.get[BatchRecoveryMetadata](sessionType, id))
+        .thenReturn(Some(makeMetadata(id, "t1")))
+
+      val sm = new BatchSessionManager(conf, sessionStore)
+      val session = sm.get(id).get
+      session.id shouldBe id
+
+      when(sessionStore.get[BatchRecoveryMetadata](sessionType, 0))
+        .thenReturn(None)
+      sm.get(0) shouldBe None
+    }
+
     it("should delete sessions from state store") {
       val conf = new LivyConf()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
In this patch, we support a new session recovery mode. In this mode, the sessions on the failed server will not be recovered until a request for it arrives. This mode will be enabled in the multi-active HA scenario.

## How was this patch tested?
New and existing unit tests.

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
