### PR TITLE
[LIVY-580] Use the right Python executable in Python interpreter tests

### DIFF
--- a/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
@@ -47,8 +47,8 @@ object PythonInterpreter extends Logging {
 
   def apply(conf: SparkConf, sparkEntries: SparkEntries): Interpreter = {
     val pythonExec = conf.getOption("spark.pyspark.python")
+      .orElse(sys.props.get("__pyspark.python__")) // Only used for internal UT.
       .orElse(sys.env.get("PYSPARK_PYTHON"))
-      .orElse(sys.props.get("pyspark.python")) // This java property is only used for internal UT.
       .getOrElse("python")
 
     val secretKey = Utils.createSecret(256)

--- a/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
@@ -251,9 +251,19 @@ abstract class PythonBaseInterpreterSpec extends BaseInterpreterSpec {
   }
 }
 
-class Python2InterpreterSpec extends PythonBaseInterpreterSpec {
+class Python2InterpreterSpec extends PythonBaseInterpreterSpec with BeforeAndAfterAll {
 
   implicit val formats = DefaultFormats
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    sys.props.put("__pyspark.python__", "python2")
+  }
+
+  override def afterAll(): Unit = {
+    sys.props.remove("__pyspark.python__")
+    super.afterAll()
+  }
 
   override def createInterpreter(): Interpreter = {
     val sparkConf = new SparkConf()
@@ -287,11 +297,11 @@ class Python3InterpreterSpec extends PythonBaseInterpreterSpec with BeforeAndAft
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    sys.props.put("pyspark.python", "python3")
+    sys.props.put("__pyspark.python__", "python3")
   }
 
   override def afterAll(): Unit = {
-    sys.props.remove("pyspark.python")
+    sys.props.remove("__pyspark.python__")
     super.afterAll()
   }
 

--- a/repl/src/test/scala/org/apache/livy/repl/PythonSessionSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/PythonSessionSpec.scala
@@ -170,7 +170,17 @@ abstract class PythonSessionSpec extends BaseSessionSpec(PySpark) {
   }
 }
 
-class Python2SessionSpec extends PythonSessionSpec
+class Python2SessionSpec extends PythonSessionSpec with BeforeAndAfterAll {
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    sys.props.put("__pyspark.python__", "python2")
+  }
+
+  override def afterAll(): Unit = {
+    sys.props.remove("__pyspark.python__")
+    super.afterAll()
+  }
+}
 
 class Python3SessionSpec extends PythonSessionSpec with BeforeAndAfterAll {
 
@@ -181,11 +191,11 @@ class Python3SessionSpec extends PythonSessionSpec with BeforeAndAfterAll {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    sys.props.put("pyspark.python", "python3")
+    sys.props.put("__pyspark.python__", "python3")
   }
 
   override def afterAll(): Unit = {
-    sys.props.remove("pyspark.python")
+    sys.props.remove("__pyspark.python__")
     super.afterAll()
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Sometimes if development/testing environment has an environment variable PYSPARK_PYTHON it will be picked up and used in some unit tests. Here, we make sure we are using the version of Python that we intended, independent of the development environment.

https://issues.apache.org/jira/browse/LIVY-580

## How was this patch tested?

Local testing.
