### PR TITLE
[LIVY-773] Fix status code when session limit reached

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -129,7 +129,7 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
   post("/") {
     synchronized {
       if (tooManySessions) {
-        BadRequest(ResponseMessage("Rejected, too many sessions are being created!"))
+        ServiceUnavailable(ResponseMessage("Rejected, too many sessions are being created!"))
       } else {
         val session = sessionManager.register(createSession(request))
         // Because it may take some time to establish the session, update the last activity

--- a/server/src/test/scala/org/apache/livy/server/batch/BatchServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/BatchServletSpec.scala
@@ -177,7 +177,7 @@ class BatchServletSpec extends BaseSessionServletSpec[BatchSession, BatchRecover
       }
 
       servlet.livyConf.set(LivyConf.SESSION_MAX_CREATION, 1)
-      jpost[Map[String, Any]]("/", createRequest, SC_BAD_REQUEST) { data => None }
+      jpost[Map[String, Any]]("/", createRequest, SC_SERVICE_UNAVAILABLE) { data => None }
 
       jdelete[Map[String, Any]]("/2") { data =>
         data should equal (Map("msg" -> "deleted"))

--- a/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionServletSpec.scala
@@ -214,7 +214,7 @@ class InteractiveSessionServletSpec extends BaseInteractiveServletSpec {
     servlet.livyConf.set(LivyConf.SESSION_MAX_CREATION, 1)
 
     waitSession
-    jpost[Map[String, Any]]("/", createRequest(), HttpServletResponse.SC_BAD_REQUEST) { data =>
+    jpost[Any]("/", createRequest(), HttpServletResponse.SC_SERVICE_UNAVAILABLE) { _ =>
       None
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

I propose to change http status code from 400 (Bad Request) to 503 (Service Unavailable) when Livy server cannot start new sessions because `livy.server.session.max-creation` is reached.

## How was this patch tested?

Modified existing unit tests.

