### PR TITLE
[LIVY-765] Not dispose rpc server may cause leak problem

### DIFF
--- a/rsc/src/main/java/org/apache/livy/rsc/ContextLauncher.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/ContextLauncher.java
@@ -112,10 +112,9 @@ class ContextLauncher {
       Utils.addListener(promise, new FutureListener<ContextInfo>() {
         @Override
         public void onFailure(Throwable error) throws Exception {
-          // If promise is cancelled or failed, make sure spark-submit is not leaked.
-          if (child != null) {
-            child.kill();
-          }
+          // If promise is cancelled or failed,
+          // dispose spark submit and rpc server in case of leak problem.
+          dispose(true);
         }
       });
 
@@ -145,7 +144,9 @@ class ContextLauncher {
   }
 
   private void dispose(boolean forceKill) {
-    factory.getServer().unregisterClient(clientId);
+    if (factory.getServer() != null) {
+      factory.getServer().unregisterClient(clientId);
+    }
     try {
       if (child != null) {
         if (forceKill) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Livy could not dispose rpc server if session is not created successfully.
To reproduce this issue,

1. Create a session with name test
2. After session created successfully, create another session with same name test
3. We would get duplicate session name exception, and the session would be stopped, but the rpc server with channel port is not closed.

Looks like RSC client called `this.contextInfoPromise.cancel(true);` method to shutdown spark submit process, but it does not close rpc server.

## How was this patch tested?

Manually tested with the above case and ran existing unit tests