### PR TITLE
[LIVY-848] Adjusting Livy test cases to be compatible with Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,8 @@ install:
   - sudo python3 -m pip -q install --upgrade "pip < 10.0.0" "setuptools < 36"
   - sudo pip2 -q install codecov cloudpickle
   - sudo python3 -m pip -q install cloudpickle
-  - sudo pip2 -q install "requests >= 2.10.0" pytest flaky flake8 requests-kerberos
-  - sudo pip3 -q install "requests >= 2.10.0" pytest flaky requests-kerberos
+  - sudo pip2 -q install "requests >= 2.10.0" pytest flaky flake8 future requests-kerberos
+  - sudo pip3 -q install "requests >= 2.10.0" pytest flaky future requests-kerberos
 
 script:
   - mvn $MVN_FLAG -Dmaven.javadoc.skip=true -B -V -e verify

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Required python packages for building Livy:
   * requests-kerberos
   * flake8
   * flaky
+  * future
   * pytest
 
 

--- a/integration-test/src/test/resources/test_python_api.py
+++ b/integration-test/src/test/resources/test_python_api.py
@@ -19,16 +19,17 @@ import base64
 import json
 import time
 from future.moves.urllib.parse import urlparse
+from future.utils import PY3
 import re
 import requests
 from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL
 import cloudpickle
 import pytest
 import sys
-if sys.version < '3':
-    import httplib
-else:
+if PY3:
     from http import HTTPStatus as httplib
+else:
+    import httplib
 from flaky import flaky
 
 global session_id, job_id

--- a/integration-test/src/test/scala/org/apache/livy/test/InteractiveIT.scala
+++ b/integration-test/src/test/scala/org/apache/livy/test/InteractiveIT.scala
@@ -93,7 +93,7 @@ class InteractiveIT extends BaseIntegrationTestSuite {
       }
       s.run("%table x").verifyResult(".*headers.*type.*name.*data.*")
       s.run("abcde").verifyError(ename = "NameError", evalue = "name 'abcde' is not defined")
-      s.run("raise KeyError, 'foo'").verifyError(ename = "KeyError", evalue = "'foo'")
+      s.run("raise KeyError('foo')").verifyError(ename = "KeyError", evalue = "'foo'")
       s.run("print(1)\r\nprint(1)").verifyResult("1\n1")
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

At the moment, the Livy test cases error out when run with Python3 instead of Python2. Many of these errors are simple errors revolving around parentheses, or errors involved imports with changed names, and the changes are mostly backwards compatible (with mild tinkering required in the case of imports with adjusted locations).

https://issues.apache.org/jira/browse/LIVY-848

## How was this patch tested?

This patch was tested with a slightly different build of Livy. While the current version of Livy was not explicitly tested, the fundamental reasoning behind each change in this PR should still be applicable and benefit the health of the repository.
