### PR TITLE
LIVY-804: Add session ID to LineBufferedStream logs

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
@@ -92,7 +92,7 @@ object BatchSession extends Logging {
       builder.redirectErrorStream(true)
 
       val file = resolveURIs(Seq(request.file), livyConf)(0)
-      val sparkSubmit = builder.start(Some(file), request.args)
+      val sparkSubmit = builder.start(Some(file), request.args, id)
 
       Utils.startDaemonThread(s"batch-session-process-$id") {
         childProcesses.incrementAndGet()

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -400,7 +400,7 @@ class InteractiveSession(
     heartbeat()
     app = mockApp.orElse {
       val driverProcess = client.flatMap { c => Option(c.getDriverProcess) }
-        .map(new LineBufferedProcess(_, livyConf.getInt(LivyConf.SPARK_LOGS_SIZE)))
+        .map(new LineBufferedProcess(_, livyConf.getInt(LivyConf.SPARK_LOGS_SIZE), Some(id)))
 
       if (livyConf.isRunningOnYarn() || driverProcess.isDefined) {
         Some(SparkApp.create(appTag, appId, driverProcess, livyConf, Some(this)))

--- a/server/src/main/scala/org/apache/livy/utils/LineBufferedProcess.scala
+++ b/server/src/main/scala/org/apache/livy/utils/LineBufferedProcess.scala
@@ -19,10 +19,15 @@ package org.apache.livy.utils
 
 import org.apache.livy.{Logging, Utils}
 
-class LineBufferedProcess(process: Process, logSize: Int) extends Logging {
+class LineBufferedProcess(
+    process: Process,
+    logSize: Int,
+    sessionId: Option[Int] = None) extends Logging {
 
-  private[this] val _inputStream = new LineBufferedStream(process.getInputStream, logSize)
-  private[this] val _errorStream = new LineBufferedStream(process.getErrorStream, logSize)
+  private[this] val _inputStream =
+    new LineBufferedStream(process.getInputStream, logSize, sessionId)
+  private[this] val _errorStream =
+    new LineBufferedStream(process.getErrorStream, logSize, sessionId)
 
   def inputLines: IndexedSeq[String] = _inputStream.lines
   def errorLines: IndexedSeq[String] = _errorStream.lines

--- a/server/src/main/scala/org/apache/livy/utils/LineBufferedStream.scala
+++ b/server/src/main/scala/org/apache/livy/utils/LineBufferedStream.scala
@@ -32,7 +32,10 @@ class CircularQueue[T](var capacity: Int) extends util.LinkedList[T] {
   }
 }
 
-class LineBufferedStream(inputStream: InputStream, logSize: Int) extends Logging {
+class LineBufferedStream(
+    inputStream: InputStream,
+    logSize: Int,
+    sessionId: Option[Int]) extends Logging {
 
   private[this] val _lines: CircularQueue[String] = new CircularQueue[String](logSize)
 
@@ -44,7 +47,8 @@ class LineBufferedStream(inputStream: InputStream, logSize: Int) extends Logging
     override def run() = {
       val lines = Source.fromInputStream(inputStream).getLines()
       for (line <- lines) {
-        info(line)
+        val sessionIdString = sessionId.map(id => s"(Livy ID $id) ").getOrElse("")
+        info(s"${sessionIdString}stdout: $line")
         _lock.lock()
         try {
           _lines.add(line)

--- a/server/src/main/scala/org/apache/livy/utils/SparkProcessBuilder.scala
+++ b/server/src/main/scala/org/apache/livy/utils/SparkProcessBuilder.scala
@@ -154,7 +154,7 @@ class SparkProcessBuilder(livyConf: LivyConf) extends Logging {
     this
   }
 
-  def start(file: Option[String], args: Traversable[String]): LineBufferedProcess = {
+  def start(file: Option[String], args: Traversable[String], id: Int): LineBufferedProcess = {
     var arguments = ArrayBuffer(_executable)
 
     def addOpt(option: String, value: Option[String]): Unit = {
@@ -212,7 +212,7 @@ class SparkProcessBuilder(livyConf: LivyConf) extends Logging {
     _redirectError.foreach(pb.redirectError)
     _redirectErrorStream.foreach(pb.redirectErrorStream)
 
-    new LineBufferedProcess(pb.start(), livyConf.getInt(LivyConf.SPARK_LOGS_SIZE))
+    new LineBufferedProcess(pb.start(), livyConf.getInt(LivyConf.SPARK_LOGS_SIZE), Some(id))
   }
 
 }


### PR DESCRIPTION
If multiple sessions are started at once, it can be difficult to corelate the stdout logs with the sessions that started the spark-submit process. This PR adds the session ID as a prefix to the LineBufferedStream logs.

https://issues.apache.org/jira/browse/LIVY-804

Manual Log Test
