### PR TITLE
[LIVY-769] Fix field name in REST API docs

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -231,8 +231,8 @@ Gets the log lines from this session.
     <td>int</td>
   </tr>
   <tr>
-    <td>size</td>
-    <td>Max number of log lines</td>
+    <td>total</td>
+    <td>The total number of log lines that exist</td>
     <td>int</td>
   </tr>
   <tr>
@@ -551,8 +551,8 @@ Gets the log lines from this batch.
     <td>int</td>
   </tr>
   <tr>
-    <td>size</td>
-    <td>Number of log lines</td>
+    <td>total</td>
+    <td>The total number of log lines that exist</td>
     <td>int</td>
   </tr>
   <tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The [session and batch log endpoints](https://github.com/apache/incubator-livy/blob/1c656aad3495814fb55b5c2f5be708642b6174f3/server/src/main/scala/org/apache/livy/server/SessionServlet.scala#L105)
return the total number of lines under the key "total", however the docs
currently describe this field as "size" - this PR corrects the docs.

Fixes https://issues.apache.org/jira/browse/LIVY-769

## How was this patch tested?

Manually building the docs.