### PR TITLE
[LIVY-793] Make keystore type configurable

### DIFF
--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -23,6 +23,9 @@
 # Specify the key password.
 # livy.key-password =
 
+# Name of the keystore implementation that was used when generating the keystore
+# livy.keystore.type = JKS
+
 # Hadoop Credential Provider Path to get "livy.keystore.password" and "livy.key-password".
 # Credential Provider can be created using command as follow:
 # hadoop credential create "livy.keystore.password" -value "secret" -provider jceks://hdfs/path/to/livy.jceks

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -83,6 +83,7 @@ object LivyConf {
   val SSL_KEYSTORE = Entry("livy.keystore", null)
   val SSL_KEYSTORE_PASSWORD = Entry("livy.keystore.password", null)
   val SSL_KEY_PASSWORD = Entry("livy.key-password", null)
+  val SSL_KEYSTORE_TYPE = Entry("livy.keystore.type", "JKS")
 
   val HADOOP_CREDENTIAL_PROVIDER_PATH = Entry("livy.hadoop.security.credential.provider.path", null)
 

--- a/server/src/main/scala/org/apache/livy/server/WebServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/WebServer.scala
@@ -69,6 +69,9 @@ class WebServer(livyConf: LivyConf, var host: String, var port: Int) extends Log
       keyStorePassword.foreach(sslContextFactory.setKeyStorePassword)
       keyPassword.foreach(sslContextFactory.setKeyManagerPassword)
 
+      val keystoreType = livyConf.get(LivyConf.SSL_KEYSTORE_TYPE)
+      sslContextFactory.setKeyStoreType(keystoreType)
+
       (new ServerConnector(server,
         new SslConnectionFactory(sslContextFactory, "http/1.1"),
         new HttpConnectionFactory(https)), "https")

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftBinaryCLIService.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftBinaryCLIService.scala
@@ -77,8 +77,9 @@ class ThriftBinaryCLIService(override val cliService: LivyCLIService, val oomHoo
             s"${LivyConf.SSL_KEYSTORE.key} Not configured for SSL connection")
         }
         val keyStorePassword = getKeyStorePassword()
+        val keystoreType = livyConf.get(LivyConf.SSL_KEYSTORE_TYPE)
         val params = new TSSLTransportFactory.TSSLTransportParameters
-        params.setKeyStore(keyStorePath, keyStorePassword)
+        params.setKeyStore(keyStorePath, keyStorePassword, null, keystoreType)
         serverSocket =
           TSSLTransportFactory.getServerSocket(portNum, 0, serverAddress.getAddress, params)
         if (serverSocket.getServerSocket.isInstanceOf[SSLServerSocket]) {

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftHttpCLIService.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftHttpCLIService.scala
@@ -88,6 +88,7 @@ class ThriftHttpCLIService(
               s"${LivyConf.SSL_KEYSTORE.key} Not configured for SSL connection")
           }
           val keyStorePassword = getKeyStorePassword()
+          val keystoreType = livyConf.get(LivyConf.SSL_KEYSTORE_TYPE)
           val sslContextFactory = new SslContextFactory
           val excludedProtocols = livyConf.get(LivyConf.THRIFT_SSL_PROTOCOL_BLACKLIST).split(",")
           info(s"HTTP Server SSL: adding excluded protocols: $excludedProtocols")
@@ -96,6 +97,7 @@ class ThriftHttpCLIService(
             sslContextFactory.getExcludeProtocols)
           sslContextFactory.setKeyStorePath(keyStorePath)
           sslContextFactory.setKeyStorePassword(keyStorePassword)
+          sslContextFactory.setKeyStoreType(keystoreType)
           new ServerConnector(server, sslContextFactory, http)
         } else {
           new ServerConnector(server, http)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change introduces configuration parameter `livy.keystore.type`.
The default value is JKS which is equivalent to current functionality.

## How was this patch tested?

This change was tested by running existing tests and manually verifying functionality using non-JKS keystore.

