### PR TITLE
[LIVY-579] Set UTF-8 locale environment variable for tests handled by Scalatest.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -724,6 +724,7 @@
           <configuration>
             <environmentVariables>
               <LIVY_TEST>true</LIVY_TEST>
+              <LC_ALL>C.UTF-8</LC_ALL>
               <SPARK_HOME>${spark.home}</SPARK_HOME>
               <LIVY_LOG_DIR>${livy.log.dir}</LIVY_LOG_DIR>
               <LIVY_SPARK_VERSION>${spark.version}</LIVY_SPARK_VERSION>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Python 2 Interpreter (via fake_shell) require OS to have the right locale/ default character set. 
Here we add an environment variable to make sure Python 2 interpreter unicode tests pass.
https://issues.apache.org/jira/browse/LIVY-579

## How was this patch tested?

Local testing.