### PR TITLE
LIVY-776 - Update Maven Shade Plugin to 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -661,7 +661,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>2.4.2</version>
+          <version>3.2.1</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
In order to apply the PR to update Jackson to 2.10.1 (https://github.com/apache/incubator-livy/pull/258/files), it is also necessary to update the Maven Shade Plugin to avoid an ASM IllegalArgumentException error in the client-http module.

