### PR TITLE
Support Python 3.8+ in REPL

### DIFF
--- a/repl/src/main/resources/fake_shell.py
+++ b/repl/src/main/resources/fake_shell.py
@@ -219,7 +219,10 @@ class NormalNode(object):
 
         try:
             for node in to_run_exec:
-                mod = ast.Module([node])
+                if sys.version < "3.8":
+                    mod = ast.Module([node])
+                else:
+                    mod = ast.Module([node], [])
                 code = compile(mod, '<stdin>', 'exec')
                 exec(code, global_dict)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Porting `ast.Module()` call to be compatible with Python 3.8 and later versions.

## How was this patch tested?
in a Yarn application

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
