### PR TITLE
[LIVY-781] Respect spark.pyspark.driver.python for PythonInterpreter

### DIFF
--- a/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
@@ -53,7 +53,8 @@ object PythonInterpreter extends Logging {
 
     val driverPythonExec = conf.getOption("spark.pyspark.driver.python")
       .orElse(sys.env.get("PYSPARK_DRIVER_PYTHON"))
-      .orElse(sys.props.get("pyspark.driver.python")) // This java property is only used for internal UT.
+      // This java property is only used for internal UT.
+      .orElse(sys.props.get("pyspark.driver.python"))
       .getOrElse("python")
 
     val secretKey = Utils.createSecret(256)

--- a/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
@@ -51,6 +51,11 @@ object PythonInterpreter extends Logging {
       .orElse(sys.props.get("pyspark.python")) // This java property is only used for internal UT.
       .getOrElse("python")
 
+    val driverPythonExec = conf.getOption("spark.pyspark.driver.python")
+      .orElse(sys.env.get("PYSPARK_DRIVER_PYTHON"))
+      .orElse(sys.props.get("pyspark.driver.python")) // This java property is only used for internal UT.
+      .getOrElse("python")
+
     val secretKey = Utils.createSecret(256)
     val gatewayServer = createGatewayServer(sparkEntries, secretKey)
     gatewayServer.start()
@@ -65,6 +70,7 @@ object PythonInterpreter extends Logging {
       .++(if (!ClientConf.TEST_MODE) findPyFiles(conf) else Nil)
 
     env.put("PYSPARK_PYTHON", pythonExec)
+    env.put("PYSPARK_DRIVER_PYTHON", driverPythonExec)
     env.put("PYTHONPATH", pythonPath.mkString(File.pathSeparator))
     env.put("PYTHONUNBUFFERED", "YES")
     env.put("PYSPARK_GATEWAY_PORT", "" + gatewayServer.getListeningPort)

--- a/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
@@ -287,11 +287,13 @@ class Python3InterpreterSpec extends PythonBaseInterpreterSpec with BeforeAndAft
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    sys.props.put("pyspark.python", "python3")
+    sys.props.put("pyspark.python", "python3.6")
+    sys.props.put("pyspark.driver.python", "python3.7")
   }
 
   override def afterAll(): Unit = {
     sys.props.remove("pyspark.python")
+    sys.props.remove("pyspark.driver.python")
     super.afterAll()
   }
 

--- a/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
@@ -287,8 +287,8 @@ class Python3InterpreterSpec extends PythonBaseInterpreterSpec with BeforeAndAft
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    sys.props.put("pyspark.python", "python3.6")
-    sys.props.put("pyspark.driver.python", "python3.7")
+    sys.props.put("pyspark.python", "python3")
+    sys.props.put("pyspark.driver.python", "python2")
   }
 
   override def afterAll(): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed to respect the `PYSPARK_DRIVER_PYTHON` reflected in [SPARK-13081](https://issues.apache.org/jira/browse/SPARK-13081).

[LIVY-781](https://issues.apache.org/jira/browse/LIVY-781)

## How was this patch tested?

Manually verified.
