### PR TITLE
[LIVY-768] Pin python dependency version for test stability

### DIFF
--- a/python-api/setup.py
+++ b/python-api/setup.py
@@ -28,7 +28,7 @@ CLASSIFIERS = [
 ]
 
 requirements = [
-    'cloudpickle>=0.2.1',
+    'cloudpickle<=1.3.0',
     'configparser>=3.5.0',
     'future>=0.15.2',
     'futures>=3.0.5',
@@ -55,5 +55,5 @@ setup(
     classifiers=CLASSIFIERS,
     install_requires=requirements,
     setup_requires=['pytest-runner', 'flake8'],
-    tests_require=['pytest']
+    tests_require=['pytest<5']
 )


### PR DESCRIPTION
## What changes were proposed in this pull request?
Running python-api tests in a fresh environments shows that some python dependencies need to pinned to earlier version to allow the tests to work.  
This PR pins dependencies pytest < 5.0 and cloudpickle to <= 1.3.0.

Test error transcript attached to the JIRA entry at https://issues.apache.org/jira/browse/LIVY-768

## How was this patch tested?
Tests run on a clean environment after dependencies are pinned.
