### PR TITLE
[LIVY-763] Fix File Descriptor leak from DirectoryStream

### DIFF
--- a/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
@@ -41,6 +41,8 @@ import org.apache.livy.{Logging, Utils}
 import org.apache.livy.client.common.ClientConf
 import org.apache.livy.rsc.driver.SparkEntries
 import org.apache.livy.sessions._
+import org.apache.livy.Utils.usingResource
+
 
 // scalastyle:off println
 object PythonInterpreter extends Logging {
@@ -86,10 +88,10 @@ object PythonInterpreter extends Logging {
           require(pyArchivesFile.exists(),
             "pyspark.zip not found; cannot start pyspark interpreter.")
 
-          val py4jFile = Files.newDirectoryStream(Paths.get(pyLibPath), "py4j-*-src.zip")
-            .iterator()
-            .next()
-            .toFile
+          val py4jFile = usingResource(
+            Files.newDirectoryStream(Paths.get(pyLibPath), "py4j-*-src.zip")) { ds =>
+              ds.iterator().next().toFile
+          }
 
           require(py4jFile.exists(),
             "py4j-*-src.zip not found; cannot start pyspark interpreter.")

--- a/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
@@ -43,7 +43,6 @@ import org.apache.livy.rsc.driver.SparkEntries
 import org.apache.livy.sessions._
 import org.apache.livy.Utils.usingResource
 
-
 // scalastyle:off println
 object PythonInterpreter extends Logging {
 

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -46,7 +46,6 @@ import org.apache.livy.sessions.SessionState.Dead
 import org.apache.livy.utils._
 import org.apache.livy.Utils.usingResource
 
-
 @JsonIgnoreProperties(ignoreUnknown = true)
 case class InteractiveRecoveryMetadata(
     id: Int,

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -44,6 +44,8 @@ import org.apache.livy.sessions._
 import org.apache.livy.sessions.Session._
 import org.apache.livy.sessions.SessionState.Dead
 import org.apache.livy.utils._
+import org.apache.livy.Utils.usingResource
+
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 case class InteractiveRecoveryMetadata(
@@ -254,10 +256,9 @@ object InteractiveSession extends Logging {
             val pyLibPath = Seq(sparkHome, "python", "lib").mkString(File.separator)
             val pyArchivesFile = new File(pyLibPath, "pyspark.zip")
             val py4jFile = Try {
-              Files.newDirectoryStream(Paths.get(pyLibPath), "py4j-*-src.zip")
-                .iterator()
-                .next()
-                .toFile
+              usingResource(Files.newDirectoryStream(Paths.get(pyLibPath), "py4j-*-src.zip")) { ds =>
+                ds.iterator().next().toFile
+              }
             }.toOption
 
             if (!pyArchivesFile.exists()) {

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -255,7 +255,8 @@ object InteractiveSession extends Logging {
             val pyLibPath = Seq(sparkHome, "python", "lib").mkString(File.separator)
             val pyArchivesFile = new File(pyLibPath, "pyspark.zip")
             val py4jFile = Try {
-              usingResource(Files.newDirectoryStream(Paths.get(pyLibPath), "py4j-*-src.zip")) { ds =>
+              usingResource(
+                Files.newDirectoryStream(Paths.get(pyLibPath), "py4j-*-src.zip")) { ds =>
                 ds.iterator().next().toFile
               }
             }.toOption


### PR DESCRIPTION
## What changes were proposed in this pull request?

Wrap calls to `Files.newDirectoryStream` with `usingResource` from the Utils package in 
`InteractiveSession` and `PythonInterpreter`

JIRA: https://issues.apache.org/jira/browse/LIVY-763

We recently upgraded from Livy 0.4 to Livy 0.6 and started to run out of FDs (we fire up thousands of InteractiveSessions a day).  Looking at the open FDs, they were all DIR handles for `/usr/lib/spark/python/lib`.

I believe this change was introduced in https://github.com/apache/incubator-livy/commit/1bbefe601641aa4db74dbed1f7faf458b9a70a63#diff-7649a51ad4bddc91b6f1038e06479d41R259-R264

The behavior without this change and the default config is Livy will open 2 FDs for each InteractiveSession, and they will never be closed (I think because `DirectoryStream` is 
`AutoCloseable` and try-with-resource doesn't work with Scala's `Try`.

As a workaround, in our production clusters, we have set `livy.rsc.pyspark.archives` to an empty string in `livy.conf`

## How was this patch tested?

Ran the functions in a scala repl and monitored the FDs using lsof.  Ran them again with `usingResource` and verified no FDs leak.  Ran unit tests.
