### PR TITLE
[LIVY-846] Fix the API endpoints 'GET /sessions' and 'GET /batches'

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -69,14 +69,17 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
   }
 
   get("/") {
-    val from = params.get("from").map(_.toInt).getOrElse(0)
-    val size = params.get("size").map(_.toInt).getOrElse(100)
-
     val sessions = sessionManager.all()
+    val sessionsSize = sessionManager.size()
+
+    val from = params.get("from").map(_.toInt).getOrElse(0)
+    val size = params.get("size").map(_.toInt).getOrElse(
+      if (sessionsSize > from) sessionsSize - from else 0
+    )
 
     Map(
       "from" -> from,
-      "total" -> sessionManager.size(),
+      "total" -> sessionsSize,
       "sessions" -> sessions.view(from, from + size).map(clientSessionView(_, request))
     )
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/LIVY-864
This PR fixes the issue mention in [LIVY-864](https://issues.apache.org/jira/browse/LIVY-864)

The endpoints 'GET /batches' and 'GET /sessions' now only return the first 100 items if no parameters are specified.
But according to the documentation, we should actually return all the active sessions and batches.
So, the endpoints should be fixed to return the correct items.

## How was this patch tested?

This patch is tested manually on our local Spark cluster and Livy server.

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
