### PR TITLE
[LIVY-888] AddJar or AddFile call on a duplicate file should not result in failure for Livy session

### DIFF
--- a/rsc/src/main/java/org/apache/livy/rsc/driver/RSCDriver.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/driver/RSCDriver.java
@@ -509,8 +509,9 @@ public class RSCDriver extends BaseProtocol {
     File localCopy = new File(localCopyDir, name);
 
     if (localCopy.exists()) {
-      throw new IOException(String.format("A file with name %s has " +
-              "already been uploaded.", name));
+      LOG.warn(String.format("A file with name %s has " +
+              "already been uploaded, and hence will not be replaced.", name));
+      return localCopy;
     }
     Configuration conf = sc.hadoopConfiguration();
     FileSystem fs = FileSystem.get(uri, conf);

--- a/rsc/src/test/java/org/apache/livy/rsc/TestSparkClient.java
+++ b/rsc/src/test/java/org/apache/livy/rsc/TestSparkClient.java
@@ -240,6 +240,11 @@ public class TestSparkClient {
           client.addJar(new URI("file:" + jar.getAbsolutePath()))
             .get(TIMEOUT, TimeUnit.SECONDS);
 
+          // Attempting to add a duplicate jar file to LivyClient. This add operation will be
+          // skipped and an appropriate warning logged
+          client.addJar(new URI("file:" + jar.getAbsolutePath()))
+            .get(TIMEOUT, TimeUnit.SECONDS);
+
           // Need to run a Spark job to make sure the jar is added to the class loader. Monitoring
           // SparkContext#addJar() doesn't mean much, we can only be sure jars have been distributed
           // when we run a task after the jar has been added.


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a duplicate file is attempted to be added using LivyClient, duplicate file's addition is skipped and an appropriate warning is logged instead of the old behavior of throwing fatal IOException. This is now consistent with SparkContext's addJar and addFile APIs behavior. 

https://issues.apache.org/jira/browse/LIVY-888

## How was this patch tested?

Modified the unit test TestSparkClient#testAddJarsAndFiles to attempt adding a duplicate file, and the test did not fail.
