### PR TITLE
[LIVY-757] Add support for Active Directory through LDAP

### DIFF
--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -90,6 +90,7 @@ object LivyConf {
   // Ldap configurations
   val AUTH_LDAP_URL = Entry("livy.server.auth.ldap.url", null)
   val AUTH_LDAP_BASE_DN = Entry("livy.server.auth.ldap.base-dn", null)
+  val AUTH_LDAP_USER_DN_PATTERN = Entry("livy.server.auth.ldap.user-dn-pattern", null)
   val AUTH_LDAP_USERNAME_DOMAIN = Entry("livy.server.auth.ldap.username-domain", null)
   val AUTH_LDAP_ENABLE_START_TLS = Entry("livy.server.auth.ldap.enable-start-tls", "false")
   val AUTH_LDAP_SECURITY_AUTH = Entry("livy.server.auth.ldap.security-authentication", "simple")

--- a/server/src/main/scala/org/apache/livy/server/LivyServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/LivyServer.scala
@@ -281,6 +281,9 @@ class LivyServer extends Logging {
         Option(livyConf.get(LivyConf.AUTH_LDAP_BASE_DN)).foreach { baseDN =>
           holder.setInitParameter(LdapAuthenticationHandlerImpl.BASE_DN, baseDN)
         }
+        Option(livyConf.get(LivyConf.AUTH_LDAP_USER_DN_PATTERN)).foreach { userDNPattern =>
+          holder.setInitParameter(LdapAuthenticationHandlerImpl.USER_DN_PATTERN, userDNPattern)
+        }
         holder.setInitParameter(LdapAuthenticationHandlerImpl.SECURITY_AUTHENTICATION,
           livyConf.get(LivyConf.AUTH_LDAP_SECURITY_AUTH))
         holder.setInitParameter(LdapAuthenticationHandlerImpl.ENABLE_START_TLS,

--- a/server/src/main/scala/org/apache/livy/server/auth/LdapUtils.scala
+++ b/server/src/main/scala/org/apache/livy/server/auth/LdapUtils.scala
@@ -71,13 +71,17 @@ object LdapUtils {
   def createCandidatePrincipal(conf: LivyConf, user: String): String = {
     val ldapDomain = conf.get(LivyConf.AUTH_LDAP_USERNAME_DOMAIN)
     val ldapBaseDN = conf.get(LivyConf.AUTH_LDAP_BASE_DN )
+    val userDNPattern = conf.get(LivyConf.AUTH_LDAP_USER_DN_PATTERN)
+
     val principle = if (!hasDomain(user) && ldapDomain != null) {
       user + "@" + ldapDomain
     } else {
       user
     }
 
-    if (ldapBaseDN != null) {
+    if (userDNPattern != null) {
+      userDNPattern.replace("%s", principle)
+    } else if (ldapBaseDN != null) {
       "uid=" + principle + "," + ldapBaseDN
     } else {
       principle


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this PR I implemented and ability to configure custom LDAP user DN pattern as and alternative to base-dn option, for cases when username attribute isn't `uid` (which is now hardcoded in Livy).

So now instead of specifying baseDN you also can specify user DN pattern by setting the following property in `livy.conf`:
```
livy.server.auth.ldap.user-dn-pattern = sAMAccountName=%s,ou=People,dc=example,dc=com
```

I decided to provide an ability to specify pattern rather than just add an option to configure user attribute, because it seems to be more common way to do this:
* https://github.com/cloudera/hue/blob/18cd309/desktop/conf.dist/hue.ini#L485
* https://github.com/apache/zeppelin/blob/5dd5a65/conf/shiro.ini.template#L46
* https://cwiki.apache.org/confluence/display/Hive/User+and+Group+Filter+Support+with+LDAP+Atn+Provider+in+HiveServer2#UserandGroupFilterSupportwithLDAPAtnProviderinHiveServer2-hive.server2.authentication.ldap.userDNPattern

On the other hand, as Livy already has an option to set baseDN, it would be more logical just to add an option to set custom user attribute.
So I opened another PR with an alternative fix for this issue: https://github.com/apache/incubator-livy/pull/330

## How was this patch tested?

Manual, since unit tests seems to be broken.