### PR TITLE
[LIVY-764] Give code block a filename and cache it in linecache

### DIFF
--- a/repl/src/main/resources/fake_shell.py
+++ b/repl/src/main/resources/fake_shell.py
@@ -215,14 +215,15 @@ class ExecutionError(Exception):
 
 class NormalNode(object):
     def __init__(self, code):
-        self.cell_name = self.code_name(code)
+        self.cell_name = NormalNode._code_name(code)
         linecache_entry = (len(code), time.time(), [line+'\n' for line in code.splitlines()], self.cell_name)
         linecache.cache[self.cell_name] = linecache_entry
         linecache._livy_cache[self.cell_name] = linecache_entry
 
         self.code = compile(code, self.cell_name, 'exec', ast.PyCF_ONLY_AST, 1)
 
-    def code_name(self, code, number=0):
+    @staticmethod
+    def _code_name(code, number=0):
         """ Compute a (probably) unique name for code for caching.
         This now expects code to be unicode.
         """

--- a/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
@@ -194,14 +194,13 @@ abstract class PythonBaseInterpreterSpec extends BaseInterpreterSpec {
 
   it should "report an error if accessing an unknown variable" in withInterpreter { interpreter =>
     val response = interpreter.execute("x")
-    response should equal(Interpreter.ExecuteError(
-      "NameError",
-      "name 'x' is not defined",
-      List(
-        "Traceback (most recent call last):\n",
-        "NameError: name 'x' is not defined\n"
-      )
-    ))
+    response shouldBe a [Interpreter.ExecuteError]
+    val executeErrorResp = response.asInstanceOf[Interpreter.ExecuteError]
+
+    executeErrorResp.ename shouldEqual "NameError"
+    executeErrorResp.evalue shouldEqual "name 'x' is not defined"
+    executeErrorResp.traceback.head shouldEqual "Traceback (most recent call last):\n"
+    executeErrorResp.traceback.last shouldEqual "NameError: name 'x' is not defined\n"
   }
 
   it should "report an error if empty magic command" in withInterpreter { interpreter =>
@@ -228,26 +227,26 @@ abstract class PythonBaseInterpreterSpec extends BaseInterpreterSpec {
         |'
       """.stripMargin)
 
-    response should equal(Interpreter.ExecuteError(
-      "SyntaxError",
-      "EOL while scanning string literal (<stdin>, line 2)",
-      List(
-        "  File \"<stdin>\", line 2\n",
-        "    '\n",
-        "    ^\n",
-        "SyntaxError: EOL while scanning string literal\n"
-      )
-    ))
+    response shouldBe a [Interpreter.ExecuteError]
+    val executeErrorResp = response.asInstanceOf[Interpreter.ExecuteError]
+
+    executeErrorResp.ename shouldEqual "SyntaxError"
+    executeErrorResp.evalue should startWith ("EOL while scanning string literal (")
+    executeErrorResp.evalue should endWith (", line 2)")
+    executeErrorResp.traceback should have size 4
+    executeErrorResp.traceback(0) should startWith ("  File ")
+    executeErrorResp.traceback(0) should endWith (", line 2\n")
+    executeErrorResp.traceback(1) shouldEqual "    '\n"
+    executeErrorResp.traceback(2) shouldEqual "    ^\n"
+    executeErrorResp.traceback(3) shouldEqual "SyntaxError: EOL while scanning string literal\n"
 
     response = intp.execute("x")
-    response should equal(Interpreter.ExecuteError(
-      "NameError",
-      "name 'x' is not defined",
-      List(
-        "Traceback (most recent call last):\n",
-        "NameError: name 'x' is not defined\n"
-      )
-    ))
+    val executeErrorResp2 = response.asInstanceOf[Interpreter.ExecuteError]
+
+    executeErrorResp2.ename shouldEqual "NameError"
+    executeErrorResp2.evalue shouldEqual "name 'x' is not defined"
+    executeErrorResp2.traceback.head shouldEqual "Traceback (most recent call last):\n"
+    executeErrorResp2.traceback.last shouldEqual "NameError: name 'x' is not defined\n"
   }
 }
 

--- a/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
@@ -194,7 +194,7 @@ abstract class PythonBaseInterpreterSpec extends BaseInterpreterSpec {
 
   it should "report an error if accessing an unknown variable" in withInterpreter { interpreter =>
     val response = interpreter.execute("x")
-    response shouldBe a [Interpreter.ExecuteError]
+    response shouldBe a[Interpreter.ExecuteError]
     val executeErrorResp = response.asInstanceOf[Interpreter.ExecuteError]
 
     executeErrorResp.ename shouldEqual "NameError"
@@ -227,7 +227,7 @@ abstract class PythonBaseInterpreterSpec extends BaseInterpreterSpec {
         |'
       """.stripMargin)
 
-    response shouldBe a [Interpreter.ExecuteError]
+    response shouldBe a[Interpreter.ExecuteError]
     val executeErrorResp = response.asInstanceOf[Interpreter.ExecuteError]
 
     executeErrorResp.ename shouldEqual "SyntaxError"

--- a/repl/src/test/scala/org/apache/livy/repl/PythonSessionSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/PythonSessionSpec.scala
@@ -17,9 +17,10 @@
 
 package org.apache.livy.repl
 
-import org.json4s.{Extraction, JString}
+import org.json4s.Extraction
 import org.json4s.jackson.JsonMethods.parse
 import org.scalatest._
+
 import org.apache.livy.sessions._
 
 abstract class PythonSessionSpec extends BaseSessionSpec(PySpark) {

--- a/repl/src/test/scala/org/apache/livy/repl/PythonSessionSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/PythonSessionSpec.scala
@@ -17,10 +17,9 @@
 
 package org.apache.livy.repl
 
-import org.json4s.Extraction
+import org.json4s.{Extraction, JString}
 import org.json4s.jackson.JsonMethods.parse
 import org.scalatest._
-
 import org.apache.livy.sessions._
 
 abstract class PythonSessionSpec extends BaseSessionSpec(PySpark) {
@@ -128,18 +127,14 @@ abstract class PythonSessionSpec extends BaseSessionSpec(PySpark) {
     statement.id should equal (0)
 
     val result = parse(statement.output)
-    val expectedResult = Extraction.decompose(Map(
-      "status" -> "error",
-      "execution_count" -> 0,
-      "traceback" -> List(
-        "Traceback (most recent call last):\n",
-        "NameError: name 'x' is not defined\n"
-      ),
-      "ename" -> "NameError",
-      "evalue" -> "name 'x' is not defined"
-    ))
+    (result \ "status").extract[String] shouldEqual "error"
+    (result \ "execution_count").extract[Int] shouldEqual 0
+    (result \ "ename").extract[String] shouldEqual "NameError"
+    (result \ "evalue").extract[String] shouldEqual "name 'x' is not defined"
 
-    result should equal (expectedResult)
+    val traceback = (result \ "traceback").values.asInstanceOf[List[String]]
+    traceback.head shouldEqual "Traceback (most recent call last):\n"
+    traceback.last shouldEqual "NameError: name 'x' is not defined\n"
   }
 
   it should "report an error if exception is thrown" in withSession { session =>
@@ -153,20 +148,18 @@ abstract class PythonSessionSpec extends BaseSessionSpec(PySpark) {
     statement.id should equal (0)
 
     val result = parse(statement.output)
-    val expectedResult = Extraction.decompose(Map(
-      "status" -> "error",
-      "execution_count" -> 0,
-      "traceback" -> List(
-        "Traceback (most recent call last):\n",
-        "  File \"<stdin>\", line 4, in func2\n",
-        "  File \"<stdin>\", line 2, in func1\n",
-        "Exception: message\n"
-      ),
-      "ename" -> "Exception",
-      "evalue" -> "message"
-    ))
+    (result \ "status").extract[String] shouldEqual "error"
+    (result \ "execution_count").extract[Int] shouldEqual 0
+    (result \ "ename").extract[String] shouldEqual "Exception"
+    (result \ "evalue").extract[String] shouldEqual "message"
 
-    result should equal (expectedResult)
+    val traceback = (result \ "traceback").values.asInstanceOf[List[String]]
+    traceback should have size 6
+    traceback(0) shouldEqual "Traceback (most recent call last):\n"
+    traceback(2) should endWith (", line 5, in <module>\n    func2()\n")
+    traceback(3) should endWith (", line 4, in func2\n    func1()\n")
+    traceback(4) should endWith (", line 2, in func1\n    raise Exception(\"message\")\n")
+    traceback(5) shouldEqual "Exception: message\n"
   }
 }
 

--- a/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
@@ -214,18 +214,15 @@ class InteractiveSessionSpec extends FunSpec
 
     withSession("should report an error if accessing an unknown variable") { session =>
       val result = executeStatement("x")
-      val expectedResult = Extraction.decompose(Map(
-        "status" -> "error",
-        "execution_count" -> 3,
-        "ename" -> "NameError",
-        "evalue" -> "name 'x' is not defined",
-        "traceback" -> List(
-          "Traceback (most recent call last):\n",
-          "NameError: name 'x' is not defined\n"
-        )
-      ))
+      (result \ "status").extract[String] shouldEqual "error"
+      (result \ "execution_count").extract[Int] shouldEqual 3
+      (result \ "ename").extract[String] shouldEqual "NameError"
+      (result \ "evalue").extract[String] shouldEqual "name 'x' is not defined"
 
-      result should equal (expectedResult)
+      val traceback = (result \ "traceback").values.asInstanceOf[List[String]]
+      traceback.head shouldEqual "Traceback (most recent call last):\n"
+      traceback.last shouldEqual "NameError: name 'x' is not defined\n"
+
       eventually(timeout(10 seconds), interval(30 millis)) {
         session.state shouldBe (SessionState.Idle)
       }


### PR DESCRIPTION
[LIVY-764] Give code block a filename and cache it in linecache

## What changes were proposed in this pull request?

Today python shell (`fake_shell.py`) uses 'stdin' as file name to compile code blocks and never caches them in linecache. This breaks the user code that depends on `inspect.findsource`, like `torch.jit.script`

To enable code block caching at the backend, we can use the way how ipython does: https://github.com/ipython/ipython/blob/44bd47d5ac27805a297798d39ad7e31f63181468/IPython/core/compilerop.py#L54

## How was this patch tested?

E2E test with local livy server
