### PR TITLE
[LIVY-853][BUILD] Update travis.yml use latest pip and setuptools to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
   - sudo apt-get -qq install python3-pip python-dev
   - sudo apt-get -qq install libkrb5-dev
   - sudo apt-get -qq remove python-setuptools
-  - sudo pip2 -q install --upgrade "pip < 10.0.0" "setuptools < 36"
+  - sudo pip2 -q install --upgrade pip setuptools
   - sudo python3 -m pip -q install --upgrade "pip < 10.0.0" "setuptools < 36"
   - sudo pip2 -q install codecov cloudpickle
   - sudo python3 -m pip -q install cloudpickle


### PR DESCRIPTION
## What changes were proposed in this pull request?

Build https://travis-ci.com/github/apache/incubator-livy/jobs/498541463 failed due to tests_require in setup.py even for no related change. Stacktrace as below:

```
Couldn't find index page for 'pytest-runner' (maybe misspelled?)
No local packages or working download links found for pytest-runner
Traceback (most recent call last):
File "setup.py", line 58, in <module>
tests_require=['pytest']
File "/usr/lib/python2.7/distutils/core.py", line 111, in setup
_setup_distribution = dist = klass(attrs)
File "/usr/local/lib/python2.7/dist-packages/setuptools/dist.py", line 318, in _init_
self.fetch_build_eggs(attrs['setup_requires'])
File "/usr/local/lib/python2.7/dist-packages/setuptools/dist.py", line 375, in fetch_build_eggs
replace_conflicting=True,
File "/usr/local/lib/python2.7/dist-packages/pkg_resources/_init_.py", line 851, in resolve
dist = best[req.key] = env.best_match(req, ws, installer)
File "/usr/local/lib/python2.7/dist-packages/pkg_resources/_init_.py", line 1123, in best_match
return self.obtain(req, installer)
File "/usr/local/lib/python2.7/dist-packages/pkg_resources/_init_.py", line 1135, in obtain
return installer(requirement)
File "/usr/local/lib/python2.7/dist-packages/setuptools/dist.py", line 443, in fetch_build_egg
return cmd.easy_install(req)
File "/usr/local/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 667, in easy_install
raise DistutilsError(msg)
distutils.errors.DistutilsError: Could not find suitable distribution for Requirement.parse('pytest-runner')
```
It seems caused by old version of pip and setuptools for python2

## How was this patch tested?

Manually tested in build CI.
