### PR TITLE
[LIVY-865][SERVER] Fix bug that Livy identifies valid yarn state of batch session as FAILED

### DIFF
--- a/server/src/main/scala/org/apache/livy/utils/SparkYarnApp.scala
+++ b/server/src/main/scala/org/apache/livy/utils/SparkYarnApp.scala
@@ -233,24 +233,24 @@ class SparkYarnApp private[utils] (
       appId: ApplicationId,
       yarnAppState: YarnApplicationState,
       finalAppStatus: FinalApplicationStatus): SparkApp.State.Value = {
-    (yarnAppState, finalAppStatus) match {
-      case (YarnApplicationState.NEW, FinalApplicationStatus.UNDEFINED) |
-           (YarnApplicationState.NEW_SAVING, FinalApplicationStatus.UNDEFINED) |
-           (YarnApplicationState.SUBMITTED, FinalApplicationStatus.UNDEFINED) |
-           (YarnApplicationState.ACCEPTED, FinalApplicationStatus.UNDEFINED) =>
+    yarnAppState match {
+      case YarnApplicationState.NEW | YarnApplicationState.NEW_SAVING |
+           YarnApplicationState.SUBMITTED | YarnApplicationState.ACCEPTED =>
         SparkApp.State.STARTING
-      case (YarnApplicationState.RUNNING, FinalApplicationStatus.UNDEFINED) |
-           (YarnApplicationState.RUNNING, FinalApplicationStatus.SUCCEEDED) =>
+      case YarnApplicationState.RUNNING =>
         SparkApp.State.RUNNING
-      case (YarnApplicationState.FINISHED, FinalApplicationStatus.SUCCEEDED) =>
-        SparkApp.State.FINISHED
-      case (YarnApplicationState.FAILED, FinalApplicationStatus.FAILED) =>
-        SparkApp.State.FAILED
-      case (YarnApplicationState.KILLED, FinalApplicationStatus.KILLED) =>
-        SparkApp.State.KILLED
-      case (state, finalStatus) => // any other combination is invalid, so FAIL the application.
-        error(s"Unknown YARN state $state for app $appId with final status $finalStatus.")
-        SparkApp.State.FAILED
+      case _ =>
+        (yarnAppState, finalAppStatus) match {
+          case (YarnApplicationState.FAILED, FinalApplicationStatus.FAILED) =>
+            SparkApp.State.FAILED
+          case (YarnApplicationState.KILLED, FinalApplicationStatus.KILLED) =>
+            SparkApp.State.KILLED
+          case (YarnApplicationState.FINISHED, FinalApplicationStatus.SUCCEEDED) =>
+            SparkApp.State.FINISHED
+          case _ => // invalid combination, FAIL the application.
+            error(s"Unknown YARN state $yarnAppState for app $appId with final status $finalAppStatus.")
+            SparkApp.State.FAILED
+        }
     }
   }
 

--- a/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
@@ -277,6 +277,8 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite {
         assert(app.mapYarnState(appId, SUBMITTED, UNDEFINED) == State.STARTING)
         assert(app.mapYarnState(appId, ACCEPTED, UNDEFINED) == State.STARTING)
         assert(app.mapYarnState(appId, RUNNING, UNDEFINED) == State.RUNNING)
+        // this combination below exists since final state and yarn state would switch sequentially.
+        assert(app.mapYarnState(appId, RUNNING, FinalApplicationStatus.SUCCEEDED) == State.RUNNING)
         assert(
           app.mapYarnState(appId, FINISHED, FinalApplicationStatus.SUCCEEDED) == State.FINISHED)
         assert(app.mapYarnState(appId, FAILED, FinalApplicationStatus.FAILED) == State.FAILED)


### PR DESCRIPTION
## What changes were proposed in this pull request?

yarnClient.getApplicationReport(appId) would return 2 states below:

1. YarnApplicationState (short as yarnState)
2. FinalApplicationStatus (short as finalState)

These 2 states may switch sequentially in practice, means (yarnState, finalState) as
(RUNNING, SUCCEEDED) would switch to (FINISHED, SUCCEEDED) finally.
For now, (yarnState, finalState)  as (RUNNING, SUCCEEDED) would be identified as `FAILED` state combination

This PR introduce new logic to map yarn state combination as bellow:

1. yarnState as NEW、NEW_SAVING、SUBMITTED、ACCEPTED would be identified as `STARTING`
2. yarnState as RUNNING would be identified as `RUNNING`
3. other yarnState and finalState combinations would be identified to rules:
- (FAILED, FAILED) -> `FAILED`
- (KILLED, KILLED) -> `KILLED`
- (FINISHED, SUCCEEDED) -> `FINISHED`
- any other combination -> `FAILED`

## How was this patch tested?

added UT.
