### PR TITLE
[LIVY-752][THRIFT] Fix implementation of limits on connections.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -672,6 +672,7 @@
             <environmentVariables>
               <LIVY_TEST>true</LIVY_TEST>
               <SPARK_HOME>${spark.home}</SPARK_HOME>
+              <LIVY_SPARK_VERSION>${spark.version}</LIVY_SPARK_VERSION>
             </environmentVariables>
             <systemProperties>
               <java.awt.headless>true</java.awt.headless>

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
@@ -21,9 +21,9 @@ import java.lang.reflect.UndeclaredThrowableException
 import java.security.PrivilegedExceptionAction
 import java.util
 import java.util.{Date, Map => JMap, UUID}
-import java.util.function.BiFunction
 import java.util.concurrent.{ConcurrentHashMap, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
 import java.util.concurrent.atomic.AtomicLong
+import java.util.function.BiFunction
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/TestLivyThriftSessionManager.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/TestLivyThriftSessionManager.scala
@@ -41,7 +41,7 @@ class TestLivyThriftSessionManager {
     val conf = new LivyConf()
     conf.set(LivyConf.LIVY_SPARK_VERSION, sys.env("LIVY_SPARK_VERSION"))
     val limit = 3
-    for (limitType <- limitTypes) {
+    limitTypes.foreach { limitType =>
       val entry = limitType match {
         case User => LivyConf.THRIFT_LIMIT_CONNECTIONS_PER_USER
         case IpAddress => LivyConf.THRIFT_LIMIT_CONNECTIONS_PER_IPADDRESS

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/TestLivyThriftSessionManager.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/TestLivyThriftSessionManager.scala
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.thriftserver
+
+import org.apache.hive.service.cli.HiveSQLException
+import org.junit.Assert._
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+import org.apache.livy.LivyConf
+import org.apache.livy.server.AccessManager
+import org.apache.livy.server.recovery.{SessionStore, StateStore}
+import org.apache.livy.sessions.InteractiveSessionManager
+
+object ConnectionLimitType extends Enumeration {
+  type ConnectionLimitType = Value
+  val User, IpAddress, UserIpAddress = Value
+}
+
+class TestLivyThriftSessionManager {
+
+  import ConnectionLimitType._
+
+  private def createThriftSessionManager(
+      limitType: ConnectionLimitType): LivyThriftSessionManager = {
+    val conf = new LivyConf()
+    conf.set(LivyConf.LIVY_SPARK_VERSION, sys.env("LIVY_SPARK_VERSION"))
+    val limit = 3
+    val entry = limitType match {
+      case User => LivyConf.THRIFT_LIMIT_CONNECTIONS_PER_USER
+      case IpAddress => LivyConf.THRIFT_LIMIT_CONNECTIONS_PER_IPADDRESS
+      case UserIpAddress => LivyConf.THRIFT_LIMIT_CONNECTIONS_PER_USER_IPADDRESS
+    }
+    conf.set(entry, limit)
+    val server = new LivyThriftServer(
+      conf,
+      mock(classOf[InteractiveSessionManager]),
+      mock(classOf[SessionStore]),
+      mock(classOf[AccessManager])
+    )
+    new LivyThriftSessionManager(server, conf)
+  }
+
+  private def testLimit(
+      thriftSessionMgr: LivyThriftSessionManager,
+      user: String,
+      ipAddress: String,
+      forwardedAddresses: java.util.List[String],
+      msg: String): Unit = {
+    val failureMsg = "Should have thrown HiveSQLException"
+    try {
+      thriftSessionMgr.incrementConnections(user, ipAddress, forwardedAddresses)
+      fail(failureMsg)
+    } catch {
+      case e: HiveSQLException =>
+        assertEquals(msg, e.getMessage)
+      case _: Throwable =>
+        fail(failureMsg)
+    }
+  }
+
+  @Test
+  def testLimitConnectionsByUser(): Unit = {
+    val thriftSessionMgr = createThriftSessionManager(User)
+    val user = "alice"
+    val forwardedAddresses = new java.util.ArrayList[String]()
+    thriftSessionMgr.incrementConnections(user, "10.20.30.40", forwardedAddresses)
+    thriftSessionMgr.incrementConnections(user, "10.20.30.41", forwardedAddresses)
+    thriftSessionMgr.incrementConnections(user, "10.20.30.42", forwardedAddresses)
+    val msg = s"Connection limit per user reached (user: $user limit: 3)"
+    testLimit(thriftSessionMgr, user, "10.20.30.43", forwardedAddresses, msg)
+  }
+
+  @Test
+  def testLimitConnectionsByIpAddress(): Unit = {
+    val thriftSessionMgr = createThriftSessionManager(IpAddress)
+    val ipAddress = "10.20.30.40"
+    val forwardedAddresses = new java.util.ArrayList[String]()
+    thriftSessionMgr.incrementConnections("alice", ipAddress, forwardedAddresses)
+    thriftSessionMgr.incrementConnections("bob", ipAddress, forwardedAddresses)
+    thriftSessionMgr.incrementConnections("charlie", ipAddress, forwardedAddresses)
+    val msg = s"Connection limit per ipaddress reached (ipaddress: $ipAddress limit: 3)"
+    testLimit(thriftSessionMgr, "dan", ipAddress, forwardedAddresses, msg)
+  }
+
+  @Test
+  def testLimitConnectionsByUserAndIpAddress(): Unit = {
+    val thriftSessionMgr = createThriftSessionManager(UserIpAddress)
+    val user = "alice"
+    val ipAddress = "10.20.30.40"
+    val userAndAddress = user + ":" + ipAddress
+    val forwardedAddresses = new java.util.ArrayList[String]()
+    thriftSessionMgr.incrementConnections(user, ipAddress, forwardedAddresses)
+
+    // more than 3 connections from the same IP Address is ok if users are different
+    thriftSessionMgr.incrementConnections("bob", ipAddress, forwardedAddresses)
+    thriftSessionMgr.incrementConnections("charlie", ipAddress, forwardedAddresses)
+    thriftSessionMgr.incrementConnections("dan", ipAddress, forwardedAddresses)
+
+    // more than 3 connections from the same user is ok if IP addresses are different
+    thriftSessionMgr.incrementConnections(user, "10.20.30.41", forwardedAddresses)
+    thriftSessionMgr.incrementConnections(user, "10.20.30.42", forwardedAddresses)
+    thriftSessionMgr.incrementConnections(user, "10.20.30.43", forwardedAddresses)
+
+    thriftSessionMgr.incrementConnections(user, ipAddress, forwardedAddresses)
+    thriftSessionMgr.incrementConnections(user, ipAddress, forwardedAddresses)
+    val msg =
+      s"Connection limit per user:ipaddress reached (user:ipaddress: $userAndAddress limit: 3)"
+    testLimit(thriftSessionMgr, user, ipAddress, forwardedAddresses, msg)
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`LivyThriftSessionManager` keeps a `ConcurrentHashMap[String, AtomicLong]` named `connectionsCount` to track the number of connections per user, etc. The `incrementConnectionsCount` and `decrementConnectionsCount` methods in `LivyThriftSessionManager` check that `connectionsCount` does not contain a key (instead of contains the key) before getting the value and incrementing or decrementing the count (leading to a `NullPointerException`). Even accounting for the incorrect condition, they do not use the `ConcurrentHashMap` correctly. There is a race -- a thread can get a count, find that it's within a limit, create a new session and then increment the count, while in the meantime, another thread could have incremented the count and so the limit is now actually exceeded.

We increment all relevant counts optimistically before creating a new session, check if any limits are violated, and if so, decrement all incremented counts.

## How was this patch tested?

Tested by deploying the change on a cluster and setting livy.server.thrift.limit.connections.per.user. Verified that the number of connections reaches but does not exceed the limit.
Also, added basic unit tests that connection limits are enforced.
