### PR TITLE
[LIVY-866] Optimizing Yarn GetApplications Query to prevent additional load on Yarn and Livy

### DIFF
--- a/integration-test/src/main/scala/org/apache/livy/test/framework/Cluster.scala
+++ b/integration-test/src/main/scala/org/apache/livy/test/framework/Cluster.scala
@@ -32,6 +32,7 @@ import org.apache.hadoop.yarn.client.api.YarnClient
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 
 import org.apache.livy.Logging
+import org.apache.livy.utils.YarnClientExt
 
 /**
  * An common interface to run test on real cluster and mini cluster.
@@ -100,7 +101,7 @@ trait Cluster {
   }
 
   lazy val yarnClient = doAsClusterUser {
-    val c = YarnClient.createYarnClient()
+    val c = new YarnClientExt
     c.init(yarnConf)
     c.start()
     c

--- a/server/src/main/scala/org/apache/livy/utils/SparkYarnApp.scala
+++ b/server/src/main/scala/org/apache/livy/utils/SparkYarnApp.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.livy.utils
 
+import java.util
 import java.util.concurrent.TimeoutException
 
 import scala.annotation.tailrec
@@ -27,8 +28,8 @@ import scala.language.postfixOps
 import scala.util.Try
 import scala.util.control.NonFatal
 
+import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationsRequest
 import org.apache.hadoop.yarn.api.records.{ApplicationId, ApplicationReport, FinalApplicationStatus, YarnApplicationState}
-import org.apache.hadoop.yarn.client.api.YarnClient
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.yarn.exceptions.ApplicationAttemptNotFoundException
 import org.apache.hadoop.yarn.util.ConverterUtils
@@ -37,7 +38,7 @@ import org.apache.livy.{LivyConf, Logging, Utils}
 
 object SparkYarnApp extends Logging {
 
-  def init(livyConf: LivyConf, client: Option[YarnClient] = None): Unit = {
+  def init(livyConf: LivyConf, client: Option[YarnClientExt] = None): Unit = {
     mockYarnClient = client
     sessionLeakageCheckInterval = livyConf.getTimeAsMs(LivyConf.YARN_APP_LEAKAGE_CHECK_INTERVAL)
     sessionLeakageCheckTimeout = livyConf.getTimeAsMs(LivyConf.YARN_APP_LEAKAGE_CHECK_TIMEOUT)
@@ -46,11 +47,15 @@ object SparkYarnApp extends Logging {
     leakedAppsGCThread.start()
   }
 
-  private var mockYarnClient: Option[YarnClient] = None
+  private var mockYarnClient: Option[YarnClientExt] = None
 
   // YarnClient is thread safe. Create once, share it across threads.
   lazy val yarnClient = {
-    val c = YarnClient.createYarnClient()
+    // Initialize an instance of YarnClientExt. This extends YarnClientImpl
+    // such that list of applications can be queried based on GetApplicationsRequest
+    // which helps in avoiding load on Yarn cluster and on the Livy server in client
+    // side filtering if there are large number of Spark applications running in Yarn cluster.
+    val c = new YarnClientExt
     c.init(new YarnConfiguration())
     c.start()
     c
@@ -84,8 +89,8 @@ object SparkYarnApp extends Logging {
           // kill the app if found it and remove it if exceeding a threshold
           val iter = leakedAppTags.entrySet().iterator()
           val now = System.currentTimeMillis()
-          val apps = client.getApplications(appType).asScala
-
+          val request = createGetApplicationsRequest(leakedAppTags.keySet())
+          val apps = yarnClient.getApplications(request).asScala
           while(iter.hasNext) {
             var isRemoved = false
             val entry = iter.next()
@@ -111,7 +116,19 @@ object SparkYarnApp extends Logging {
     }
   }
 
-
+  /**
+   * Generates GetApplicationsRequest for Spark Job type. Application tags
+   * provided via appTags are added in the GetApplicationRequest.
+   * @param appTags Set[String]
+   * @return GetApplicationsRequest
+   */
+  private def createGetApplicationsRequest(appTags: util.Set[String])
+  : GetApplicationsRequest = {
+    val request: GetApplicationsRequest =
+      GetApplicationsRequest.newInstance(appType)
+    request.setApplicationTags(appTags)
+    request
+  }
 }
 
 /**
@@ -130,7 +147,7 @@ class SparkYarnApp private[utils] (
     process: Option[LineBufferedProcess],
     listener: Option[SparkAppListener],
     livyConf: LivyConf,
-    yarnClient: => YarnClient = SparkYarnApp.yarnClient) // For unit test.
+    yarnClient: => YarnClientExt = SparkYarnApp.yarnClient) // For unit test.
   extends SparkApp
   with Logging {
   import SparkYarnApp._
@@ -194,9 +211,11 @@ class SparkYarnApp private[utils] (
 
     val appTagLowerCase = appTag.toLowerCase()
 
-    // FIXME Should not loop thru all YARN applications but YarnClient doesn't offer an API.
-    // Consider calling rmClient in YarnClient directly.
-    yarnClient.getApplications(appType).asScala.find(_.getApplicationTags.contains(appTagLowerCase))
+    val appTags: util.Set[String] = util.Collections.singleton(appTag)
+    val request = createGetApplicationsRequest(appTags)
+    val applicationReports = yarnClient.getApplications(request)
+
+    applicationReports.asScala.find(_.getApplicationTags.contains(appTagLowerCase))
     match {
       case Some(app) => app.getApplicationId
       case None =>

--- a/server/src/main/scala/org/apache/livy/utils/YarnClientExt.scala
+++ b/server/src/main/scala/org/apache/livy/utils/YarnClientExt.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.livy.utils
+
+import java.io.IOException
+import java.util
+
+import org.apache.hadoop.yarn.api.protocolrecords.{GetApplicationsRequest, GetApplicationsResponse}
+import org.apache.hadoop.yarn.api.records.ApplicationReport
+import org.apache.hadoop.yarn.client.api.impl.YarnClientImpl
+import org.apache.hadoop.yarn.exceptions.YarnException
+
+import org.apache.livy.Logging
+
+
+
+/**
+ * Provides an extended implementation of @YarnClientImpl with required methods.
+ * Uses the protected rmClient for any custom methods.
+ */
+class YarnClientExt extends YarnClientImpl with Logging {
+
+
+  /**
+   * Returns the list of Yarn applications based on the
+   * GetApplicationsRequest.
+   * @param request GetApplicationsRequest
+   * @return List of ApplicationReport matching the GetApplicationsRequest.
+   */
+  @throws[YarnException]
+  @throws[IOException]
+  def getApplications(request: GetApplicationsRequest): util
+  .List[ApplicationReport] = {
+    logger.trace("getApplications called in YarnClientExt with " +
+      "GetApplicationsRequest, calling rmClient to get Applications")
+    val response: GetApplicationsResponse = rmClient.getApplications(request)
+    response.getApplicationList
+  }
+}

--- a/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkYarnAppSpec.scala
@@ -59,7 +59,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite {
 
     it("should poll YARN state and terminate") {
       Clock.withSleepMethod(mockSleep) {
-        val mockYarnClient = mock[YarnClient]
+        val mockYarnClient = mock[YarnClientExt]
         val mockAppListener = mock[SparkAppListener]
 
         val mockAppReport = mock[ApplicationReport]
@@ -127,7 +127,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite {
     it("should kill yarn app") {
       Clock.withSleepMethod(mockSleep) {
         val diag = "DIAG"
-        val mockYarnClient = mock[YarnClient]
+        val mockYarnClient = mock[YarnClientExt]
 
         val mockAppReport = mock[ApplicationReport]
         when(mockAppReport.getApplicationId).thenReturn(appId)
@@ -164,7 +164,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite {
 
     it("should return spark-submit log") {
       Clock.withSleepMethod(mockSleep) {
-        val mockYarnClient = mock[YarnClient]
+        val mockYarnClient = mock[YarnClientExt]
         val mockSparkSubmit = mock[LineBufferedProcess]
         val sparkSubmitInfoLog = IndexedSeq("SPARK-SUBMIT", "LOG")
         val sparkSubmitErrorLog = IndexedSeq("SPARK-SUBMIT", "error log")
@@ -212,10 +212,10 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite {
         when(mockAppReport.getFinalApplicationStatus).thenReturn(FinalApplicationStatus.SUCCEEDED)
         when(mockAppReport.getYarnApplicationState).thenReturn(RUNNING)
 
-        val mockYarnClient = mock[YarnClient]
+        val mockYarnClient = mock[YarnClientExt]
         when(mockYarnClient.getApplicationReport(appId)).thenReturn(mockAppReport)
 
-        val mockSparkSubmit = mock[LineBufferedProcess]
+       val mockSparkSubmit = mock[LineBufferedProcess]
 
         val sparkSubmitRunningLatch = new CountDownLatch(1)
         // Simulate a running spark-submit
@@ -295,7 +295,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite {
 
     it("should get App Id") {
       Clock.withSleepMethod(mockSleep) {
-        val mockYarnClient = mock[YarnClient]
+        val mockYarnClient = mock[YarnClientExt]
         val mockAppReport = mock[ApplicationReport]
 
         when(mockAppReport.getApplicationTags).thenReturn(Set(appTag.toLowerCase).asJava)
@@ -324,7 +324,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite {
 
     it("should expose driver log url and Spark UI url") {
       Clock.withSleepMethod(mockSleep) {
-        val mockYarnClient = mock[YarnClient]
+        val mockYarnClient = mock[YarnClientExt]
         val driverLogUrl = "DRIVER LOG URL"
         val sparkUiUrl = "SPARK UI URL"
 
@@ -387,7 +387,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite {
 
     it("should not die on YARN-4411") {
       Clock.withSleepMethod(mockSleep) {
-        val mockYarnClient = mock[YarnClient]
+        val mockYarnClient = mock[YarnClientExt]
 
         // Block test until getApplicationReport is called 10 times.
         val pollCountDown = new CountDownLatch(10)
@@ -412,7 +412,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite {
 
     it("should not die on ApplicationAttemptNotFoundException") {
       Clock.withSleepMethod(mockSleep) {
-        val mockYarnClient = mock[YarnClient]
+        val mockYarnClient = mock[YarnClientExt]
         val mockAppReport = mock[ApplicationReport]
         val mockApplicationAttemptId = mock[ApplicationAttemptId]
         val done = new AtomicBoolean(false)
@@ -468,7 +468,7 @@ class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite {
         livyConf.set(LivyConf.YARN_APP_LEAKAGE_CHECK_INTERVAL, "100ms")
         livyConf.set(LivyConf.YARN_APP_LEAKAGE_CHECK_TIMEOUT, "1000ms")
 
-        val client = mock[YarnClient]
+        val client = mock[YarnClientExt]
         when(client.getApplications(SparkYarnApp.appType)).
           thenReturn(new ArrayList[ApplicationReport]())
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently Livy queries Yarn applications by applicationType : Spark. This will put a heavy load on Yarn clusters if there are thousands or more Spark applications in all states (running, finished, failed, queued etc.).
A better approach would be to query the applications by tags in addition to job type since Livy only needs to track applications with certain application tags. However, YarnClient does not expose any API to query applications by tags.

As part of this implementation, extending the YarnClientImpl and implementing getApplications method which can take GetApplicationRequest as parameter. Instead of querying all SPARK applications, query SPARK applications with required tags to avoid load on Yarn and Livy servers.

JIRA: https://issues.apache.org/jira/browse/LIVY-866

## How was this patch tested?

Verified in a local Yarn cluster. Checked in the trace logs that the request is sent with the applicationTags and the response returns the application report. Please see the logs below.

Verified that other calls to Yarn client such as getApplicationAttemptReport, getContainerReport are successful.
Updated existing tests to use the new YarnClientExt.

`21/09/07 15:38:50 TRACE YarnClientExt: getApplications called in YarnClientExt with GetApplicationsRequest, calling rmClient to get Applications`
`21/09/07 15:38:50 TRACE ProtobufRpcEngine: 75: Call -> 0.0.0.0/0.0.0.0:8032: getApplications {application_types: "SPARK" applicationTags: "livy-batch-5-osefkl7m"}`
`21/09/07 15:38:50 DEBUG Client: IPC Client (72154307) connection to 0.0.0.0/0.0.0.0:8032 from Administrator sending #28`
`21/09/07 15:38:50 DEBUG Client: IPC Client (72154307) connection to 0.0.0.0/0.0.0.0:8032 from Administrator got value #28`
`21/09/07 15:38:50 DEBUG ProtobufRpcEngine: Call: getApplications took 8ms`
`21/09/07 15:38:50 TRACE ProtobufRpcEngine: 75: Response <- 0.0.0.0/0.0.0.0:8032: getApplications {applications { applicationId { id: 2 cluster_timestamp: 1631009244715 } user: "Administrator" queue: "default" name: "SparkBatchJobTest-8" host: "N/A" rpc_port: -1 yarn_application_state: ACCEPTED trackingUrl: "http://MININT-AHVKP1D:8088/proxy/application_1631009244715_0002/" diagnostics: "[Tue Sep 07 15:38:50 +0530 2021] Application is Activated, waiting for resources to be assigned for AM.  Details : AM Partition = <DEFAULT_PARTITION> ; Partition Resource = <memory:14336, vCores:8> ; Queue\'s Absolute capacity = 100.0 % ; Queue\'s Absolute used capacity = 0.0 % ; Queue\'s Absolute max capacity = 100.0 % ; " startTime: 1631009330477 finishTime: 0 final_application_status: APP_UNDEFINED app_resource_Usage { num_used_containers: 0 num_reserved_containers: 0 used_resources { memory: 0 virtual_cores: 0 3: "\n\tmemory-mb\020\000\032\002Mi \000" 3: "\n\006vcores\020\000\032\000 \000" } reserved_resources { memory: 0 virtual_cores: 0 3: "\n\tmemory-mb\020\000\032\002Mi \000" 3: "\n\006vcores\020\000\032\000 \000" } needed_resources { memory: 0 virtual_cores: 0 3: "\n\tmemory-mb\020\000\032\002Mi \000" 3: "\n\006vcores\020\000\032\000 \000" } memory_seconds: 0 vcore_seconds: 0 8: 0x00000000 9: 0x00000000 10: 0 11: 0 12: "\n\tmemory-mb\020\000" 12: "\n\006vcores\020\000" 13: "\n\tmemory-mb\020\000" 13: "\n\006vcores\020\000" } originalTrackingUrl: "N/A" currentApplicationAttemptId { application_id { id: 2 cluster_timestamp: 1631009244715 } attemptId: 1 } progress: 0.0 applicationType: "SPARK" applicationTags: "livy-batch-5-osefkl7m" 21: 1 22: 0 23: "\b\000" 24: "<Not set>" 25: "<DEFAULT_PARTITION>" 26: "\b\001\022\030\b\001\022\tUNLIMITED\030\377\377\377\377\377\377\377\377\377\001" 27: 0 }}`
