### PR TITLE
Bump jetty.version from 9.3.24.v20180605 to 9.4.31.v20200723

### DIFF
--- a/client-http/src/test/scala/org/apache/livy/client/http/LivyConnectionSpec.scala
+++ b/client-http/src/test/scala/org/apache/livy/client/http/LivyConnectionSpec.scala
@@ -38,7 +38,9 @@ class LivyConnectionSpec extends FunSpecLike with BeforeAndAfterAll with LivyBas
       val roles = Array("user")
 
       val l = new HashLoginService()
-      l.putUser(username, Credential.getCredential(password), roles)
+      val userStore = new UserStore()
+      userStore.addUser(username, Credential.getCredential(password), roles)
+      l.setUserStore(userStore)
       l.setName(realm)
 
       val constraint = new Constraint()

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <httpcore.version>4.4.4</httpcore.version>
     <jackson.version>2.10.1</jackson.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-    <jetty.version>9.3.24.v20180605</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
     <json4s.spark-2.11.version>3.5.3</json4s.spark-2.11.version>
     <json4s.spark-2.12.version>3.5.3</json4s.spark-2.12.version>
     <json4s.version>${json4s.spark-2.11.version}</json4s.version>

--- a/server/src/main/scala/org/apache/livy/server/WebServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/WebServer.scala
@@ -47,7 +47,7 @@ class WebServer(livyConf: LivyConf, var host: String, var port: Int) extends Log
       https.setResponseHeaderSize(livyConf.getInt(LivyConf.RESPONSE_HEADER_SIZE))
       https.addCustomizer(new SecureRequestCustomizer())
 
-      val sslContextFactory = new SslContextFactory()
+      val sslContextFactory = new SslContextFactory.Server()
       sslContextFactory.setKeyStorePath(keystore)
 
       val credentialProviderPath = livyConf.get(LivyConf.HADOOP_CREDENTIAL_PROVIDER_PATH)

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftHttpCLIService.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftHttpCLIService.scala
@@ -88,7 +88,7 @@ class ThriftHttpCLIService(
               s"${LivyConf.SSL_KEYSTORE.key} Not configured for SSL connection")
           }
           val keyStorePassword = getKeyStorePassword()
-          val sslContextFactory = new SslContextFactory
+          val sslContextFactory = new SslContextFactory.Server
           val excludedProtocols = livyConf.get(LivyConf.THRIFT_SSL_PROTOCOL_BLACKLIST).split(",")
           info(s"HTTP Server SSL: adding excluded protocols: $excludedProtocols")
           sslContextFactory.addExcludeProtocols(excludedProtocols: _*)


### PR DESCRIPTION

## What changes were proposed in this pull request?

This change upgrades jetty version to a more recent version from the current one that has know security vulnerabilities.
Two code changes were necessary with the upgrade:
- Using SSLContextFactory.Server to allow multiple certificates in keystores
- User management in LivyConnectionSpec

## How was this patch tested?

Ran existing tests
