### PR TITLE
[LIVY-756] Add Support Spark 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ metastore_db/
 derby.log
 dependency-reduced-pom.xml
 release-staging/
+venv/
 
 # For python setup.py, which pollutes the source dirs.
 python-api/dist

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -28,3 +28,4 @@ logs/*
 **/jquery-2.1.1.min.js
 docs/**/*.html
 docs/**/JB/**
+venv/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,12 @@ matrix:
     env: MVN_FLAG='-Pspark-2.4 -Pthriftserver -DskipITs'
   - name: "Spark 2.4 ITs"
     env: MVN_FLAG='-Pspark-2.4 -Pthriftserver -DskipTests'
+  - name: "Spark 3.0 Unit Tests"
+    env: MVN_FLAG='-Pthriftserver -Pspark-3.0 -DskipITs'
+  - name: "Spark 3.0 ITs"
+    env: 
+      - MVN_FLAG='-Pthriftserver -Pspark-3.0 -DskipTests'
+      - PYSPARK_ROW_FIELD_SORTING_ENABLED=true
 
 jdk:
   - oraclejdk8

--- a/assembly/assembly.xml
+++ b/assembly/assembly.xml
@@ -56,8 +56,8 @@
       </includes>
     </fileSet>
     <fileSet>
-      <directory>${project.parent.basedir}/repl/scala-2.11/target/jars</directory>
-      <outputDirectory>${assembly.name}/repl_2.11-jars</outputDirectory>
+      <directory>${project.parent.basedir}/repl/scala-${scala.binary.version}/target/jars</directory>
+      <outputDirectory>${assembly.name}/repl_${scala.binary.version}-jars</outputDirectory>
       <includes>
         <include>*</include>
       </includes>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -29,7 +29,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <assembly.name>apache-livy-${project.version}-bin</assembly.name>
+    <assembly.name>apache-livy-${project.version}-bin_${scala.binary.version}</assembly.name>
     <assembly.format>zip</assembly.format>
     <skipDeploy>true</skipDeploy>
   </properties>
@@ -43,7 +43,7 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>livy-repl_2.11</artifactId>
+      <artifactId>livy-repl_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -51,6 +51,79 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>livy-server</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>livy-core_2.11</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>livy-core_2.12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.json4s</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.scalatra</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-scala_2.11</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-scala_2.12</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-core_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.json4s</groupId>
+      <artifactId>json4s-ast_${scala.binary.version}</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.json4s</groupId>
+      <artifactId>json4s-core_${scala.binary.version}</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.json4s</groupId>
+      <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatra</groupId>
+      <artifactId>scalatra_${scala.binary.version}</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.scalatra</groupId>
+      <artifactId>scalatra-json_${scala.binary.version}</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.scalatra</groupId>
+      <artifactId>scalatra-metrics_${scala.binary.version}</artifactId>
+      <version>${scalatra.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.typesafe.akka</groupId>
+          <artifactId>akka-actor_${scala.binary.version}</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
     </dependency>
   </dependencies>
 

--- a/client-common/pom.xml
+++ b/client-common/pom.xml
@@ -36,7 +36,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.esotericsoftware.kryo</groupId>
+      <groupId>com.esotericsoftware</groupId>
       <artifactId>kryo</artifactId>
     </dependency>
     <dependency>

--- a/client-common/src/main/java/org/apache/livy/client/common/Serializer.java
+++ b/client-common/src/main/java/org/apache/livy/client/common/Serializer.java
@@ -23,7 +23,8 @@ import java.nio.ByteBuffer;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
-import com.esotericsoftware.shaded.org.objenesis.strategy.StdInstantiatorStrategy;
+import com.esotericsoftware.kryo.serializers.ClosureSerializer;
+import org.objenesis.strategy.StdInstantiatorStrategy;
 
 import org.apache.livy.annotations.Private;
 
@@ -49,7 +50,10 @@ public class Serializer {
           kryo.register(klass, REG_ID_BASE + count);
           count++;
         }
-        kryo.setInstantiatorStrategy(new StdInstantiatorStrategy());
+        kryo.setInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(
+                new StdInstantiatorStrategy()));
+        kryo.register(java.lang.invoke.SerializedLambda.class);
+        kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
         kryo.setClassLoader(Thread.currentThread().getContextClassLoader());
         return kryo;
       }

--- a/core/scala-2.12/pom.xml
+++ b/core/scala-2.12/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.livy</groupId>
+  <artifactId>livy-core_2.12</artifactId>
+  <version>0.8.0-incubating-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>org.apache.livy</groupId>
+    <artifactId>livy-core-parent</artifactId>
+    <version>0.8.0-incubating-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <properties>
+    <scala.version>${scala-2.12.version}</scala.version>
+    <scala.binary.version>2.12</scala.binary.version>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/core/src/test/scala/org/apache/livy/LivyBaseUnitTestSuite.scala
+++ b/core/src/test/scala/org/apache/livy/LivyBaseUnitTestSuite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.livy
 
-import org.scalatest.{Outcome, Suite}
+import org.scalatest.{Outcome, TestSuite}
 
-trait LivyBaseUnitTestSuite extends Suite with Logging {
+trait LivyBaseUnitTestSuite extends TestSuite with Logging {
 
   protected override def withFixture(test: NoArgTest): Outcome = {
     val testName = test.name

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -52,13 +52,7 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>livy-core_2.11</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>livy-repl_2.11</artifactId>
+      <artifactId>livy-repl_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -72,11 +66,84 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>livy-server</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>livy-core_2.11</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>livy-core_2.12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.json4s</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.scalatra</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-scala_2.11</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-scala_2.12</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>livy-scala-api_2.11</artifactId>
+      <artifactId>livy-core_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.json4s</groupId>
+      <artifactId>json4s-ast_${scala.binary.version}</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.json4s</groupId>
+      <artifactId>json4s-core_${scala.binary.version}</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.json4s</groupId>
+      <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatra</groupId>
+      <artifactId>scalatra_${scala.binary.version}</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.scalatra</groupId>
+      <artifactId>scalatra-json_${scala.binary.version}</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.scalatra</groupId>
+      <artifactId>scalatra-metrics_${scala.binary.version}</artifactId>
+      <version>${scalatra.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.typesafe.akka</groupId>
+          <artifactId>akka-actor_${scala.binary.version}</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-scala-api_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/examples/src/main/scala/org/apache/livy/examples/WordCountApp.scala
+++ b/examples/src/main/scala/org/apache/livy/examples/WordCountApp.scala
@@ -119,7 +119,7 @@ object WordCountApp {
     scalaClient.submit { context =>
       val sqlctx = context.sqlctx
       val rdd = sqlctx.read.json(inputPath)
-      rdd.registerTempTable("words")
+      rdd.createOrReplaceTempView("words")
       val result = sqlctx.sql("select word, count(word) as word_count from words " +
         "group by word order by word_count desc limit 1")
       result.first().toString()

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -49,9 +49,49 @@
       <version>${project.version}</version>
     </dependency>
 
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-rsc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>livy-server</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>livy-core_2.11</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>livy-core_2.12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.json4s</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.scalatra</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-scala_2.11</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-scala_2.12</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-core_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -70,6 +110,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.json4s</groupId>
+      <artifactId>json4s-ast_${scala.binary.version}</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>
@@ -80,14 +125,58 @@
     </dependency>
 
     <dependency>
+      <groupId>org.json4s</groupId>
+      <artifactId>json4s-core_${scala.binary.version}</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.json4s</groupId>
+      <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatra</groupId>
+      <artifactId>scalatra_${scala.binary.version}</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.scalatra</groupId>
+      <artifactId>scalatra-json_${scala.binary.version}</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.scalatra</groupId>
+      <artifactId>scalatra-metrics_${scala.binary.version}</artifactId>
+      <version>${scalatra.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.typesafe.akka</groupId>
+          <artifactId>akka-actor_${scala.binary.version}</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
     </dependency>
 
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-client-http</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-test-lib</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.asynchttpclient</groupId>
       <artifactId>async-http-client</artifactId>
-      <version>2.10.1</version>
     </dependency>
 
     <dependency>

--- a/integration-test/src/test/resources/rtest.R
+++ b/integration-test/src/test/resources/rtest.R
@@ -18,14 +18,13 @@
 library(SparkR)
 
 # Initialize SparkContext and SQLContext
-sc <- sparkR.init(appName="SparkR-DataFrame-example")
-sqlContext <- sparkRSQL.init(sc)
+sc <- sparkR.session(appName="SparkR-DataFrame-example")
 
 # Create a simple local data.frame
 localDF <- data.frame(name=c("John", "Smith", "Sarah"), age=c(19, 23, 18))
 
 # Convert local data frame to a SparkDataFrame
-df <- createDataFrame(sqlContext, localDF)
+df <- createDataFrame(localDF)
 
 # Print its schema
 printSchema(df)

--- a/integration-test/src/test/scala/org/apache/livy/test/BatchIT.scala
+++ b/integration-test/src/test/scala/org/apache/livy/test/BatchIT.scala
@@ -76,6 +76,7 @@ class BatchIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
   }
 
   test("submit a SparkR application") {
+    assume(!sys.props.getOrElse("skipRTests", "false").toBoolean, "Skipping R tests.")
     val hdfsPath = uploadResource("rtest.R")
     withScript(hdfsPath, List.empty) { s =>
       s.verifySessionSuccess()

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
   </mailingLists>
 
   <properties>
+    <asynchttpclient.version>2.0.23</asynchttpclient.version>
     <hadoop.version>2.7.3</hadoop.version>
     <hadoop.scope>compile</hadoop.scope>
     <spark.scala-2.11.version>2.2.3</spark.scala-2.11.version>
@@ -86,24 +87,25 @@
     <commons-codec.version>1.9</commons-codec.version>
     <httpclient.version>4.5.3</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>
-    <jackson.version>2.9.9</jackson.version>
+    <jackson.version>2.10.1</jackson.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <jetty.version>9.3.24.v20180605</jetty.version>
     <json4s.version>3.2.11</json4s.version>
     <junit.version>4.11</junit.version>
     <libthrift.version>0.9.3</libthrift.version>
-    <kryo.version>2.22</kryo.version>
+    <kryo.version>4.0.2</kryo.version>
     <metrics.version>3.1.0</metrics.version>
-    <mockito.version>1.9.5</mockito.version>
+    <mockito.version>1.10.19</mockito.version>
     <netty.spark-2.11.version>4.0.37.Final</netty.spark-2.11.version>
     <netty.version>${netty.spark-2.11.version}</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <py4j.version>0.10.7</py4j.version>
     <scala-2.11.version>2.11.12</scala-2.11.version>
+    <scala-2.12.version>2.12.10</scala-2.12.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scala.version>${scala-2.11.version}</scala.version>
-    <scalatest.version>2.2.4</scalatest.version>
-    <scalatra.version>2.3.0</scalatra.version>
+    <scalatest.version>3.0.8</scalatest.version>
+    <scalatra.version>2.6.5</scalatra.version>
     <java.version>1.8</java.version>
     <test.redirectToFile>true</test.redirectToFile>
     <execution.root>${user.dir}</execution.root>
@@ -120,6 +122,9 @@
 
     <!-- Set this to "true" to skip PySpark3 tests. -->
     <skipPySpark3Tests>false</skipPySpark3Tests>
+
+    <!-- Set this to "true" to skip Python 2 tests. -->
+    <skipPython2Tests>false</skipPython2Tests>
 
     <!-- Required for testing LDAP integration -->
     <apacheds.version>2.0.0-M21</apacheds.version>
@@ -190,6 +195,17 @@
         <enabled>false</enabled>
       </snapshots>
     </repository>
+    <repository>
+      <id>apache-staging</id>
+      <name>Apache Repository</name>
+      <url>https://repository.apache.org/content/groups/staging/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
   </repositories>
 
   <modules>
@@ -198,16 +214,16 @@
     <module>client-common</module>
     <module>client-http</module>
     <module>core</module>
-    <module>core/scala-2.11</module>
+    <module>core/scala-${scala.binary.version}</module>
     <module>coverage</module>
     <module>examples</module>
     <module>python-api</module>
     <module>repl</module>
-    <module>repl/scala-2.11</module>
+    <module>repl/scala-${scala.binary.version}</module>
     <module>rsc</module>
     <module>scala</module>
     <module>scala-api</module>
-    <module>scala-api/scala-2.11</module>
+    <module>scala-api/scala-${scala.binary.version}</module>
     <module>server</module>
     <module>test-lib</module>
     <module>integration-test</module>
@@ -240,6 +256,12 @@
       <artifactId>scalatra-scalatest_${scala.binary.version}</artifactId>
       <version>${scalatra.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.mockito</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>
@@ -254,7 +276,7 @@
       </dependency>
 
       <dependency>
-        <groupId>com.esotericsoftware.kryo</groupId>
+        <groupId>com.esotericsoftware</groupId>
         <artifactId>kryo</artifactId>
         <version>${kryo.version}</version>
       </dependency>
@@ -547,6 +569,12 @@
 
       <dependency>
         <groupId>org.scalatra</groupId>
+        <artifactId>scalatra-metrics_${scala.binary.version}</artifactId>
+        <version>${scalatra.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.scalatra</groupId>
         <artifactId>scalatra-test_${scala.binary.version}</artifactId>
         <version>${scalatra.version}</version>
       </dependency>
@@ -555,6 +583,11 @@
         <groupId>net.sf.py4j</groupId>
         <artifactId>py4j</artifactId>
         <version>${py4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.asynchttpclient</groupId>
+        <artifactId>async-http-client</artifactId>
+        <version>${asynchttpclient.version}</version>
       </dependency>
 
       <!-- we need a version > 1.7.13 because of SLF4J-324 -->
@@ -611,7 +644,7 @@
         <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
-          <version>3.2.2</version>
+          <version>4.2.0</version>
           <executions>
             <execution>
               <goals>
@@ -630,7 +663,6 @@
           <configuration>
             <scalaVersion>${scala.version}</scalaVersion>
             <recompileMode>incremental</recompileMode>
-            <useZincServer>true</useZincServer>
             <checkMultipleScalaVersions>false</checkMultipleScalaVersions>
             <args>
               <arg>-unchecked</arg>
@@ -661,7 +693,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>2.4.2</version>
+          <version>3.2.4</version>
         </plugin>
 
         <plugin>
@@ -683,6 +715,7 @@
               <project.version>${project.version}</project.version>
               <skipRTests>${skipRTests}</skipRTests>
               <skipPySpark3Tests>${skipPySpark3Tests}</skipPySpark3Tests>
+              <skipPython2Tests>${skipPython2Tests}</skipPython2Tests>
             </systemProperties>
             <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
             <useFile>${test.redirectToFile}</useFile>
@@ -694,7 +727,7 @@
         <plugin>
           <groupId>org.scalatest</groupId>
           <artifactId>scalatest-maven-plugin</artifactId>
-          <version>1.0</version>
+          <version>2.0.0</version>
           <configuration>
             <environmentVariables>
               <LIVY_TEST>true</LIVY_TEST>
@@ -712,6 +745,7 @@
               <project.version>${project.version}</project.version>
               <skipRTests>${skipRTests}</skipRTests>
               <skipPySpark3Tests>${skipPySpark3Tests}</skipPySpark3Tests>
+              <skipPython2Tests>${skipPython2Tests}</skipPython2Tests>
             </systemProperties>
             <stdout>D</stdout>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
@@ -1033,6 +1067,7 @@
         <spark.scala-2.11.version>2.3.3</spark.scala-2.11.version>
         <spark.version>${spark.scala-2.11.version}</spark.version>
         <netty.spark-2.11.version>4.1.17.Final</netty.spark-2.11.version>
+        <asynchttpclient.version>2.10.1</asynchttpclient.version>
         <spark.bin.download.url>
           https://archive.apache.org/dist/spark/spark-2.3.3/spark-2.3.3-bin-hadoop2.7.tgz
         </spark.bin.download.url>
@@ -1053,10 +1088,37 @@
         <netty.spark-2.11.version>4.1.17.Final</netty.spark-2.11.version>
         <java.version>1.8</java.version>
         <py4j.version>0.10.7</py4j.version>
+        <asynchttpclient.version>2.10.1</asynchttpclient.version>
         <spark.bin.download.url>
           https://archive.apache.org/dist/spark/spark-2.4.5/spark-2.4.5-bin-hadoop2.7.tgz
         </spark.bin.download.url>
         <spark.bin.name>spark-2.4.5-bin-hadoop2.7</spark.bin.name>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>spark-3.0</id>
+      <activation>
+        <property>
+          <name>spark-3.0</name>
+        </property>
+      </activation>
+      <properties>
+        <spark.scala-2.12.version>3.0.0</spark.scala-2.12.version>
+        <spark.version>${spark.scala-2.12.version}</spark.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <scala.version>${scala-2.12.version}</scala.version>
+        <netty.spark-2.12.version>4.1.47.Final</netty.spark-2.12.version>
+        <netty.version>${netty.spark-2.12.version}</netty.version>
+        <java.version>1.8</java.version>
+        <py4j.version>0.10.9</py4j.version>
+        <json4s.version>3.6.6</json4s.version>
+        <asynchttpclient.version>2.10.1</asynchttpclient.version>
+        <skipRTests>true</skipRTests>
+        <spark.bin.download.url>
+          https://archive.apache.org/dist/spark/spark-3.0.0/spark-3.0.0-bin-hadoop2.7.tgz
+        </spark.bin.download.url>
+        <spark.bin.name>spark-3.0.0-bin-hadoop2.7</spark.bin.name>
       </properties>
     </profile>
 

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -175,6 +175,7 @@
                   <include>org.json4s:json4s-ast_${scala.binary.version}</include>
                   <include>org.json4s:json4s-core_${scala.binary.version}</include>
                   <include>org.json4s:json4s-jackson_${scala.binary.version}</include>
+                  <include>org.json4s:json4s-scalap_${scala.binary.version}</include>
                 </includes>
               </artifactSet>
               <filters>

--- a/repl/scala-2.11/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -27,12 +27,10 @@ import scala.tools.nsc.interpreter.IMain
 import scala.tools.nsc.interpreter.JLineCompletion
 import scala.tools.nsc.interpreter.JPrintWriter
 import scala.tools.nsc.interpreter.Results.Result
-import scala.util.control.NonFatal
 
 import org.apache.spark.SparkConf
 import org.apache.spark.repl.SparkILoop
 
-import org.apache.livy.rsc.driver.SparkEntries
 
 /**
  * This represents a Spark interpreter. It is not thread safe.

--- a/repl/scala-2.12/pom.xml
+++ b/repl/scala-2.12/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.livy</groupId>
+  <artifactId>livy-repl_2.12</artifactId>
+  <version>0.8.0-incubating-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>org.apache.livy</groupId>
+    <artifactId>livy-repl-parent</artifactId>
+    <version>0.8.0-incubating-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <properties>
+    <scala.version>${scala-2.12.version}</scala.version>
+    <scala.binary.version>2.12</scala.binary.version>
+    <spark.version>${spark.scala-2.12.version}</spark.version>
+    <netty.version>${netty.spark-2.12.version}</netty.version>
+  </properties>
+
+</project>

--- a/repl/scala-2.12/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.12/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.repl
+
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.file.{Files, Paths}
+
+import scala.tools.nsc.Settings
+import scala.tools.nsc.interpreter.Completion
+import scala.tools.nsc.interpreter.IMain
+import scala.tools.nsc.interpreter.JPrintWriter
+import scala.tools.nsc.interpreter.NoCompletion
+import scala.tools.nsc.interpreter.Results.Result
+import scala.util.control.NonFatal
+
+import org.apache.spark.SparkConf
+import org.apache.spark.repl.SparkILoop
+
+import org.apache.livy.rsc.driver.SparkEntries
+
+/**
+ * This represents a Spark interpreter. It is not thread safe.
+ */
+class SparkInterpreter(protected override val conf: SparkConf) extends AbstractSparkInterpreter {
+
+  private var sparkILoop: SparkILoop = _
+
+  override def start(): Unit = {
+    require(sparkILoop == null)
+
+    val rootDir = conf.get("spark.repl.classdir", System.getProperty("java.io.tmpdir"))
+    val outputDir = Files.createTempDirectory(Paths.get(rootDir), "spark").toFile
+    outputDir.deleteOnExit()
+    conf.set("spark.repl.class.outputDir", outputDir.getAbsolutePath)
+
+    val settings = new Settings()
+    settings.processArguments(List("-Yrepl-class-based",
+      "-Yrepl-outdir", s"${outputDir.getAbsolutePath}"), true)
+    settings.usejavacp.value = true
+    settings.embeddedDefaults(Thread.currentThread().getContextClassLoader())
+
+    sparkILoop = new SparkILoop(None, new JPrintWriter(outputStream, true))
+    sparkILoop.settings = settings
+    sparkILoop.createInterpreter()
+    sparkILoop.initializeSynchronous()
+
+    restoreContextClassLoader {
+      sparkILoop.compilerClasspath
+      sparkILoop.ensureClassLoader
+      var classLoader = Thread.currentThread().getContextClassLoader
+      while (classLoader != null) {
+        if (classLoader.getClass.getCanonicalName ==
+          "org.apache.spark.util.MutableURLClassLoader") {
+          val extraJarPath = classLoader.asInstanceOf[URLClassLoader].getURLs()
+            // Check if the file exists. Otherwise an exception will be thrown.
+            .filter { u => u.getProtocol == "file" && new File(u.getPath).isFile }
+            // Livy rsc and repl are also in the extra jars list. Filter them out.
+            .filterNot { u => Paths.get(u.toURI).getFileName.toString.startsWith("livy-") }
+            // Some bad spark packages depend on the wrong version of scala-reflect. Blacklist it.
+            .filterNot { u =>
+              Paths.get(u.toURI).getFileName.toString.contains("org.scala-lang_scala-reflect")
+            }
+
+          extraJarPath.foreach { p => debug(s"Adding $p to Scala interpreter's class path...") }
+          sparkILoop.addUrlsToClassPath(extraJarPath: _*)
+          classLoader = null
+        } else {
+          classLoader = classLoader.getParent
+        }
+      }
+
+      postStart()
+    }
+  }
+
+  override def close(): Unit = synchronized {
+    super.close()
+
+    if (sparkILoop != null) {
+      sparkILoop.closeInterpreter()
+      sparkILoop = null
+    }
+  }
+
+  override protected def isStarted(): Boolean = {
+    sparkILoop != null
+  }
+
+  override protected def interpret(code: String): Result = {
+    sparkILoop.interpret(code)
+  }
+
+  override protected def completeCandidates(code: String, cursor: Int) : Array[String] = {
+    val completer : Completion = {
+      try {
+        val cls = Class.forName("scala.tools.nsc.interpreter.PresentationCompilerCompleter")
+        cls.getDeclaredConstructor(classOf[IMain]).newInstance(sparkILoop.intp)
+          .asInstanceOf[Completion]
+      } catch {
+        case e : ClassNotFoundException => NoCompletion
+      }
+    }
+    completer.complete(code, cursor).candidates.toArray
+  }
+
+  override protected def valueOfTerm(name: String): Option[Any] = {
+    // IMain#valueOfTerm will always return None, so use other way instead.
+    Option(sparkILoop.lastRequest.lineRep.call("$result"))
+  }
+
+  override protected def bind(name: String,
+      tpe: String,
+      value: Object,
+      modifier: List[String]): Unit = {
+    sparkILoop.beQuietDuring {
+      sparkILoop.bind(name, tpe, value, modifier)
+    }
+  }
+}

--- a/repl/scala-2.12/src/test/scala/org/apache/livy/repl/SparkInterpreterSpec.scala
+++ b/repl/scala-2.12/src/test/scala/org/apache/livy/repl/SparkInterpreterSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.repl
+
+import org.scalatest._
+
+import org.apache.livy.LivyBaseUnitTestSuite
+
+class SparkInterpreterSpec extends FunSpec with Matchers with LivyBaseUnitTestSuite {
+  describe("SparkInterpreter") {
+    val interpreter = new SparkInterpreter(null)
+
+    it("should parse Scala compile error.") {
+      // Regression test for LIVY-.
+      val error =
+        """<console>:27: error: type mismatch;
+          | found   : Int
+          | required: String
+          |       sc.setJobGroup(groupName, groupName, true)
+          |                      ^
+          |<console>:27: error: type mismatch;
+          | found   : Int
+          | required: String
+          |       sc.setJobGroup(groupName, groupName, true)
+          |                                 ^
+          |""".stripMargin
+
+      val parsedError = AbstractSparkInterpreter.KEEP_NEWLINE_REGEX.split(error)
+
+      val expectedTraceback = parsedError.tail
+
+      val (ename, traceback) = interpreter.parseError(error)
+      ename shouldBe "<console>:27: error: type mismatch;"
+      traceback shouldBe expectedTraceback
+    }
+
+    it("should parse Scala runtime error.") {
+      val error =
+        """java.lang.RuntimeException: message
+          |    ... 48 elided
+          |
+          |Tailing message""".stripMargin
+
+      val parsedError = AbstractSparkInterpreter.KEEP_NEWLINE_REGEX.split(error)
+
+      val expectedTraceback = parsedError.tail
+
+      val (ename, traceback) = interpreter.parseError(error)
+      ename shouldBe "java.lang.RuntimeException: message"
+      traceback shouldBe expectedTraceback
+    }
+  }
+}

--- a/repl/src/main/scala/org/apache/livy/repl/SparkRInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/SparkRInterpreter.scala
@@ -205,7 +205,6 @@ class SparkRInterpreter(
         sendRequest("""assign(".sparkRsession", SparkR:::callJStatic("org.apache.livy.repl.SparkRInterpreter", "getSparkSession"), envir = SparkR:::.sparkREnv)""")
         sendRequest("""assign("spark", get(".sparkRsession", envir = SparkR:::.sparkREnv), envir=.GlobalEnv)""")
       }
-
       sendRequest("""assign(".sqlc", SparkR:::callJStatic("org.apache.livy.repl.SparkRInterpreter", "getSQLContext"), envir = SparkR:::.sparkREnv)""")
       sendRequest("""assign("sqlContext", get(".sqlc", envir = SparkR:::.sparkREnv), envir = .GlobalEnv)""")
       // scalastyle:on line.size.limit

--- a/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
@@ -255,6 +255,11 @@ class Python2InterpreterSpec extends PythonBaseInterpreterSpec {
 
   implicit val formats = DefaultFormats
 
+  override protected def withFixture(test: NoArgTest) = {
+    assume(!sys.props.getOrElse("skipPython2Tests", "false").toBoolean, "Skipping Python2 tests.")
+    test()
+  }
+
   override def createInterpreter(): Interpreter = {
     val sparkConf = new SparkConf()
     PythonInterpreter(sparkConf, new SparkEntries(sparkConf))

--- a/repl/src/test/scala/org/apache/livy/repl/PythonSessionSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/PythonSessionSpec.scala
@@ -170,7 +170,13 @@ abstract class PythonSessionSpec extends BaseSessionSpec(PySpark) {
   }
 }
 
-class Python2SessionSpec extends PythonSessionSpec
+class Python2SessionSpec extends PythonSessionSpec {
+
+  override protected def withFixture(test: NoArgTest): Outcome = {
+    assume(!sys.props.getOrElse("skipPython2Tests", "false").toBoolean, "Skipping Python 2 tests.")
+    test()
+  }
+}
 
 class Python3SessionSpec extends PythonSessionSpec with BeforeAndAfterAll {
 

--- a/repl/src/test/scala/org/apache/livy/repl/SQLInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/SQLInterpreterSpec.scala
@@ -113,7 +113,7 @@ class SQLInterpreterSpec extends BaseInterpreterSpec {
   it should "execute sql queries" in withInterpreter { interpreter =>
     val rdd = sparkEntries.sc().parallelize(Seq(People("Jerry", 20), People("Michael", 21)))
     val df = sparkEntries.sqlctx().createDataFrame(rdd)
-    df.registerTempTable("people")
+    df.createOrReplaceTempView("people")
 
     // Test normal behavior
     val resp1 = interpreter.execute(
@@ -159,7 +159,7 @@ class SQLInterpreterSpec extends BaseInterpreterSpec {
       ("1", new java.math.BigDecimal(1.0)),
       ("2", new java.math.BigDecimal(2.0))))
     val df = sparkEntries.sqlctx().createDataFrame(rdd).selectExpr("_1 as col1", "_2 as col2")
-    df.registerTempTable("test")
+    df.createOrReplaceTempView("test")
 
     val resp1 = interpreter.execute(
       """

--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -50,6 +50,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.livy</groupId>
       <artifactId>livy-core_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
@@ -58,7 +63,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.esotericsoftware.kryo</groupId>
+      <groupId>com.esotericsoftware</groupId>
       <artifactId>kryo</artifactId>
     </dependency>
     <dependency>
@@ -116,11 +121,6 @@
       <artifactId>hadoop-common</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
 
   <build>
@@ -140,7 +140,9 @@
               <artifactSet>
                 <includes>
                   <include>org.apache.livy:livy-client-common</include>
-                  <include>com.esotericsoftware.kryo:kryo</include>
+                  <include>com.esotericsoftware:kryo</include>
+                  <include>com.esotericsoftware:minlog</include>
+                  <include>com.esotericsoftware:reflectasm</include>
                 </includes>
               </artifactSet>
               <filters>

--- a/rsc/src/main/java/org/apache/livy/rsc/ContextLauncher.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/ContextLauncher.java
@@ -243,7 +243,9 @@ class ContextLauncher {
       launcher.setAppResource(SparkLauncher.NO_RESOURCE);
       launcher.setPropertiesFile(confFile.getAbsolutePath());
       launcher.setMainClass(RSCDriverBootstrapper.class.getName());
-
+      if (conf.get(MASTER) != null) {
+        launcher.setMaster(conf.get(MASTER));
+      }
       if (conf.get(PROXY_USER) != null) {
         launcher.addSparkArg("--proxy-user", conf.get(PROXY_USER));
       }

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
@@ -82,7 +82,9 @@ public class RSCConf extends ClientConf<RSCConf> {
     RETAINED_SHARE_VARIABLES("retained.share-variables", 100),
 
     // Number of result rows to get for SQL Interpreters.
-    SQL_NUM_ROWS("sql.num-rows", 1000);
+    SQL_NUM_ROWS("sql.num-rows", 1000),
+
+    MASTER("spark.master", null);
 
     private final String key;
     private final Object dflt;

--- a/rsc/src/main/java/org/apache/livy/rsc/driver/SparkEntries.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/driver/SparkEntries.java
@@ -17,7 +17,6 @@
 
 package org.apache.livy.rsc.driver;
 
-import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.spark.SparkConf;
@@ -60,7 +59,7 @@ public class SparkEntries {
     return sc;
   }
 
-  public SparkSession sparkSession() throws Exception {
+  public SparkSession sparkSession() {
     if (sparksession == null) {
       synchronized (this) {
         if (sparksession == null) {
@@ -100,7 +99,7 @@ public class SparkEntries {
     if (sqlctx == null) {
       synchronized (this) {
         if (sqlctx == null) {
-          sqlctx = new SQLContext(sc());
+          sqlctx = sparkSession().sqlContext();
           LOG.info("Created SQLContext.");
         }
       }
@@ -112,7 +111,7 @@ public class SparkEntries {
     if (hivectx == null) {
       synchronized (this) {
         if (hivectx == null) {
-          SparkConf conf = sc.getConf();
+          SparkConf conf = sc().getConf();
           if (conf.getBoolean("spark.repl.enableHiveContext", false) ||
             conf.get("spark.sql.catalogImplementation", "in-memory").toLowerCase()
               .equals("hive")) {
@@ -123,7 +122,7 @@ public class SparkEntries {
                "classpath.");
             }
             hivectx = new HiveContext(sc().sc());
-            LOG.info("Created HiveContext.");
+            LOG.info("Created hive HiveContext.");
           }
         }
       }

--- a/rsc/src/main/java/org/apache/livy/rsc/rpc/KryoMessageCodec.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/rpc/KryoMessageCodec.java
@@ -17,17 +17,10 @@
 
 package org.apache.livy.rsc.rpc;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.List;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.io.ByteBufferInputStream;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
-import com.esotericsoftware.shaded.org.objenesis.strategy.StdInstantiatorStrategy;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageCodec;

--- a/scala-api/scala-2.12/pom.xml
+++ b/scala-api/scala-2.12/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.livy</groupId>
+  <artifactId>livy-scala-api_2.12</artifactId>
+  <version>0.8.0-incubating-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>org.apache.livy</groupId>
+    <artifactId>livy-scala-api-parent</artifactId>
+    <version>0.8.0-incubating-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <properties>
+    <scala.version>${scala-2.12.version}</scala.version>
+    <scala.binary.version>2.12</scala.binary.version>
+    <spark.version>${spark.scala-2.12.version}</spark.version>
+    <netty.version>${netty.spark-2.12.version}</netty.version>
+  </properties>
+</project>

--- a/scala-api/src/main/scala/org/apache/livy/scalaapi/ScalaJobHandle.scala
+++ b/scala-api/src/main/scala/org/apache/livy/scalaapi/ScalaJobHandle.scala
@@ -190,6 +190,19 @@ class ScalaJobHandle[T] private[livy] (jobHandle: JobHandle[T]) extends Future[T
     getJavaFutureResult(jobHandle, atMost)
     this
   }
+
+  // These two methods must be implemented in Scala 2.12. They're implemented as a no-op here
+  // and then filled in with a real implementation in the two subclasses below. The no-op exists
+  // here so that those implementations can declare "override", necessary in 2.12, while working
+  // in 2.11, where the method doesn't exist in the superclass.
+  // After 2.11 support goes away, remove these two:
+
+  def transform[S](f: (Try[T]) => Try[S])(implicit executor: ExecutionContext): Future[S] =
+    throw new UnsupportedOperationException()
+
+  def transformWith[S](f: (Try[T]) => Future[S])(implicit executor: ExecutionContext): Future[S] =
+    throw new UnsupportedOperationException()
+
 }
 
 private abstract class AbstractScalaJobHandleListener[T] extends Listener[T] {

--- a/scala-api/src/test/scala/org/apache/livy/scalaapi/ScalaClientTestUtils.scala
+++ b/scala-api/src/test/scala/org/apache/livy/scalaapi/ScalaClientTestUtils.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.{CountDownLatch, TimeUnit}
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
+import scala.language.postfixOps
 
 import org.scalatest.FunSuite
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -200,7 +200,7 @@
     <dependency>
       <groupId>org.scalatra</groupId>
       <artifactId>scalatra-metrics_${scala.binary.version}</artifactId>
-      <version>2.4.0.M3</version>
+      <version>${scalatra.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.typesafe.akka</groupId>
@@ -255,6 +255,12 @@
       <groupId>org.scalatra</groupId>
       <artifactId>scalatra-test_${scala.binary.version}</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.mockito</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -367,5 +373,17 @@
     </plugins>
   </build>
 
-</project>
+  <profiles>
+    <profile>
+      <id>spark-3.0</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.json4s</groupId>
+          <artifactId>json4s-scalap_2.12</artifactId>
+          <version>3.6.6</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
+</project>

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -47,7 +47,7 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
   with ApiVersioningSupport
   with MethodOverride
   with UrlGeneratorSupport
-  with GZipSupport
+  with ContentEncodingSupport
 {
   /**
    * Creates a new session based on the current request. The implementation is responsible for

--- a/server/src/main/scala/org/apache/livy/utils/LivySparkUtils.scala
+++ b/server/src/main/scala/org/apache/livy/utils/LivySparkUtils.scala
@@ -30,6 +30,8 @@ object LivySparkUtils extends Logging {
   // For each Spark version we supported, we need to add this mapping relation in case Scala
   // version cannot be detected from "spark-submit --version".
   private val _defaultSparkScalaVersion = SortedMap(
+    // Spark 3.0 + Scala 2.12
+    (3, 0) -> "2.12",
     // Spark 2.4 + Scala 2.11
     (2, 4) -> "2.11",
     // Spark 2.3 + Scala 2.11
@@ -40,7 +42,7 @@ object LivySparkUtils extends Logging {
 
   // Supported Spark version
   private val MIN_VERSION = (2, 2)
-  private val MAX_VERSION = (3, 0)
+  private val MAX_VERSION = (3, 1)
 
   private val sparkVersionRegex = """version (.*)""".r.unanchored
   private val scalaVersionRegex = """Scala version (.*), Java""".r.unanchored

--- a/server/src/test/scala/org/apache/livy/server/BaseJsonServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/BaseJsonServletSpec.scala
@@ -108,7 +108,8 @@ abstract class BaseJsonServletSpec extends ScalatraSuite
     // Only try to parse the body if response is in the "OK" range (20x).
     if ((status / 100) * 100 == SC_OK) {
       val result =
-        if (header("Content-Type").startsWith("application/json")) {
+        if (klass.runtimeClass != classOf[Unit] &&
+          header("Content-Type").startsWith("application/json")) {
           // Sometimes there's an empty body with no "Content-Length" header. So read the whole
           // body first, and only send it to Jackson if there's content.
           val in = response.inputStream

--- a/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
@@ -20,7 +20,7 @@ package org.apache.livy.server
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse._
 
-import org.scalatest.mock.MockitoSugar.mock
+import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.LivyConf
 import org.apache.livy.server.recovery.SessionStore

--- a/server/src/test/scala/org/apache/livy/server/batch/BatchServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/BatchServletSpec.scala
@@ -26,7 +26,7 @@ import javax.servlet.http.HttpServletResponse._
 import scala.concurrent.duration.Duration
 
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar.mock
+import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{LivyConf, Utils}
 import org.apache.livy.server.{AccessManager, BaseSessionServletSpec}

--- a/server/src/test/scala/org/apache/livy/server/batch/BatchSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/BatchSessionSpec.scala
@@ -26,8 +26,8 @@ import scala.concurrent.duration.Duration
 import org.mockito.Matchers
 import org.mockito.Matchers.anyObject
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfter, FunSpec, ShouldMatchers}
-import org.scalatest.mock.MockitoSugar.mock
+import org.scalatest.{BeforeAndAfter, FunSpec}
+import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf, Utils}
 import org.apache.livy.server.AccessManager
@@ -38,7 +38,7 @@ import org.apache.livy.utils.{AppInfo, Clock, SparkApp}
 class BatchSessionSpec
   extends FunSpec
   with BeforeAndAfter
-  with ShouldMatchers
+  with org.scalatest.Matchers
   with LivyBaseUnitTestSuite {
 
   val script: Path = {

--- a/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionServletSpec.scala
@@ -23,6 +23,7 @@ import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.concurrent.Future
+import scala.language.postfixOps
 
 import org.json4s.jackson.Json4sScalaModule
 import org.mockito.Matchers._
@@ -31,7 +32,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.Entry
 import org.scalatest.concurrent.Eventually._
-import org.scalatest.mock.MockitoSugar.mock
+import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{ExecuteRequest, LivyConf}
 import org.apache.livy.client.common.HttpMessages.SessionInfo

--- a/server/src/test/scala/org/apache/livy/server/interactive/JobApiSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/JobApiSpec.scala
@@ -29,7 +29,7 @@ import scala.language.postfixOps
 
 import org.apache.hadoop.security.UserGroupInformation
 import org.scalatest.concurrent.Eventually._
-import org.scalatest.mock.MockitoSugar.mock
+import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{Job, JobHandle, LivyConf}
 import org.apache.livy.client.common.{BufferUtils, Serializer}

--- a/server/src/test/scala/org/apache/livy/server/interactive/SessionHeartbeatSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/SessionHeartbeatSpec.scala
@@ -24,7 +24,7 @@ import scala.language.postfixOps
 import org.mockito.Mockito.{never, verify, when}
 import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.concurrent.Eventually._
-import org.scalatest.mock.MockitoSugar.mock
+import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.LivyConf
 import org.apache.livy.server.recovery.SessionStore

--- a/server/src/test/scala/org/apache/livy/server/recovery/FileSystemStateStoreSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/recovery/FileSystemStateStoreSpec.scala
@@ -32,7 +32,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.FunSpec
 import org.scalatest.Matchers._
-import org.scalatest.mock.MockitoSugar.mock
+import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 

--- a/server/src/test/scala/org/apache/livy/server/recovery/SessionStoreSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/recovery/SessionStoreSpec.scala
@@ -22,7 +22,7 @@ import scala.util.Success
 import org.mockito.Mockito._
 import org.scalatest.FunSpec
 import org.scalatest.Matchers._
-import org.scalatest.mock.MockitoSugar.mock
+import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 import org.apache.livy.sessions.Session.RecoveryMetadata

--- a/server/src/test/scala/org/apache/livy/server/recovery/StateStoreSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/recovery/StateStoreSpec.scala
@@ -17,8 +17,6 @@
 
 package org.apache.livy.server.recovery
 
-import scala.reflect.classTag
-
 import org.scalatest.{BeforeAndAfter, FunSpec}
 import org.scalatest.Matchers._
 

--- a/server/src/test/scala/org/apache/livy/server/recovery/ZooKeeperStateStoreSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/recovery/ZooKeeperStateStoreSpec.scala
@@ -26,7 +26,7 @@ import org.apache.zookeeper.data.Stat
 import org.mockito.Mockito._
 import org.scalatest.FunSpec
 import org.scalatest.Matchers._
-import org.scalatest.mock.MockitoSugar.mock
+import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 

--- a/server/src/test/scala/org/apache/livy/sessions/SessionManagerSpec.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/SessionManagerSpec.scala
@@ -25,7 +25,7 @@ import scala.util.{Failure, Try}
 import org.mockito.Mockito.{doReturn, never, verify, when}
 import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.concurrent.Eventually._
-import org.scalatest.mock.MockitoSugar.mock
+import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
 import org.apache.livy.server.batch.{BatchRecoveryMetadata, BatchSession}

--- a/server/src/test/scala/org/apache/livy/utils/LivySparkUtilsSuite.scala
+++ b/server/src/test/scala/org/apache/livy/utils/LivySparkUtilsSuite.scala
@@ -46,6 +46,8 @@ class LivySparkUtilsSuite extends FunSuite with Matchers with LivyBaseUnitTestSu
   test("should recognize supported Spark versions") {
     testSparkVersion("2.2.0")
     testSparkVersion("2.3.0")
+    testSparkVersion("2.4.0")
+    testSparkVersion("3.0.0")
   }
 
   test("should complain about unsupported Spark versions") {
@@ -85,6 +87,8 @@ class LivySparkUtilsSuite extends FunSuite with Matchers with LivyBaseUnitTestSu
   test("defaultSparkScalaVersion() should return default Scala version") {
     defaultSparkScalaVersion(formatSparkVersion("2.2.1")) shouldBe "2.11"
     defaultSparkScalaVersion(formatSparkVersion("2.3.0")) shouldBe "2.11"
+    defaultSparkScalaVersion(formatSparkVersion("2.4.0")) shouldBe "2.11"
+    defaultSparkScalaVersion(formatSparkVersion("3.0.0")) shouldBe "2.12"
   }
 
   test("sparkScalaVersion() should use spark-submit detected Scala version.") {
@@ -104,5 +108,6 @@ class LivySparkUtilsSuite extends FunSuite with Matchers with LivyBaseUnitTestSu
   test("sparkScalaVersion() should use default Spark Scala version.") {
     sparkScalaVersion(formatSparkVersion("2.2.0"), None, livyConf) shouldBe "2.11"
     sparkScalaVersion(formatSparkVersion("2.3.1"), None, livyConf) shouldBe "2.11"
+    sparkScalaVersion(formatSparkVersion("3.0.0"), None, livyConf) shouldBe "2.12"
   }
 }

--- a/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
@@ -35,7 +35,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.concurrent.Eventually
 import org.scalatest.FunSpec
-import org.scalatest.mock.MockitoSugar.mock
+import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf, Utils}
 import org.apache.livy.utils.SparkApp._

--- a/test-lib/src/main/java/org/apache/livy/test/jobs/SQLGetTweets.java
+++ b/test-lib/src/main/java/org/apache/livy/test/jobs/SQLGetTweets.java
@@ -61,7 +61,7 @@ public class SQLGetTweets implements Job<List<String>> {
     }
 
     SQLContext sqlctx = useHiveContext ? jc.hivectx() : jc.sqlctx();
-    sqlctx.read().json(input.toString()).registerTempTable("tweets");
+    sqlctx.read().json(input.toString()).createOrReplaceTempView("tweets");
 
     List<String> tweetList = new ArrayList<>();
     Row[] result =

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/types/DataTypeUtils.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/types/DataTypeUtils.scala
@@ -17,7 +17,7 @@
 
 package org.apache.livy.thriftserver.types
 
-import org.json4s.{DefaultFormats, JValue}
+import org.json4s.{DefaultFormats, JValue, StringInput}
 import org.json4s.JsonAST.{JObject, JString}
 import org.json4s.jackson.JsonMethods.parse
 
@@ -52,6 +52,7 @@ object DataTypeUtils {
     }
   }
 
+
   /**
    * Converts a JSON representing the Spark schema (the one returned by `df.schema.json`) into
    * a [[Schema]] instance.
@@ -60,7 +61,7 @@ object DataTypeUtils {
    * @return a [[Schema]] representing the schema provided as input
    */
   def schemaFromSparkJson(sparkJson: String): Schema = {
-    val schema = parse(sparkJson) \ "fields"
+    val schema = parse(StringInput(sparkJson), false) \ "fields"
     val fields = schema.children.map { field =>
       val name = (field \ "name").extract[String]
       val hiveType = toFieldType(field \ "type")

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
@@ -516,7 +516,8 @@ class BinaryThriftServerSuite extends ThriftServerBaseTest with CommonThriftTest
           statement.close()
         }
       }
-      assert(caught.getMessage.contains("Table or view not found: `global_temp`.`invalid_table`"))
+      assert(caught.getMessage.replaceAll("`", "")
+        .contains("Table or view not found: global_temp.invalid_table"))
     }
   }
 

--- a/thriftserver/session/pom.xml
+++ b/thriftserver/session/pom.xml
@@ -106,5 +106,17 @@
         <json4s.version>3.5.3</json4s.version>
       </properties>
     </profile>
+    <profile>
+      <id>spark-2.4-2.12</id>
+      <properties>
+        <json4s.version>3.5.3</json4s.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>spark-3.0</id>
+      <properties>
+        <json4s.version>3.6.6</json4s.version>
+      </properties>
+    </profile>
   </profiles>
 </project>

--- a/thriftserver/session/src/test/java/org/apache/livy/thriftserver/session/ColumnBufferTest.java
+++ b/thriftserver/session/src/test/java/org/apache/livy/thriftserver/session/ColumnBufferTest.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.launcher.SparkLauncher;
 import org.apache.spark.sql.Dataset;
@@ -36,6 +35,7 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.StructField;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -46,14 +46,14 @@ public class ColumnBufferTest {
   public void testColumnBuffer() throws Exception {
     String warehouse = Files.createTempDirectory("spark-warehouse-").toFile().getAbsolutePath();
 
-    SparkConf conf = new SparkConf()
-      .set(SparkLauncher.SPARK_MASTER, "local")
-      .set("spark.app.name", getClass().getName())
-      .set("spark.sql.warehouse.dir", warehouse);
-    SparkContext sc = new SparkContext(conf);
+    SparkSession session = SparkSession.builder()
+            .master("local")
+            .appName(getClass().getName())
+            .config("spark.sql.warehouse.dir", warehouse)
+            .getOrCreate();
 
     try {
-      SQLContext spark = SQLContext.getOrCreate(sc);
+      SQLContext spark = session.sqlContext();
 
       TestBean tb = new TestBean();
       tb.setId(1);
@@ -144,7 +144,7 @@ public class ColumnBufferTest {
         }
       }
     } finally {
-      sc.stop();
+      session.stop();
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add spark 3.0 support to livy with scala 2.12 and Python 3
Fix also https://issues.apache.org/jira/browse/LIVY-423 

## How was this patch tested?
Scala, Python 2 and 3 test work
I'm not able yet to make sparkR work for spark 3 yet.
