### PR TITLE
[LIVY-892] Enhance Livy Java Client to execute statements [WIP]

### DIFF
--- a/api/src/main/java/org/apache/livy/JobHandle.java
+++ b/api/src/main/java/org/apache/livy/JobHandle.java
@@ -17,7 +17,6 @@
 
 package org.apache.livy;
 
-import java.util.List;
 import java.util.concurrent.Future;
 
 /**
@@ -31,6 +30,13 @@ public interface JobHandle<T> extends Future<T> {
    * @return The current State of this job
    */
   State getState();
+
+  /**
+   * Return the current state of the job.
+   *
+   * @return The current State of this job
+   */
+  String getId();
 
   /**
    * Add a listener to the job handle. If the job's state is not SENT, a callback for the
@@ -47,6 +53,7 @@ public interface JobHandle<T> extends Future<T> {
     SENT,
     QUEUED,
     STARTED,
+    CANCELLING,
     CANCELLED,
     FAILED,
     SUCCEEDED;

--- a/api/src/main/java/org/apache/livy/LivyClient.java
+++ b/api/src/main/java/org/apache/livy/LivyClient.java
@@ -27,6 +27,15 @@ import java.util.concurrent.Future;
 public interface LivyClient {
 
   /**
+   * Submits a code snippet passed in as a string for asynchronous execution.
+   * @param <T> The return type of the statement
+   * @param code The code to execute
+   * @param kind The code kind - can be one of (spark, pyspark sparkr, sql)
+   * @return A handle that can be used monitor the statement execution.
+   */
+  <T> JobHandle<T> submitStatement(String code, String kind);
+
+  /**
    * Submits a job for asynchronous execution.
    *
    * @param <T> The return type of the job

--- a/api/src/test/java/org/apache/livy/TestClientFactory.java
+++ b/api/src/test/java/org/apache/livy/TestClientFactory.java
@@ -57,6 +57,11 @@ public class TestClientFactory implements LivyClientFactory {
     }
 
     @Override
+    public <T> JobHandle<T> submitStatement(String code, String kind){
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public <T> JobHandle<T> submit(Job<T> job) {
       throw new UnsupportedOperationException();
     }

--- a/client-common/src/main/java/org/apache/livy/client/common/AbstractJobHandle.java
+++ b/client-common/src/main/java/org/apache/livy/client/common/AbstractJobHandle.java
@@ -17,12 +17,11 @@
 
 package org.apache.livy.client.common;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-
 import org.apache.livy.JobHandle;
 import org.apache.livy.annotations.Private;
+
+import java.util.LinkedList;
+import java.util.List;
 
 @Private
 public abstract class AbstractJobHandle<T> implements JobHandle<T> {
@@ -33,6 +32,10 @@ public abstract class AbstractJobHandle<T> implements JobHandle<T> {
   protected AbstractJobHandle() {
     this.listeners = new LinkedList<>();
     this.state = State.SENT;
+  }
+
+  public String getId(){
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/client-common/src/main/java/org/apache/livy/client/common/HttpMessages.java
+++ b/client-common/src/main/java/org/apache/livy/client/common/HttpMessages.java
@@ -17,11 +17,11 @@
 
 package org.apache.livy.client.common;
 
-import java.util.List;
-import java.util.Map;
-
 import org.apache.livy.JobHandle.State;
 import org.apache.livy.annotations.Private;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * There are the Java representations of the JSON messages used by the client protocol.
@@ -77,6 +77,22 @@ public class HttpMessages {
 
     private SessionInfo() {
       this(-1, null, null, null, null, null, null, null, null);
+    }
+
+  }
+
+  public static class SerializedStatement implements ClientMessage {
+
+    public final String code;
+    public final String kind;
+
+    public SerializedStatement(String code, String kind) {
+      this.code = code;
+      this.kind = kind;
+    }
+
+    private SerializedStatement() {
+      this(null, null);
     }
 
   }

--- a/client-http/src/main/java/org/apache/livy/client/http/HttpClient.java
+++ b/client-http/src/main/java/org/apache/livy/client/http/HttpClient.java
@@ -17,23 +17,20 @@
 
 package org.apache.livy.client.http;
 
+import org.apache.livy.Job;
+import org.apache.livy.JobHandle;
+import org.apache.livy.LivyClient;
+import org.apache.livy.client.common.Serializer;
+
 import java.io.File;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.livy.Job;
-import org.apache.livy.JobHandle;
-import org.apache.livy.LivyClient;
-import org.apache.livy.client.common.Serializer;
 import static org.apache.livy.client.common.HttpMessages.*;
 
 /**
@@ -94,6 +91,13 @@ class HttpClient implements LivyClient {
     });
 
     this.serializer = new Serializer();
+  }
+
+  @Override
+  public <T> JobHandle<T> submitStatement(String code, String kind) {
+    StatementHandleImpl<T> handle = new StatementHandleImpl<T>(config, conn, sessionId, executor, serializer);
+    handle.start("statements", code, kind);
+    return handle;
   }
 
   @Override

--- a/client-http/src/main/java/org/apache/livy/client/http/JobHandleImpl.java
+++ b/client-http/src/main/java/org/apache/livy/client/http/JobHandleImpl.java
@@ -17,17 +17,13 @@
 
 package org.apache.livy.client.http;
 
-import java.nio.ByteBuffer;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 import org.apache.livy.client.common.AbstractJobHandle;
 import org.apache.livy.client.common.BufferUtils;
 import org.apache.livy.client.common.Serializer;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.*;
+
 import static org.apache.livy.client.common.HttpMessages.*;
 
 class JobHandleImpl<T> extends AbstractJobHandle<T> {
@@ -131,6 +127,10 @@ class JobHandleImpl<T> extends AbstractJobHandle<T> {
   @Override
   protected Throwable error() {
     return error;
+  }
+
+  public String getId() {
+    return Long.toString(jobId);
   }
 
   void start(final String command, final ByteBuffer serializedJob) {

--- a/client-http/src/main/java/org/apache/livy/client/http/StatementHandleImpl.java
+++ b/client-http/src/main/java/org/apache/livy/client/http/StatementHandleImpl.java
@@ -1,0 +1,358 @@
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *    http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+package org.apache.livy.client.http;
+
+    import com.fasterxml.jackson.annotation.JsonValue;
+    import org.apache.livy.JobHandle;
+    import org.apache.livy.client.common.AbstractJobHandle;
+    import org.apache.livy.client.common.HttpMessages.ClientMessage;
+    import org.apache.livy.client.common.HttpMessages.SerializedStatement;
+    import org.apache.livy.client.common.Serializer;
+
+    import java.util.Map;
+    import java.util.concurrent.*;
+
+    class StatementHandleImpl<T> extends AbstractJobHandle<T> {
+
+        private final long sessionId;
+        private final LivyConnection conn;
+        private final ScheduledExecutorService executor;
+        private final Object lock;
+
+        private final long initialPollInterval;
+        private final long maxPollInterval;
+
+        private long statementId;
+        private T result;
+        private Throwable error;
+        private volatile boolean isDone;
+        private volatile boolean isCancelled;
+        private volatile boolean isCancelPending;
+
+        StatementHandleImpl(HttpConf config, LivyConnection conn, long sessionId,
+                            ScheduledExecutorService executor, Serializer s) {
+            this.conn = conn;
+            this.sessionId = sessionId;
+            this.executor = executor;
+            this.lock = new Object();
+            this.isDone = false;
+
+            this.initialPollInterval = config.getTimeAsMs(HttpConf.Entry.JOB_INITIAL_POLL_INTERVAL);
+            this.maxPollInterval = config.getTimeAsMs(HttpConf.Entry.JOB_MAX_POLL_INTERVAL);
+
+            if (initialPollInterval <= 0) {
+                throw new IllegalArgumentException("Invalid initial poll interval.");
+            }
+            if (maxPollInterval <= 0 || maxPollInterval < initialPollInterval) {
+                throw new IllegalArgumentException("Invalid max poll interval, or lower than initial interval.");
+            }
+
+            // The job ID is set asynchronously, and there might be a call to
+            // cancel() before it's
+            // set. So cancel() will always set the isCancelPending flag, even if
+            // there's no job
+            // ID yet. If the thread setting the job ID sees that flag, it will send
+            // a cancel request
+            // to the server. There's still a possibility that two cancel requests
+            // will be sent,
+            // but that doesn't cause any harm.
+            this.isCancelPending = false;
+            this.statementId = -1;
+        }
+
+        @Override
+        public T get() throws ExecutionException, InterruptedException {
+            try {
+                return get(true, -1, TimeUnit.MILLISECONDS);
+            } catch (TimeoutException te) {
+                // Not gonna happen.
+                throw new RuntimeException(te);
+            }
+        }
+
+        @Override
+        public T get(long timeout, TimeUnit unit)
+                throws ExecutionException, InterruptedException, TimeoutException {
+            return get(false, timeout, unit);
+        }
+
+        @Override
+        public boolean isDone() {
+            return isDone;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return isCancelled;
+        }
+
+        @Override
+        public boolean cancel(final boolean mayInterrupt) {
+            // Do a best-effort to detect if already cancelled, but the final say is
+            // always
+            // on the server side. Don't block the caller, though.
+            if (!isCancelled && !isCancelPending) {
+                isCancelPending = true;
+                if (statementId > -1) {
+                    sendCancelRequest(statementId);
+                }
+                return true;
+            }
+
+            return false;
+        }
+
+        @Override
+        protected T result() {
+            return result;
+        }
+
+        @Override
+        protected Throwable error() {
+            return error;
+        }
+
+        public long getStatementId() {
+            return statementId;
+        }
+
+        void start(final String command, String code, String kind) {
+            Runnable task = new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        ClientMessage msg = new SerializedStatement(code, kind);
+                        StatementStatus statement = conn.post(msg, StatementStatus.class, "/%d/%s", sessionId,
+                                command);
+
+                        if (isCancelPending) {
+                            sendCancelRequest(statement.id);
+                        }
+
+                        statementId = statement.id;
+
+                        executor.schedule(new StatementPollTask(initialPollInterval), initialPollInterval,
+                                TimeUnit.MILLISECONDS);
+                    } catch (Exception e) {
+                        setResult(null, e, State.FAILED);
+                    }
+                }
+            };
+            executor.submit(task);
+        }
+
+        private void sendCancelRequest(final long id) {
+            executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        // TODO: Check if sessions/ is required
+                        conn.post(null, Void.class, "/%d/statements/%d/cancel", sessionId, id);
+                    } catch (Exception e) {
+                        setResult(null, e, State.FAILED);
+                    }
+                }
+            });
+        }
+
+        private T get(boolean waitIndefinitely, long timeout, TimeUnit unit)
+                throws ExecutionException, InterruptedException, TimeoutException {
+            if (!isDone) {
+                synchronized (lock) {
+                    if (waitIndefinitely) {
+                        while (!isDone) {
+                            lock.wait();
+                        }
+                    } else {
+                        long now = System.nanoTime();
+                        long deadline = now + unit.toNanos(timeout);
+                        while (!isDone && deadline > now) {
+                            lock.wait(TimeUnit.NANOSECONDS.toMillis(deadline - now));
+                            now = System.nanoTime();
+                        }
+                        if (!isDone) {
+                            throw new TimeoutException();
+                        }
+                    }
+                }
+            }
+            if (isCancelled) {
+                throw new CancellationException();
+            }
+            if (error != null) {
+                throw new ExecutionException(error);
+            }
+            return result;
+        }
+
+        private JobHandle.State getJobState(StatementStatus statement) {
+            switch (StatementState.getValue(statement.state)) {
+                case Waiting:
+                    return JobHandle.State.QUEUED;
+                case Running:
+                    return JobHandle.State.STARTED;
+                case Cancelled:
+                    return JobHandle.State.CANCELLED;
+                case Cancelling:
+                    return JobHandle.State.CANCELLING;
+                case Error:
+                    return JobHandle.State.FAILED;
+                case Available:
+                    String stmtOutputStatus = (String) statement.output.get("status");
+                    switch (stmtOutputStatus) {
+                        case "error":
+                            return JobHandle.State.FAILED;
+                        case "ok":
+                            return JobHandle.State.SUCCEEDED;
+                        default:
+                            throw new IllegalStateException(
+                                    String.format("Unknown statement state %s", stmtOutputStatus));
+                    }
+                default:
+                    throw new IllegalStateException(String.format("Unknown statement state %s", statement.state));
+            }
+
+        }
+
+        private void setResult(T result, Throwable error, State newState) {
+            if (!isDone) {
+                synchronized (lock) {
+                    if (!isDone) {
+                        this.result = result;
+                        this.error = error;
+                        this.isDone = true;
+                        changeState(newState);
+                    }
+                    lock.notifyAll();
+                }
+            }
+        }
+
+        private class StatementPollTask implements Runnable {
+
+            private long currentInterval;
+
+            StatementPollTask(long currentInterval) {
+                this.currentInterval = currentInterval;
+            }
+
+            @Override
+            public void run() {
+                try {
+                    StatementStatus statement = conn.get(StatementStatus.class, "/%d/statements/%d", sessionId,
+                            statementId);
+                    T result = null;
+                    Throwable error = null;
+                    boolean finished = false;
+                    State stState = getJobState(statement);
+                    switch (stState) {
+                        case SUCCEEDED:
+                            finished = true;
+                            @SuppressWarnings("unchecked")
+                            T localResult = (T) ((java.util.LinkedHashMap<String, String>) statement.output.get("data")).get("text/plain");
+
+                            result = localResult;
+                            break;
+
+                        case FAILED:
+                            finished = true;
+                            if (StatementState.getValue(statement.state).equals(StatementState.Error)) {
+                                // TODO find out how to retrieve error in this case
+                                error = new RuntimeException((String) statement.output.get("evalue"));
+                            }
+                            error = new RuntimeException((String) statement.output.get("evalue"));
+                            break;
+
+                        case CANCELLED:
+                            isCancelled = true;
+                            finished = true;
+                            break;
+
+                        default:
+                            // Nothing to do.
+                    }
+                    if (finished) {
+                        setResult(result, error, stState);
+                    } else if (stState != state) {
+                        changeState(stState);
+                    }
+                    if (!finished) {
+                        currentInterval = Math.min(currentInterval * 2, maxPollInterval);
+                        executor.schedule(this, currentInterval, TimeUnit.MILLISECONDS);
+                    }
+                } catch (Exception e) {
+                    setResult(null, e, State.FAILED);
+                }
+            }
+        }
+
+        @Override
+        public String getId() {
+            return Long.toString(statementId);
+        }
+
+        public static class StatementStatus {
+            public final int id;
+            public final String code;
+            public final String state;
+            public final Map<String, Object> output;
+            public final double progress;
+            public final long started;
+            public final long completed;
+
+            public StatementStatus(Integer id, String code, String state, Map<String, Object> output,
+                                   double progress, long started, long completed) {
+                this.id = id;
+                this.code = code;
+                this.state = state;
+                this.output = output;
+                this.progress = progress;
+                this.started = started;
+                this.completed = completed;
+            }
+
+            private StatementStatus() {
+                this(0, null, null, null, 0.0, 0, 0);
+            }
+        }
+
+        public enum StatementState {
+            Waiting("waiting"), Running("running"), Available("available"), Cancelling("cancelling"), Cancelled(
+                    "cancelled"), Error("error");
+
+            private final String state;
+
+            StatementState(final String text) {
+                this.state = text;
+            }
+
+            @JsonValue
+            @Override
+            public String toString() {
+                return state;
+            }
+
+            // TODO: Change it to capitalize
+            public static StatementState getValue(String state) {
+                String firstLetter = state.substring(0, 1);
+                String remainingLetters = state.substring(1, state.length());
+                return valueOf(firstLetter.toUpperCase().concat(remainingLetters));
+            }
+        }
+    }
+

--- a/rsc/src/main/java/org/apache/livy/rsc/JobHandleImpl.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/JobHandleImpl.java
@@ -17,16 +17,12 @@
 
 package org.apache.livy.rsc;
 
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+import io.netty.util.concurrent.Promise;
+import org.apache.livy.client.common.AbstractJobHandle;
+
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import io.netty.util.concurrent.Promise;
-
-import org.apache.livy.JobHandle;
-import org.apache.livy.client.common.AbstractJobHandle;
 
 /**
  * A handle to a submitted job. Allows for monitoring and controlling of the running remote job.
@@ -101,6 +97,10 @@ class JobHandleImpl<T> extends AbstractJobHandle<T> {
       promise.setFailure(error);
       changeState(State.FAILED);
     }
+  }
+  @Override
+  public String getId() {
+    return jobId;
   }
 
 }

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
@@ -17,6 +17,23 @@
 
 package org.apache.livy.rsc;
 
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import io.netty.util.concurrent.Promise;
+import org.apache.livy.Job;
+import org.apache.livy.JobHandle;
+import org.apache.livy.LivyClient;
+import org.apache.livy.client.common.BufferUtils;
+import org.apache.livy.rsc.driver.AddFileJob;
+import org.apache.livy.rsc.driver.AddJarJob;
+import org.apache.livy.rsc.rpc.Rpc;
+import org.apache.livy.sessions.SessionState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -28,25 +45,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.util.concurrent.GenericFutureListener;
-import io.netty.util.concurrent.ImmediateEventExecutor;
-import io.netty.util.concurrent.Promise;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import org.apache.livy.Job;
-import org.apache.livy.JobHandle;
-import org.apache.livy.LivyClient;
-import org.apache.livy.client.common.BufferUtils;
-import org.apache.livy.rsc.driver.AddFileJob;
-import org.apache.livy.rsc.driver.AddJarJob;
-import org.apache.livy.rsc.rpc.Rpc;
-import org.apache.livy.sessions.SessionState;
-
-import static org.apache.livy.rsc.RSCConf.Entry.*;
+import static org.apache.livy.rsc.RSCConf.Entry.CLIENT_SHUTDOWN_TIMEOUT;
+import static org.apache.livy.rsc.RSCConf.Entry.RPC_MAX_THREADS;
 
 public class RSCClient implements LivyClient {
   private static final Logger LOG = LoggerFactory.getLogger(RSCClient.class);
@@ -431,5 +431,9 @@ public class RSCClient implements LivyClient {
       }
       replState = msg.state;
     }
+  }
+  @Override
+  public <T> JobHandle<T> submitStatement(String code, String kind){
+    throw new UnsupportedOperationException();
   }
 }

--- a/rsc/src/test/java/org/apache/livy/rsc/TestSparkClient.java
+++ b/rsc/src/test/java/org/apache/livy/rsc/TestSparkClient.java
@@ -17,19 +17,11 @@
 
 package org.apache.livy.rsc;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
-import java.net.URI;
-import java.nio.ByteBuffer;
-import java.time.Duration;
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.jar.JarOutputStream;
-import java.util.zip.ZipEntry;
-
 import org.apache.commons.io.FileUtils;
+import org.apache.livy.*;
+import org.apache.livy.client.common.Serializer;
+import org.apache.livy.rsc.rpc.RpcException;
+import org.apache.livy.test.jobs.*;
 import org.apache.spark.launcher.SparkLauncher;
 import org.apache.spark.streaming.api.java.JavaStreamingContext;
 import org.junit.Test;
@@ -37,18 +29,24 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Properties;
+import java.util.concurrent.*;
+import java.util.jar.JarOutputStream;
+import java.util.zip.ZipEntry;
+
+import static org.apache.livy.rsc.RSCConf.Entry.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
-
-import org.apache.livy.Job;
-import org.apache.livy.JobContext;
-import org.apache.livy.JobHandle;
-import org.apache.livy.LivyClient;
-import org.apache.livy.LivyClientBuilder;
-import org.apache.livy.client.common.Serializer;
-import org.apache.livy.rsc.rpc.RpcException;
-import org.apache.livy.test.jobs.*;
-import static org.apache.livy.rsc.RSCConf.Entry.*;
 
 public class TestSparkClient {
 
@@ -103,6 +101,26 @@ public class TestSparkClient {
       }
     });
   }
+
+//  public void testStatementSubmission() throws Exception {
+//    runTest(true, new TestFunction() {
+//      @Override
+//      public void call(LivyClient client) throws Exception {
+//        JobHandle.Listener<String> listener = newListener();
+//        JobHandle<String> handle = client.submit(new Echo<>("hello"));
+//        handle.addListener(listener);
+//        assertEquals("hello", handle.get(TIMEOUT, TimeUnit.SECONDS));
+//
+//        // Try an invalid state transition on the handle. This ensures that the actual state
+//        // change we're interested in actually happened, since internally the handle serializes
+//        // state changes.
+//        assertFalse(((JobHandleImpl<String>)handle).changeState(JobHandle.State.SENT));
+//
+//        verify(listener).onJobStarted(handle);
+//        verify(listener).onJobSucceeded(same(handle), eq(handle.get()));
+//      }
+//    });
+//  }
 
   @Test
   public void testSimpleSparkJob() throws Exception {

--- a/scala-api/src/test/scala/org/apache/livy/scalaapi/ScalaJobHandleTest.scala
+++ b/scala-api/src/test/scala/org/apache/livy/scalaapi/ScalaJobHandleTest.scala
@@ -174,6 +174,8 @@ class ScalaJobHandleTest extends FunSuite
 
 private abstract class AbstractJobHandleStub[T] private[livy] extends JobHandle[T] {
 
+  override def getId: String = null
+
   override def getState: State = null
 
   override def addListener(l: Listener[T]): Unit = {}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Current java http client doesn't support running statements. This Jira tracks the work for executing statements using http-client, monitoring them with the existing job monitoring logic and returning the results of the executed statement. 

https://issues.apache.org/jira/browse/LIVY-892

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
