### PR TITLE
[LIVY-871] Add client config to keep fields of table magic in query order

### DIFF
--- a/repl/scala-2.11/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -31,10 +31,14 @@ import scala.tools.nsc.interpreter.Results.Result
 import org.apache.spark.SparkConf
 import org.apache.spark.repl.SparkILoop
 
+import org.apache.livy.rsc.RSCConf
+
 /**
  * This represents a Scala 2.11 Spark interpreter. It is not thread safe.
  */
-class SparkInterpreter(protected override val conf: SparkConf) extends AbstractSparkInterpreter {
+class SparkInterpreter(
+    protected override val conf: SparkConf,
+    protected override val livyConf: RSCConf) extends AbstractSparkInterpreter {
 
   private var sparkILoop: SparkILoop = _
 

--- a/repl/scala-2.11/src/test/scala/org/apache/livy/repl/SparkInterpreterSpec.scala
+++ b/repl/scala-2.11/src/test/scala/org/apache/livy/repl/SparkInterpreterSpec.scala
@@ -23,7 +23,7 @@ import org.apache.livy.LivyBaseUnitTestSuite
 
 class SparkInterpreterSpec extends FunSpec with Matchers with LivyBaseUnitTestSuite {
   describe("SparkInterpreter") {
-    val interpreter = new SparkInterpreter(null)
+    val interpreter = new SparkInterpreter(null, null)
 
     it("should parse Scala compile error.") {
       // Regression test for LIVY-.

--- a/repl/scala-2.12/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.12/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -31,10 +31,14 @@ import scala.tools.nsc.interpreter.Results.Result
 import org.apache.spark.SparkConf
 import org.apache.spark.repl.SparkILoop
 
+import org.apache.livy.rsc.RSCConf
+
 /**
  * This represents a Spark interpreter. It is not thread safe.
  */
-class SparkInterpreter(protected override val conf: SparkConf) extends AbstractSparkInterpreter {
+class SparkInterpreter(
+    protected override val conf: SparkConf,
+    protected override val livyConf: RSCConf) extends AbstractSparkInterpreter {
 
   private var sparkILoop: SparkILoop = _
 

--- a/repl/scala-2.12/src/test/scala/org/apache/livy/repl/SparkInterpreterSpec.scala
+++ b/repl/scala-2.12/src/test/scala/org/apache/livy/repl/SparkInterpreterSpec.scala
@@ -23,7 +23,7 @@ import org.apache.livy.LivyBaseUnitTestSuite
 
 class SparkInterpreterSpec extends FunSpec with Matchers with LivyBaseUnitTestSuite {
   describe("SparkInterpreter") {
-    val interpreter = new SparkInterpreter(null)
+    val interpreter = new SparkInterpreter(null, null)
 
     it("should parse Scala compile error.") {
       // Regression test for LIVY-.

--- a/repl/src/main/scala/org/apache/livy/repl/Session.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/Session.scala
@@ -124,7 +124,7 @@ class Session(
 
       // Always start SparkInterpreter after beginning, because we rely on SparkInterpreter to
       // initialize SparkContext and create SparkEntries.
-      val sparkInterp = mockSparkInterpreter.getOrElse(new SparkInterpreter(sparkConf))
+      val sparkInterp = mockSparkInterpreter.getOrElse(new SparkInterpreter(sparkConf, livyConf))
       sparkInterp.start()
 
       entries = sparkInterp.sparkEntries()

--- a/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
@@ -155,19 +155,19 @@ abstract class PythonBaseInterpreterSpec extends BaseInterpreterSpec {
 
   it should "do table magic with None type Row" in withInterpreter { interpreter =>
     val response = interpreter.execute(
-      """x = [{"a":None, "b":None}, {"a":"2", "b":2}]
+      """x = [{"b":None, "a":None}, {"b":"2", "a":2}]
         |%table x
       """.stripMargin)
 
     response should equal(Interpreter.ExecuteSuccess(
       APPLICATION_LIVY_TABLE_JSON -> (
         ("headers" -> List(
-          ("type" -> "STRING_TYPE") ~ ("name" -> "a"),
-          ("type" -> "INT_TYPE") ~ ("name" -> "b")
+          ("type" -> "INT_TYPE") ~ ("name" -> "a"),
+          ("type" -> "STRING_TYPE") ~ ("name" -> "b")
         )) ~
           ("data" -> List(
             List[JValue](JNull, JNull),
-            List[JValue]("2", 2)
+            List[JValue](2, "2")
           ))
         )
     ))

--- a/repl/src/test/scala/org/apache/livy/repl/SessionSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/SessionSpec.scala
@@ -68,7 +68,7 @@ class SessionSpec extends FunSpec with Eventually with LivyBaseUnitTestSuite wit
       val actualStateTransitions = new ConcurrentLinkedQueue[String]()
 
       val blockFirstExecuteCall = new CountDownLatch(1)
-      val interpreter = new SparkInterpreter(new SparkConf()) {
+      val interpreter = new SparkInterpreter(new SparkConf(), new RSCConf()) {
         override def execute(code: String): ExecuteResponse = {
           blockFirstExecuteCall.await(10, TimeUnit.SECONDS)
           super.execute(code)

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
@@ -82,7 +82,10 @@ public class RSCConf extends ClientConf<RSCConf> {
     RETAINED_SHARE_VARIABLES("retained.share-variables", 100),
 
     // Number of result rows to get for SQL Interpreters.
-    SQL_NUM_ROWS("sql.num-rows", 1000);
+    SQL_NUM_ROWS("sql.num-rows", 1000),
+
+    // Sort fields of table magic
+    TABLE_MAGIC_SORT_FIELDS("table-magic.sort-fields", true);
 
     private final String key;
     private final Object dflt;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the fields in table magic are sorted by field name by default, but in many scenarios, we want to keep fields of table magic in query order, for example:

`val result = spark.sql("select b, a from table")`
`%table result`

currently Livy responses json with fields in the order of "a", "b", but we want them in the order of "b", "a" which is consistent with the SQL

JIRA: https://issues.apache.org/jira/browse/LIVY-871

fix #871

## How was this patch tested?

existing tests & new tests in ScalaInterpreterSpec.
