### PR TITLE
[LIVY-891] Expose the sessionID via the client APIs [WIP]

### DIFF
--- a/api/src/main/java/org/apache/livy/LivyClient.java
+++ b/api/src/main/java/org/apache/livy/LivyClient.java
@@ -107,4 +107,18 @@ public interface LivyClient {
    */
   Future<?> addFile(URI uri);
 
+  /**
+   *  Retrieves the session id internally created by Livy.
+   *
+   * @return An integer representing the session id of the running session
+   */
+  int getSessionId();
+
+  /**
+   * Retrieves the internally generated session app id.
+   *
+   * @return A string representing the livy session app id.
+   */
+  String getSessionAppId();
+
 }

--- a/api/src/test/java/org/apache/livy/TestClientFactory.java
+++ b/api/src/test/java/org/apache/livy/TestClientFactory.java
@@ -91,6 +91,11 @@ public class TestClientFactory implements LivyClientFactory {
       throw new UnsupportedOperationException();
     }
 
+    @Override
+    public int getSessionId(){throw new UnsupportedOperationException();}
+
+    @Override
+    public String getSessionAppId(){throw new UnsupportedOperationException();}
   }
 
 }

--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -121,6 +121,12 @@
       <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
+      <dependency>
+          <groupId>org.apache.livy</groupId>
+          <artifactId>livy-api</artifactId>
+          <version>0.8.0-incubating-SNAPSHOT</version>
+          <scope>compile</scope>
+      </dependency>
   </dependencies>
 
   <build>

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
@@ -17,6 +17,23 @@
 
 package org.apache.livy.rsc;
 
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import io.netty.util.concurrent.Promise;
+import org.apache.livy.Job;
+import org.apache.livy.JobHandle;
+import org.apache.livy.LivyClient;
+import org.apache.livy.client.common.BufferUtils;
+import org.apache.livy.rsc.driver.AddFileJob;
+import org.apache.livy.rsc.driver.AddJarJob;
+import org.apache.livy.rsc.rpc.Rpc;
+import org.apache.livy.sessions.SessionState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -28,25 +45,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.util.concurrent.GenericFutureListener;
-import io.netty.util.concurrent.ImmediateEventExecutor;
-import io.netty.util.concurrent.Promise;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import org.apache.livy.Job;
-import org.apache.livy.JobHandle;
-import org.apache.livy.LivyClient;
-import org.apache.livy.client.common.BufferUtils;
-import org.apache.livy.rsc.driver.AddFileJob;
-import org.apache.livy.rsc.driver.AddJarJob;
-import org.apache.livy.rsc.rpc.Rpc;
-import org.apache.livy.sessions.SessionState;
-
-import static org.apache.livy.rsc.RSCConf.Entry.*;
+import static org.apache.livy.rsc.RSCConf.Entry.CLIENT_SHUTDOWN_TIMEOUT;
+import static org.apache.livy.rsc.RSCConf.Entry.RPC_MAX_THREADS;
 
 public class RSCClient implements LivyClient {
   private static final Logger LOG = LoggerFactory.getLogger(RSCClient.class);
@@ -426,10 +426,15 @@ public class RSCClient implements LivyClient {
       LOG.trace("Received repl state for {}", msg.state);
       // Update last activity timestamp when state change is from busy to idle.
       if (SessionState.Busy$.MODULE$.state().equals(replState) && msg != null &&
-        SessionState.Idle$.MODULE$.state().equals(msg.state)) {
+              SessionState.Idle$.MODULE$.state().equals(msg.state)) {
         replLastActivity = System.nanoTime();
       }
       replState = msg.state;
     }
   }
+  @Override
+  public String getSessionAppId(){throw new UnsupportedOperationException();}
+
+  @Override
+  public int getSessionId(){throw new UnsupportedOperationException();}
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LIVY-891

## What changes were proposed in this pull request?

Currently getSessionID() is exposed in HttpClient only for testing purposes. Since the internally created session ID is useful to doing operations such as re-connecting to the session, killing the session etc., it will be useful to expose it as a public api in HttpClient and LivyClient. (Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
