### PR TITLE
[Bug] porting ast.Module to py3.8+

### DIFF
--- a/repl/src/main/resources/fake_shell.py
+++ b/repl/src/main/resources/fake_shell.py
@@ -219,10 +219,10 @@ class NormalNode(object):
 
         try:
             for node in to_run_exec:
-                if sys.version > "3.7":
-                    mod = ast.Module([node], [])
-                else:
+                if sys.version < "3.8":
                     mod = ast.Module([node])
+                else:
+                    mod = ast.Module([node], [])
                 code = compile(mod, '<stdin>', 'exec')
                 exec(code, global_dict)
 

--- a/repl/src/main/resources/fake_shell.py
+++ b/repl/src/main/resources/fake_shell.py
@@ -219,7 +219,10 @@ class NormalNode(object):
 
         try:
             for node in to_run_exec:
-                mod = ast.Module([node])
+                if sys.version > "3.7":
+                    mod = ast.Module([node], [])
+                else:
+                    mod = ast.Module([node])
                 code = compile(mod, '<stdin>', 'exec')
                 exec(code, global_dict)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Porting `ast.Module()` call to Python 3.8 and newer versions. 
Starting py3.8, a required argument `type_ignores` has been added to ast.Module(). See [here]( https://bugs.python.org/issue35894 ) for more discussions about this breaking change in Python. 

## How was this patch tested?
in a Yarn application

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
