### PR TITLE
[LIVY-889] Adding jars to Spark Interpreter classpath on an already running Livy Session

### DIFF
--- a/repl/scala-2.11/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -18,7 +18,7 @@
 package org.apache.livy.repl
 
 import java.io.File
-import java.net.URLClassLoader
+import java.net.{URL, URLClassLoader}
 import java.nio.file.{Files, Paths}
 
 import scala.tools.nsc.Settings
@@ -93,6 +93,10 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
       sparkILoop.closeInterpreter()
       sparkILoop = null
     }
+  }
+
+  override def addJar(jar: String): Unit = {
+    sparkILoop.addUrlsToClassPath(new URL(jar))
   }
 
   override protected def isStarted(): Boolean = {

--- a/repl/scala-2.12/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.12/src/main/scala/org/apache/livy/repl/SparkInterpreter.scala
@@ -18,7 +18,7 @@
 package org.apache.livy.repl
 
 import java.io.File
-import java.net.URLClassLoader
+import java.net.{URL, URLClassLoader}
 import java.nio.file.{Files, Paths}
 
 import scala.tools.nsc.Settings
@@ -93,6 +93,10 @@ class SparkInterpreter(protected override val conf: SparkConf) extends AbstractS
       sparkILoop.closeInterpreter()
       sparkILoop = null
     }
+  }
+
+  override def addJar(jar: String): Unit = {
+    sparkILoop.addUrlsToClassPath(new URL(jar))
   }
 
   override protected def isStarted(): Boolean = {

--- a/repl/src/main/scala/org/apache/livy/repl/AbstractSparkInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/AbstractSparkInterpreter.scala
@@ -61,6 +61,8 @@ abstract class AbstractSparkInterpreter extends Interpreter with Logging {
 
   protected def conf: SparkConf
 
+  protected def addJar(jar: String): Unit
+
   protected def postStart(): Unit = {
     entries = new SparkEntries(conf)
 

--- a/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
@@ -290,13 +290,14 @@ private class PythonInterpreter(
     pysparkJobProcessor.addFile(path)
   }
 
-  def addPyFile(driver: ReplDriver, conf: SparkConf, path: String): Unit = {
+  def addPyFile(driver: ReplDriver, conf: SparkConf, path: String): String = {
     val localCopyDir = new File(pysparkJobProcessor.getLocalTmpDirPath)
     val localCopyFile = driver.copyFileToLocal(localCopyDir, path, SparkContext.getOrCreate(conf))
     pysparkJobProcessor.addPyFile(localCopyFile.getPath)
     if (path.endsWith(".jar")) {
       driver.addLocalFileToClassLoader(localCopyFile)
     }
+    localCopyFile.getPath
   }
 
   private def updatePythonGatewayPort(port: Int): Unit = {

--- a/rsc/src/main/java/org/apache/livy/rsc/driver/RSCDriver.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/driver/RSCDriver.java
@@ -482,11 +482,12 @@ public class RSCDriver extends BaseProtocol {
     jc.sc().addFile(path);
   }
 
-  protected void addJarOrPyFile(String path) throws Exception {
+  protected String addJarOrPyFile(String path) throws Exception {
     File localCopyDir = new File(jc.getLocalTmpDir(), "__livy__");
     File localCopy = copyFileToLocal(localCopyDir, path, jc.sc().sc());
     addLocalFileToClassLoader(localCopy);
     jc.sc().addJar(path);
+    return localCopy.getPath();
   }
 
   public void addLocalFileToClassLoader(File localCopy) throws MalformedURLException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

* addJar invoked for a running Livy session will add that jar resource to SparkInterpreter classpath in addition to Spark driver classpath.
* addJarOrPyFile signature changed to return the local path to which it was copied. This local path is required to add the same jar resource to SparkInterpreter classpath.
* addFile now goes through appropriate Interpreter based on the interpreter instead of default PythonInterpreter.

https://issues.apache.org/jira/browse/LIVY-889

## How was this patch tested?

This patch was tested by adding a Jar on a running Livy session and then trying to load a class from that jar using spark interpreter.
