### PR TITLE
[LIVY-785] Enable adding security related HTTP headers to responses

### DIFF
--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -96,6 +96,17 @@
 # http-header "X-Requested-By" in request if the http method is POST/DELETE/PUT/PATCH.
 # livy.server.csrf-protection.enabled =
 
+# Whether to add security related HTTP headers to responses, by default false. If enabled,
+# Livy server adds HTTP headers to responses based on below configuration parameters starting with
+# `Livy.server.http.header.`
+# livy.server.security-headers.enabled =
+
+# Security headers added to responses by default when
+# configuration `livy.server.security-headers.enabled` is set to true.
+# livy.server.http.header.X-XSS-Protection = 1; mode=block
+# livy.server.http.header.X-Frame-Options = SAMEORIGIN
+# livy.server.http.header.X-Content-Type-Options = nosniff
+
 # Whether to enable HiveContext in livy interpreter, if it is true hive-site.xml will be detected
 # on user request and then livy server classpath automatically.
 # livy.repl.enable-hive-context =

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -69,6 +69,14 @@ object LivyConf {
 
   val CSRF_PROTECTION = Entry("livy.server.csrf-protection.enabled", false)
 
+  val SECURITY_HEADERS_ENABLED = Entry("livy.server.security-headers.enabled", false)
+  val SECURITY_HEADERS_XSS_PROTECTION =
+    Entry("livy.server.http.header.X-XSS-Protection", "1; mode=block")
+  val SECURITY_HEADERS_FRAME_OPTIONS =
+    Entry("livy.server.http.header.X-Frame-Options", "SAMEORIGIN")
+  val SECURITY_HEADERS_CONTENT_TYPE_OPTIONS =
+    Entry("livy.server.http.header.X-Content-Type-Options", "nosniff")
+
   val IMPERSONATION_ENABLED = Entry("livy.impersonation.enabled", false)
   val SUPERUSERS = Entry("livy.superusers", null)
 

--- a/server/src/main/scala/org/apache/livy/server/LivyServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/LivyServer.scala
@@ -30,7 +30,7 @@ import scala.concurrent.Future
 import org.apache.hadoop.security.{SecurityUtil, UserGroupInformation}
 import org.apache.hadoop.security.authentication.server._
 import org.eclipse.jetty.servlet.FilterHolder
-import org.scalatra.{NotFound, ScalatraServlet}
+import org.scalatra.{ApiFormats, NotFound, ScalatraServlet}
 import org.scalatra.metrics.MetricsBootstrap
 import org.scalatra.metrics.MetricsSupportExtensions._
 import org.scalatra.servlet.{MultipartConfig, ServletApiImplicits}
@@ -177,14 +177,26 @@ class LivyServer extends Logging {
     // Servlet for hosting static files such as html, css, and js
     // Necessary since Jetty cannot set it's resource base inside a jar
     // Returns 404 if the file does not exist
-    val staticResourceServlet = new ScalatraServlet {
+    val staticResourceServlet = new ScalatraServlet with ApiFormats {
+
+      addMimeMapping("image/png", "png")
+      addMimeMapping("application/vnd.ms-fontobject", "eot")
+      addMimeMapping("image/svg+xml", "svg")
+      addMimeMapping("font/ttf", "ttf")
+      addMimeMapping("font/woff", "woff")
+      addMimeMapping("font/woff2", "woff2")
+
       get("/*") {
         val fileName = params("splat")
         val notFoundMsg = "File not found"
 
         if (!fileName.isEmpty) {
           getClass.getResourceAsStream(s"ui/static/$fileName") match {
-            case is: InputStream => new BufferedInputStream(is)
+            case is: InputStream => {
+              val extension = fileName.split("\\.").last
+              contentType = formats(extension)
+              new BufferedInputStream(is)
+            }
             case null => NotFound(notFoundMsg)
           }
         } else {
@@ -313,6 +325,12 @@ class LivyServer extends Logging {
       info("CSRF protection is enabled.")
       val csrfHolder = new FilterHolder(new CsrfFilter())
       server.context.addFilter(csrfHolder, "/*", EnumSet.allOf(classOf[DispatcherType]))
+    }
+
+    if(livyConf.getBoolean(SECURITY_HEADERS_ENABLED)) {
+      info("Adding security headers is enabled.")
+      val securityHeadersHolder = new FilterHolder(new SecurityHeadersFilter(livyConf))
+      server.context.addFilter(securityHeadersHolder, "/*", EnumSet.allOf(classOf[DispatcherType]))
     }
 
     if (accessManager.isAccessControlOn) {

--- a/server/src/main/scala/org/apache/livy/server/SecurityHeadersFilter.scala
+++ b/server/src/main/scala/org/apache/livy/server/SecurityHeadersFilter.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.server
+
+import javax.servlet.{Filter, FilterChain, FilterConfig, ServletRequest, ServletResponse}
+import javax.servlet.http.HttpServletResponse
+
+import org.apache.livy.LivyConf
+
+/**
+ * Adds security related headers to HTTP responses.
+ */
+class SecurityHeadersFilter(livyConf: LivyConf) extends Filter {
+
+  val headers : Map[String, String] = Map(
+    "X-Content-Type-Options" -> livyConf.get(LivyConf.SECURITY_HEADERS_CONTENT_TYPE_OPTIONS),
+    "X-Frame-Options" -> livyConf.get(LivyConf.SECURITY_HEADERS_FRAME_OPTIONS),
+    "X-XSS-Protection" -> livyConf.get(LivyConf.SECURITY_HEADERS_XSS_PROTECTION))
+    .filter(e => e._2 != null && e._2.trim().length > 0)
+
+  override def init(filterConfig: FilterConfig): Unit = {}
+
+  override def doFilter(request: ServletRequest,
+                        response: ServletResponse,
+                        chain: FilterChain): Unit = {
+    val servletResponse = response.asInstanceOf[HttpServletResponse]
+    for ((k, v) <- headers) {
+      servletResponse.addHeader(k, v)
+    }
+    chain.doFilter(request, response)
+}
+
+  override def destroy(): Unit = {}
+}


### PR DESCRIPTION


## What changes were proposed in this pull request?

This change introduces a new configuration option `livy.server.security-headers.enabled`.
When this property is set to true, the following security headers are added to HTTP
responses by default:
* X-XSS-Protection
* X-Frame_options
* X-Content-Type-Options

Also, adds content type information to all responses as required when using content type option nosniff

## How was this patch tested?

Tested manually

