### PR TITLE
[LIVY-771][THRIFT] Do not remove trailing zeros from decimal values.

### DIFF
--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/ThriftServerSuites.scala
@@ -17,6 +17,7 @@
 
 package org.apache.livy.thriftserver
 
+import java.math.BigDecimal
 import java.sql.{Connection, Date, SQLException, Statement, Timestamp, Types}
 
 import scala.collection.mutable.ArrayBuffer
@@ -49,7 +50,10 @@ trait CommonThriftTests {
         "cast('2018-08-06 09:11:15' as timestamp)," +
         "cast('2018-08-06' as date)," +
         "cast(1234567890 as decimal(10))," +
-        "cast(1234567890 as decimal)")
+        "cast(1234567890 as decimal)," +
+        "cast(123.45 as decimal(5, 2))," +
+        "cast(123.4 as decimal(5, 2))," +
+        "cast(123 as decimal(5, 2))")
 
     val rsMetaData = resultSet.getMetaData()
 
@@ -112,6 +116,13 @@ trait CommonThriftTests {
     assert(rsMetaData.getColumnTypeName(16) == "decimal")
     assert(rsMetaData.getPrecision(16) == 10)
     assert(rsMetaData.getScale(16) == 0)
+
+    assert(resultSet.getString(17) == "123.45")
+    assert(resultSet.getBigDecimal(17) == new BigDecimal("123.45"))
+    assert(resultSet.getString(18) == "123.40")
+    assert(resultSet.getBigDecimal(18) == new BigDecimal("123.40"))
+    assert(resultSet.getString(19) == "123.00")
+    assert(resultSet.getBigDecimal(19) == new BigDecimal("123.00"))
 
     assert(!resultSet.next())
 

--- a/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ResultSet.java
+++ b/thriftserver/session/src/main/java/org/apache/livy/thriftserver/session/ResultSet.java
@@ -88,7 +88,7 @@ public class ResultSet {
     } else if (quoteStrings && value instanceof String) {
       return "\"" + value + "\"";
     } else if (value instanceof BigDecimal) {
-      return ((BigDecimal) value).stripTrailingZeros().toString();
+      return ((BigDecimal) value).toString();
     } else if (value instanceof Map) {
       return stream(new ScalaIterator<>(((Map<?,?>) value).iterator()))
         .map(o -> toHiveString(o, true))

--- a/thriftserver/session/src/test/java/org/apache/livy/thriftserver/session/ColumnBufferTest.java
+++ b/thriftserver/session/src/test/java/org/apache/livy/thriftserver/session/ColumnBufferTest.java
@@ -76,6 +76,8 @@ public class ColumnBufferTest {
 
       Encoder<TestBean> encoder = Encoders.bean(TestBean.class);
       Dataset<TestBean> ds = spark.createDataset(Arrays.asList(tb), encoder);
+      // In ds, the decimal field will be a org.apache.spark.sql.types.DecimalType,
+      // specifically DecimalType.SYSTEM_DEFAULT, i.e., DecimalType(38, 18).
 
       ds.write().format("parquet").saveAsTable("types_test");
 
@@ -117,7 +119,9 @@ public class ColumnBufferTest {
           assertEquals(Double.valueOf(tb.getDbl()), cols[idx++].get(0));
           break;
         case "decimal":
-          assertEquals(tb.getDecimal().stripTrailingZeros().toString(), cols[idx++].get(0));
+          // As decimal maps to DecimalType(38, 18), we need to change the scale
+          // before comparing
+          assertEquals(tb.getDecimal().setScale(18).toString(), cols[idx++].get(0));
           break;
         case "desc":
           assertEquals(tb.getDesc(), cols[idx++].get(0));

--- a/thriftserver/session/src/test/java/org/apache/livy/thriftserver/session/ColumnBufferTest.java
+++ b/thriftserver/session/src/test/java/org/apache/livy/thriftserver/session/ColumnBufferTest.java
@@ -75,9 +75,9 @@ public class ColumnBufferTest {
       tb.getChild().getM().put("two", 2);
 
       Encoder<TestBean> encoder = Encoders.bean(TestBean.class);
+      // In the following Dataset ds, the Encoder maps the decimal field in the TestBean class
+      // to org.apache.spark.sql.types.DecimalType.SYSTEM_DEFAULT, i.e., DecimalType(38, 18).
       Dataset<TestBean> ds = spark.createDataset(Arrays.asList(tb), encoder);
-      // In ds, the decimal field will be a org.apache.spark.sql.types.DecimalType,
-      // specifically DecimalType.SYSTEM_DEFAULT, i.e., DecimalType(38, 18).
 
       ds.write().format("parquet").saveAsTable("types_test");
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The decimal SQL type is mapped to `java.math.BigDecimal`. Livy removes trailing zeros from the `BigDecimal` before storing its string representation in a `ColumnBuffer`. This causes loss of information in queries of tables with columns of decimal(precision, scale) type. In particular, if you connect to the Livy Thrift server using JDBC, execute a query and get a `java.sql.ResultSet`, then `ResultSet#getBigDecimal` on the index of a column of decimal type can return a `BigDecimal` value of incorrect scale.
In this change, we simply do not remove trailing zeros from the `BigDecimal`.

## How was this patch tested?

Added cases to integration tests, which fail without this change and pass with it.
Fixed `ColumnBufferTest` to account for the change in behavior.
Also tested manually by running beeline against a Livy Thrift server with this change.