### PR TITLE
[MINOR] Fix CI breakage in python-api unit tests.

### DIFF
--- a/python-api/setup.py
+++ b/python-api/setup.py
@@ -32,6 +32,7 @@ requirements = [
     'configparser>=3.5.0',
     'future>=0.15.2',
     'futures>=3.0.5',
+    'mock~=3.0.5',
     'requests>=2.10.0',
     'responses>=0.5.1',
     'requests-kerberos>=0.11.0',


### PR DESCRIPTION
## What changes were proposed in this pull request?

Freeze python mock library at 3.0.5 to avoid pulling in 4.0.0b1.

## How was this patch tested?

Existing unit tests.