### PR TITLE
[LIVY-757] Add support of Active Directory through LDAP by providing an option to set user attribute

### DIFF
--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -90,6 +90,7 @@ object LivyConf {
   // Ldap configurations
   val AUTH_LDAP_URL = Entry("livy.server.auth.ldap.url", null)
   val AUTH_LDAP_BASE_DN = Entry("livy.server.auth.ldap.base-dn", null)
+  val AUTH_LDAP_USER_ATTRIBUTE = Entry("livy.server.auth.ldap.user-attribute", "uid")
   val AUTH_LDAP_USERNAME_DOMAIN = Entry("livy.server.auth.ldap.username-domain", null)
   val AUTH_LDAP_ENABLE_START_TLS = Entry("livy.server.auth.ldap.enable-start-tls", "false")
   val AUTH_LDAP_SECURITY_AUTH = Entry("livy.server.auth.ldap.security-authentication", "simple")

--- a/server/src/main/scala/org/apache/livy/server/LivyServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/LivyServer.scala
@@ -281,6 +281,9 @@ class LivyServer extends Logging {
         Option(livyConf.get(LivyConf.AUTH_LDAP_BASE_DN)).foreach { baseDN =>
           holder.setInitParameter(LdapAuthenticationHandlerImpl.BASE_DN, baseDN)
         }
+        Option(livyConf.get(LivyConf.AUTH_LDAP_USER_ATTRIBUTE)).foreach { userAttribute =>
+          holder.setInitParameter(LdapAuthenticationHandlerImpl.USER_ATTRIBUTE, userAttribute)
+        }
         holder.setInitParameter(LdapAuthenticationHandlerImpl.SECURITY_AUTHENTICATION,
           livyConf.get(LivyConf.AUTH_LDAP_SECURITY_AUTH))
         holder.setInitParameter(LdapAuthenticationHandlerImpl.ENABLE_START_TLS,

--- a/server/src/main/scala/org/apache/livy/server/auth/LdapAuthenticationHandlerImpl.scala
+++ b/server/src/main/scala/org/apache/livy/server/auth/LdapAuthenticationHandlerImpl.scala
@@ -41,14 +41,16 @@ object LdapAuthenticationHandlerImpl {
   val SECURITY_AUTHENTICATION = "simple"
   val PROVIDER_URL = "ldap.providerurl"
   val BASE_DN = "ldap.basedn"
+  val USER_ATTRIBUTE = "ldap.userattribute"
   val LDAP_BIND_DOMAIN = "ldap.binddomain"
   val ENABLE_START_TLS = "ldap.enablestarttls"
 }
 
 class LdapAuthenticationHandlerImpl extends AuthenticationHandler with Logging {
-  private var ldapDomain = "null"
-  private var baseDN = "null"
   private var providerUrl = "null"
+  private var baseDN = "null"
+  private var userAttribute = "uid"
+  private var ldapDomain = "null"
   private var enableStartTls = false
   private var disableHostNameVerification = false
 
@@ -56,8 +58,9 @@ class LdapAuthenticationHandlerImpl extends AuthenticationHandler with Logging {
 
   @throws[ServletException]
   def init(config: Properties): Unit = {
-    this.baseDN = config.getProperty(LdapAuthenticationHandlerImpl.BASE_DN)
     this.providerUrl = config.getProperty(LdapAuthenticationHandlerImpl.PROVIDER_URL)
+    this.baseDN = config.getProperty(LdapAuthenticationHandlerImpl.BASE_DN)
+    this.userAttribute = config.getProperty(LdapAuthenticationHandlerImpl.USER_ATTRIBUTE)
     this.ldapDomain = config.getProperty(LdapAuthenticationHandlerImpl.LDAP_BIND_DOMAIN)
     this.enableStartTls = config.getProperty(
       LdapAuthenticationHandlerImpl.ENABLE_START_TLS, "false").toBoolean
@@ -128,7 +131,7 @@ class LdapAuthenticationHandlerImpl extends AuthenticationHandler with Logging {
       principle = userName + "@" + ldapDomain
     }
     val bindDN = if (baseDN != null) {
-      "uid=" + principle + "," + baseDN
+      userAttribute + "=" + principle + "," + baseDN
     } else {
       principle
     }

--- a/server/src/main/scala/org/apache/livy/server/auth/LdapUtils.scala
+++ b/server/src/main/scala/org/apache/livy/server/auth/LdapUtils.scala
@@ -70,7 +70,9 @@ object LdapUtils {
    */
   def createCandidatePrincipal(conf: LivyConf, user: String): String = {
     val ldapDomain = conf.get(LivyConf.AUTH_LDAP_USERNAME_DOMAIN)
-    val ldapBaseDN = conf.get(LivyConf.AUTH_LDAP_BASE_DN )
+    val ldapBaseDN = conf.get(LivyConf.AUTH_LDAP_BASE_DN)
+    val userAttribute = conf.get(LivyConf.AUTH_LDAP_USER_ATTRIBUTE)
+
     val principle = if (!hasDomain(user) && ldapDomain != null) {
       user + "@" + ldapDomain
     } else {
@@ -78,7 +80,7 @@ object LdapUtils {
     }
 
     if (ldapBaseDN != null) {
-      "uid=" + principle + "," + ldapBaseDN
+      userAttribute + "=" + principle + "," + ldapBaseDN
     } else {
       principle
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this PR I added an option to set custom username attribute instead of `uid`.
It can be configured in the following way in the `livy.conf`:
```
livy.server.auth.ldap.user-attribute = sAMAccountName
```

This is an alternative implementation of https://github.com/apache/incubator-livy/pull/328

## How was this patch tested?

Manual, since unit tests seems to be broken.