### PR TITLE
Expose livy session id to allow the session to be shared

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ cd incubator-livy
 mvn package
 ```
 
-By default Livy is built against Apache Spark 2.4.5, but the version of Spark used when running
+By default Livy is built against Apache Spark 2.4.6, but the version of Spark used when running
 Livy does not need to match the version used to build Livy. Livy internally handles the differences
 between different Spark versions.
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-api</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-assembly</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <properties>
@@ -38,12 +38,6 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>livy-rsc</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>livy-repl_2.11</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/client-common/pom.xml
+++ b/client-common/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-common</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <dependencies>
@@ -37,7 +37,7 @@
 
     <dependency>
       <groupId>com.esotericsoftware</groupId>
-      <artifactId>kryo</artifactId>
+      <artifactId>kryo-shaded</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/client-http/pom.xml
+++ b/client-http/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-http</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <dependencies>
@@ -140,22 +140,30 @@
                 </filter>
               </filters>
               <relocations>
-                <relocation>
-                  <pattern>com.esotericsoftware</pattern>
-                  <shadedPattern>org.apache.livy.shaded.kryo</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.fasterxml.jackson</pattern>
-                  <shadedPattern>org.apache.livy.shaded.jackson</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.commons</pattern>
-                  <shadedPattern>org.apache.livy.shaded.apache.commons</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.http</pattern>
-                  <shadedPattern>org.apache.livy.shaded.apache.http</shadedPattern>
-                </relocation>
+                  <relocation>
+                      <pattern>com.esotericsoftware.kryo-shaded</pattern>
+                      <shadedPattern>org.apache.livy.shaded.kryo-shaded</shadedPattern>
+                  </relocation>
+                  <relocation>
+                      <pattern>com.esotericsoftware</pattern>
+                      <shadedPattern>org.apache.livy.shaded.kryo</shadedPattern>
+                  </relocation>
+                  <relocation>
+                      <pattern>com.fasterxml.jackson</pattern>
+                      <shadedPattern>org.apache.livy.shaded.jackson</shadedPattern>
+                  </relocation>
+                  <relocation>
+                      <pattern>org.apache.commons</pattern>
+                      <shadedPattern>org.apache.livy.shaded.apache.commons</shadedPattern>
+                  </relocation>
+                  <relocation>
+                      <pattern>org.apache.http</pattern>
+                      <shadedPattern>org.apache.livy.shaded.apache.http</shadedPattern>
+                  </relocation>
+                  <relocation>
+                      <pattern>org.objectweb.asm</pattern>
+                      <shadedPattern>org.apache.livy.shaded.kryo-shaded.com.esotericsoftware.reflectasm.shaded.org.objectweb.asm</shadedPattern>
+                  </relocation>
               </relocations>
             </configuration>
           </execution>

--- a/client-http/src/main/java/org/apache/livy/client/http/HttpClient.java
+++ b/client-http/src/main/java/org/apache/livy/client/http/HttpClient.java
@@ -40,7 +40,7 @@ import static org.apache.livy.client.common.HttpMessages.*;
  * What is currently missing:
  * - monitoring of spark job IDs launched by jobs
  */
-class HttpClient implements LivyClient {
+public class HttpClient implements LivyClient {
 
   private final HttpConf config;
   private final LivyConnection conn;
@@ -184,7 +184,7 @@ class HttpClient implements LivyClient {
   }
 
   // For testing.
-  int getSessionId() {
+  public int getSessionId() {
     return sessionId;
   }
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../scala/pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-core-parent</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/core/scala-2.11/pom.xml
+++ b/core/scala-2.11/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-core_2.11</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-core-parent</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/core/scala-2.12/pom.xml
+++ b/core/scala-2.12/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-core_2.12</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-core-parent</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
   </parent>
 
   <artifactId>livy-coverage-report</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/docs/_data/project.yml
+++ b/docs/_data/project.yml
@@ -16,6 +16,6 @@
 # Apache Project configurations
 #
 name: Apache Livy
-version: 0.8.0-incubating-SNAPSHOT
+version: 0.8.0-incubating-onedot
 
 podling: true

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-examples</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
   </parent>
 
   <artifactId>livy-integration-test</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -107,6 +107,10 @@
         <exclusion>
           <groupId>org.apache.zookeeper</groupId>
           <artifactId>zookeeper</artifactId>
+        </exclusion>
+        <exclusion>
+           <groupId>asm</groupId>
+           <artifactId>asm</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-main</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>pom</packaging>
   <name>Livy Project Parent POM</name>
   <description>Livy Project</description>
@@ -81,9 +81,9 @@
     <asynchttpclient.version>2.10.1</asynchttpclient.version>
     <hadoop.version>2.7.3</hadoop.version>
     <hadoop.scope>compile</hadoop.scope>
-    <spark.scala-2.11.version>2.4.5</spark.scala-2.11.version>
-    <spark.scala-2.12.version>2.4.5</spark.scala-2.12.version>
-    <spark.version>${spark.scala-2.11.version}</spark.version>
+    <spark.scala-2.11.version>2.4.6</spark.scala-2.11.version>
+    <spark.scala-2.12.version>2.4.6</spark.scala-2.12.version>
+    <spark.version>${spark.scala-2.12.version}</spark.version>
     <hive.version>3.0.0</hive.version>
     <commons-codec.version>1.9</commons-codec.version>
     <httpclient.version>4.5.3</httpclient.version>
@@ -93,7 +93,7 @@
     <jetty.version>9.3.24.v20180605</jetty.version>
     <json4s.spark-2.11.version>3.5.3</json4s.spark-2.11.version>
     <json4s.spark-2.12.version>3.5.3</json4s.spark-2.12.version>
-    <json4s.version>${json4s.spark-2.11.version}</json4s.version>
+    <json4s.version>${json4s.spark-2.12.version}</json4s.version>
     <junit.version>4.11</junit.version>
     <libthrift.version>0.9.3</libthrift.version>
     <kryo.version>4.0.2</kryo.version>
@@ -101,13 +101,13 @@
     <mockito.version>1.10.19</mockito.version>
     <netty.spark-2.11.version>4.1.17.Final</netty.spark-2.11.version>
     <netty.spark-2.12.version>4.1.17.Final</netty.spark-2.12.version>
-    <netty.version>${netty.spark-2.11.version}</netty.version>
+    <netty.version>${netty.spark-2.12.version}</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <py4j.version>0.10.7</py4j.version>
     <scala-2.11.version>2.11.12</scala-2.11.version>
-    <scala-2.12.version>2.12.10</scala-2.12.version>
-    <scala.binary.version>2.11</scala.binary.version>
-    <scala.version>${scala-2.11.version}</scala.version>
+    <scala-2.12.version>2.12.12</scala-2.12.version>
+    <scala.binary.version>2.12</scala.binary.version>
+    <scala.version>${scala-2.12.version}</scala.version>
     <scalatest.version>3.0.8</scalatest.version>
     <scalatra.version>2.6.5</scalatra.version>
     <java.version>1.8</java.version>
@@ -115,17 +115,17 @@
     <execution.root>${user.dir}</execution.root>
     <spark.home>${execution.root}/dev/spark</spark.home>
     <spark.bin.download.url>
-      https://archive.apache.org/dist/spark/spark-2.4.5/spark-2.4.5-bin-hadoop2.7.tgz
+      https://archive.apache.org/dist/spark/spark-2.4.6/spark-2.4.6-bin-without-hadoop-scala-2.12.tgz
     </spark.bin.download.url>
-    <spark.bin.name>spark-2.4.5-bin-hadoop2.7</spark.bin.name>
+    <spark.bin.name>spark-2.4.6-bin-without-hadoop-scala-2.12</spark.bin.name>
     <!--  used for testing, NCSARequestLog use it for access log  -->
     <livy.log.dir>${basedir}/target</livy.log.dir>
 
     <!-- Set this to "true" to skip R tests. -->
-    <skipRTests>false</skipRTests>
+    <skipRTests>true</skipRTests>
 
     <!-- Set this to "true" to skip PySpark3 tests. -->
-    <skipPySpark3Tests>false</skipPySpark3Tests>
+    <skipPySpark3Tests>true</skipPySpark3Tests>
 
     <!-- Required for testing LDAP integration -->
     <apacheds.version>2.0.0-M21</apacheds.version>
@@ -270,7 +270,7 @@
 
       <dependency>
         <groupId>com.esotericsoftware</groupId>
-        <artifactId>kryo</artifactId>
+        <artifactId>kryo-shaded</artifactId>
         <version>${kryo.version}</version>
       </dependency>
 
@@ -1061,7 +1061,7 @@
       </activation>
       <properties>
         <spark.scala-2.12.version>3.0.0</spark.scala-2.12.version>
-        <spark.scala-2.11.version>2.4.5</spark.scala-2.11.version>
+        <spark.scala-2.11.version>2.4.6</spark.scala-2.11.version>
         <spark.version>${spark.scala-2.11.version}</spark.version>
         <netty.spark-2.12.version>4.1.47.Final</netty.spark-2.12.version>
         <netty.spark-2.11.version>4.1.47.Final</netty.spark-2.11.version>
@@ -1070,7 +1070,7 @@
         <py4j.version>0.10.9</py4j.version>
         <json4s.spark-2.11.version>3.5.3</json4s.spark-2.11.version>
         <json4s.spark-2.12.version>3.6.6</json4s.spark-2.12.version>
-        <json4s.version>${json4s.spark-2.11.version}</json4s.version>
+        <json4s.version>${json4s.spark-2.12.version}</json4s.version>
         <spark.bin.download.url>
           https://archive.apache.org/dist/spark/spark-3.0.0/spark-3.0.0-bin-hadoop2.7.tgz
         </spark.bin.download.url>

--- a/python-api/pom.xml
+++ b/python-api/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-python-api</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <build>

--- a/python-api/setup.py
+++ b/python-api/setup.py
@@ -40,7 +40,7 @@ requirements = [
 
 setup(
     name='livy-python-api',
-    version="0.8.0-incubating-SNAPSHOT",
+    version="0.8.0-incubating-onedot",
     packages=["livy", "livy-tests"],
     package_dir={
         "": "src/main/python",

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
     <relativePath>../scala/pom.xml</relativePath>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
   </parent>
 
   <artifactId>livy-repl-parent</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/repl/scala-2.11/pom.xml
+++ b/repl/scala-2.11/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-repl_2.11</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-repl-parent</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/repl/scala-2.12/pom.xml
+++ b/repl/scala-2.12/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-repl_2.12</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-repl-parent</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -59,7 +59,7 @@
 
     <dependency>
       <groupId>com.esotericsoftware</groupId>
-      <artifactId>kryo</artifactId>
+      <artifactId>kryo-shaded</artifactId>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
@@ -115,6 +115,12 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -141,6 +147,7 @@
                 <includes>
                   <include>org.apache.livy:livy-client-common</include>
                   <include>com.esotericsoftware:kryo</include>
+                  <include>com.esotericsoftware:kryo-shaded</include>
                   <include>com.esotericsoftware:minlog</include>
                   <include>com.esotericsoftware:reflectasm</include>
                 </includes>
@@ -159,6 +166,10 @@
                 <relocation>
                   <pattern>com.esotericsoftware</pattern>
                   <shadedPattern>org.apache.livy.shaded.kryo</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.esotericsoftware.kryo-shaded</pattern>
+                  <shadedPattern>org.apache.livy.shaded.kryo-shaded</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/scala-api/pom.xml
+++ b/scala-api/pom.xml
@@ -23,12 +23,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../scala/pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-scala-api-parent</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/scala-api/scala-2.11/pom.xml
+++ b/scala-api/scala-2.11/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-scala-api_2.11</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-scala-api-parent</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala-api/scala-2.12/pom.xml
+++ b/scala-api/scala-2.12/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-scala-api_2.12</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-scala-api-parent</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>multi-scala-project-root</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
   </parent>
 
   <artifactId>livy-server</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/test-lib/pom.xml
+++ b/test-lib/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-test-lib</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/thriftserver/client/pom.xml
+++ b/thriftserver/client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/thriftserver/server/pom.xml
+++ b/thriftserver/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/thriftserver/session/pom.xml
+++ b/thriftserver/session/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
See RD-4563

This allows us to create a Livy client instance, and fetch the Session ID from it. From that point on, we can reuse the session by attaching the session ID to the URL when creating another client instance