### PR TITLE
[LIVY-795] Add support for PySpark with Python >= 3.8 

### DIFF
--- a/repl/src/main/resources/fake_shell.py
+++ b/repl/src/main/resources/fake_shell.py
@@ -40,6 +40,14 @@ else:
     import cStringIO
     import StringIO
 
+if sys.version_info > (3,8):
+    from ast import Module
+else :
+    # mock the new API, ignore second argument
+    # see https://github.com/ipython/ipython/issues/11590
+    from ast import Module as OriginalModule
+    Module = lambda nodelist, type_ignores: OriginalModule(nodelist)
+
 logging.basicConfig()
 LOG = logging.getLogger('fake_shell')
 
@@ -219,7 +227,7 @@ class NormalNode(object):
 
         try:
             for node in to_run_exec:
-                mod = ast.Module([node])
+                mod = Module([node], [])
                 code = compile(mod, '<stdin>', 'exec')
                 exec(code, global_dict)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

A mock for the `ast.Module` is created in case of running older Python versions (< 3.8). The mocked module will ignore the new `type_ignores` parameter, and pass only the first parameter to the old module.

As already mentioned by Shiquan Wang (the issue reporter), Python 3.8 introduced a change in the API (https://github.com/python/cpython/pull/11645/files), and IPython had a similar problem. The strategy used for this fix is similar to the one utilized by IPython in this PR: https://github.com/ipython/ipython/pull/11593 

JIRA: https://issues.apache.org/jira/projects/LIVY/issues/LIVY-795

## How was this patch tested?

Tested locally, using Jupyter notebook to run pyspark commands.