### PR TITLE
[LIVY-786] Fix cancellation of driver side jobs

### DIFF
--- a/repl/src/main/scala/org/apache/livy/repl/Interpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/Interpreter.scala
@@ -52,4 +52,7 @@ trait Interpreter {
 
   /** Shut down the interpreter. */
   def close(): Unit
+
+  /** Cancel the executions */
+  def cancel(): Unit
 }

--- a/repl/src/main/scala/org/apache/livy/repl/ProcessInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/ProcessInterpreter.scala
@@ -76,6 +76,8 @@ abstract class ProcessInterpreter(process: Process)
     }
   }
 
+  override def cancel(): Unit = {}
+
   protected def sendExecuteRequest(request: String): Interpreter.ExecuteResponse
 
   protected def sendShutdownRequest(): Unit = {}

--- a/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
@@ -277,6 +277,20 @@ private class PythonInterpreter(
     }
   }
 
+  override def cancel(): Unit = {
+    val pythonPid = getPythonPid()
+    info("Sending SIGUSR1 to " + pythonPid)
+    Runtime.getRuntime().exec("kill -SIGUSR1 " + pythonPid)
+  }
+
+  def getPythonPid(): Int = {
+    // This implementation is specific to Unix type systems
+    val field = process.getClass().getDeclaredField("pid")
+    field.setAccessible(true)
+    val pid = field.get(process).asInstanceOf[Int]
+    pid
+  }
+
   private def sendRequest(request: Map[String, Any]): Option[JValue] = {
     stdin.println(write(request))
     stdin.flush()

--- a/repl/src/main/scala/org/apache/livy/repl/SQLInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/SQLInterpreter.scala
@@ -121,4 +121,6 @@ class SQLInterpreter(
   }
 
   override def close(): Unit = { }
+
+  override def cancel(): Unit = {}
 }

--- a/repl/src/test/scala/org/apache/livy/repl/SparkSessionSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/SparkSessionSpec.scala
@@ -209,7 +209,7 @@ class SparkSessionSpec extends BaseSessionSpec(Spark) {
     eventually(timeout(30 seconds), interval(100 millis)) {
       assert(session.statements(stmtId).state.get() == StatementState.Cancelled)
       session.statements(stmtId).output should include (
-        "Job 0 cancelled part of cancelled job group 0")
+        "java.lang.InterruptedException")
     }
   }
 
@@ -232,7 +232,7 @@ class SparkSessionSpec extends BaseSessionSpec(Spark) {
     eventually(timeout(30 seconds), interval(100 millis)) {
       assert(session.statements(stmtId1).state.get() == StatementState.Cancelled)
       session.statements(stmtId1).output should include (
-        "Job 0 cancelled part of cancelled job group 0")
+        "java.lang.InterruptedException")
     }
   }
 

--- a/rsc/src/main/java/org/apache/livy/rsc/driver/Statement.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/driver/Statement.java
@@ -30,6 +30,7 @@ public class Statement {
   public double progress;
   public long started = 0;
   public long completed = 0;
+  public transient String kind;
 
   public Statement(Integer id, String code, StatementState state, String output) {
     this.id = id;
@@ -37,6 +38,11 @@ public class Statement {
     this.state = new AtomicReference<>(state);
     this.output = output;
     this.progress = 0.0;
+  }
+
+  public Statement(Integer id, String code, StatementState state, String output, String kind) {
+    this(id, code, state, output);
+    this.kind = kind;
   }
 
   public Statement() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, cancelling a statement on an interactive session only cancels the jobs running on Spark executors but anything running on the Driver keeps running and keeps the session busy. This can be seen by running a sleep in code and running something immediately after cancelling it. This change fixes the cancellation of such tasks for Scala and Python interpreters.

https://issues.apache.org/jira/projects/LIVY/issues/LIVY-786

## How was this patch tested?
Tested manually on local setup. Sequence of steps followed:
For Python:
1. curl localhost:8998/sessions/0/statements -X POST -H 'Content-Type: application/json' -d '{"code":"import time\ntime.sleep(60)"}' 
2. curl -X POST localhost:8998/sessions/0/statements/0/cancel
3. curl localhost:8998/sessions/0/statements -X POST -H 'Content-Type: application/json' -d '{"code":"print(\"hello\")"}'

The result of second statement was available immediately, meaning that the repl was free.

For Scala:
1. curl localhost:8998/sessions/0/statements -X POST -H 'Content-Type: application/json' -d '{"code":"Thread.sleep(60000)", "kind":"scala"}'
2. curl -X POST localhost:8998/sessions/0/statements/2/cancel
3. curl localhost:8998/sessions/0/statements -X POST -H 'Content-Type: application/json' -d '{"code":"val a=1", "kind":"scala"}'

Here also the sleep was interrupted.