### PR TITLE
[LIVY-783] Use shaded kryo library

### DIFF
--- a/client-common/pom.xml
+++ b/client-common/pom.xml
@@ -37,7 +37,7 @@
 
     <dependency>
       <groupId>com.esotericsoftware</groupId>
-      <artifactId>kryo</artifactId>
+      <artifactId>kryo-shaded</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
 
       <dependency>
         <groupId>com.esotericsoftware</groupId>
-        <artifactId>kryo</artifactId>
+        <artifactId>kryo-shaded</artifactId>
         <version>${kryo.version}</version>
       </dependency>
 

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -124,6 +124,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.esotericsoftware</groupId>
+      <artifactId>kryo-shaded</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-compiler</artifactId>
       <scope>provided</scope>
@@ -176,6 +181,7 @@
                   <include>org.json4s:json4s-core_${scala.binary.version}</include>
                   <include>org.json4s:json4s-jackson_${scala.binary.version}</include>
                   <include>org.json4s:json4s-scalap_${scala.binary.version}</include>
+                  <include>com.esotericsoftware:kryo-shaded</include>
                 </includes>
               </artifactSet>
               <filters>
@@ -191,6 +197,10 @@
                 <relocation>
                   <pattern>org.json4s</pattern>
                   <shadedPattern>org.apache.livy.shaded.json4s</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.esotericsoftware</pattern>
+                  <shadedPattern>org.apache.livy.shaded.kryo</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -59,7 +59,7 @@
 
     <dependency>
       <groupId>com.esotericsoftware</groupId>
-      <artifactId>kryo</artifactId>
+      <artifactId>kryo-shaded</artifactId>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
@@ -140,9 +140,8 @@
               <artifactSet>
                 <includes>
                   <include>org.apache.livy:livy-client-common</include>
-                  <include>com.esotericsoftware:kryo</include>
+                  <include>com.esotericsoftware:kryo-shaded</include>
                   <include>com.esotericsoftware:minlog</include>
-                  <include>com.esotericsoftware:reflectasm</include>
                 </includes>
               </artifactSet>
               <filters>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use shaded kryo library which causes inconsistencies in asm dependencies. https://issues.apache.org/jira/browse/LIVY-783

## How was this patch tested?

Tested on live cluster.
