### PR TITLE
Fix pip for Python 3 in Travis definition - steps towards getting the builds working again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ install:
   - sudo apt-get -qq install python-pip
   - sudo pip2 -q install setuptools
   - sudo pip2 -q install --upgrade "pip < 10.0.0"
+  - sudo python3 -m pip -q install setuptools
   - sudo python3 -m pip -q install --upgrade "pip < 10.0.0"
   - sudo pip2 -q install codecov cloudpickle
   - sudo python3 -m pip -q install cloudpickle

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,12 @@ install:
   - sudo apt-get update
   - sudo apt-get -qq --allow-unauthenticated install r-base
   - sudo apt-get -qq install python3-pip python-dev
-  - sudo apt-get -qq install libkrb5-dev
+  - sudo apt-get -qq install libkrb5-dev libffi-dev
   - sudo apt-get -qq remove python-setuptools
-  - sudo pip2 -q install --upgrade "pip < 10.0.0" "setuptools < 36"
-  - sudo python3 -m pip -q install --upgrade "pip < 10.0.0" "setuptools < 36"
+  - sudo apt-get -qq install python-pip
+  - sudo pip2 -q install setuptools
+  - sudo pip2 -q install --upgrade "pip < 10.0.0"
+  - sudo python3 -m pip -q install --upgrade pip
   - sudo pip2 -q install codecov cloudpickle
   - sudo python3 -m pip -q install cloudpickle
   - sudo pip2 -q install "requests >= 2.10.0" pytest flaky flake8 requests-kerberos

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,19 +44,14 @@ install:
   - sudo apt-get update
   - sudo apt-get -qq --allow-unauthenticated install r-base
   - sudo apt-get -qq install python3-pip python-dev
-  - sudo apt-get -qq install libkrb5-dev libffi-dev
+  - sudo apt-get -qq install libkrb5-dev
   - sudo apt-get -qq remove python-setuptools
-  - sudo apt-get -qq install python-pip
-  - sudo pip2 -q install setuptools
-  - sudo pip2 -q install --upgrade "pip < 10.0.0"
-  - sudo python3 -m pip -q install setuptools
-  - sudo python3 -m pip -q install --upgrade "pip < 10.0.0"
+  - sudo pip2 -q install --upgrade pip "setuptools < 36"
+  - sudo python3 -m pip -q install --upgrade pip "setuptools < 36"
   - sudo pip2 -q install codecov cloudpickle
   - sudo python3 -m pip -q install cloudpickle
   - sudo pip2 -q install "requests >= 2.10.0" pytest flaky flake8 requests-kerberos
-  - sudo pip3 -q install "requests >= 2.10.0" flaky 
-  - sudo python3 -m pip -q install --upgrade pip
-  - sudo pip3 -q install pytest requests-kerberos
+  - sudo pip3 -q install "requests >= 2.10.0" pytest flaky requests-kerberos
 
 script:
   - mvn $MVN_FLAG -Dmaven.javadoc.skip=true -B -V -e verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,9 @@ install:
   - sudo apt-get -qq install libkrb5-dev
   - sudo apt-get -qq remove python-setuptools
   - sudo pip2 -q install --upgrade pip "setuptools < 36"
-  - sudo python3 -m pip -q install --upgrade pip "setuptools < 36"
+  - sudo pip3 -q install --upgrade pip "setuptools < 36"
   - sudo pip2 -q install codecov cloudpickle
-  - sudo python3 -m pip -q install cloudpickle
+  - sudo pip3 -q install cloudpickle
   - sudo pip2 -q install "requests >= 2.10.0" pytest flaky flake8 requests-kerberos
   - sudo pip3 -q install "requests >= 2.10.0" pytest flaky requests-kerberos
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,11 +48,11 @@ install:
   - sudo apt-get -qq remove python-setuptools
   - sudo pip2 -q install --upgrade pip "setuptools < 36"
   - sudo curl -fsSL https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3.5
-  - sudo pip3 -q install "setuptools < 36"
+  - sudo python3 -m pip -q install "setuptools < 36"
   - sudo pip2 -q install codecov cloudpickle
-  - sudo pip3 -q install cloudpickle
+  - sudo python3 -m pip -q install cloudpickle
   - sudo pip2 -q install "requests >= 2.10.0" pytest flaky flake8 requests-kerberos
-  - sudo pip3 -q install "requests >= 2.10.0" pytest flaky requests-kerberos
+  - sudo python3 -m pip -q install "requests >= 2.10.0" pytest flaky requests-kerberos
 
 script:
   - mvn $MVN_FLAG -Dmaven.javadoc.skip=true -B -V -e verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,12 @@ install:
   - sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran35/'
   - sudo apt-get update
   - sudo apt-get -qq --allow-unauthenticated install r-base
-  - sudo apt-get -qq install python3-pip python-dev
+  - sudo apt-get -qq install python-dev
   - sudo apt-get -qq install libkrb5-dev
   - sudo apt-get -qq remove python-setuptools
   - sudo pip2 -q install --upgrade pip "setuptools < 36"
-  - sudo pip3 -q install --upgrade pip "setuptools < 36"
+  - sudo curl -fsSL https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3.5
+  - sudo pip3 -q install "setuptools < 36"
   - sudo pip2 -q install codecov cloudpickle
   - sudo pip3 -q install cloudpickle
   - sudo pip2 -q install "requests >= 2.10.0" pytest flaky flake8 requests-kerberos

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,11 +49,13 @@ install:
   - sudo apt-get -qq install python-pip
   - sudo pip2 -q install setuptools
   - sudo pip2 -q install --upgrade "pip < 10.0.0"
-  - sudo python3 -m pip -q install --upgrade pip
+  - sudo python3 -m pip -q install --upgrade "pip < 10.0.0"
   - sudo pip2 -q install codecov cloudpickle
   - sudo python3 -m pip -q install cloudpickle
   - sudo pip2 -q install "requests >= 2.10.0" pytest flaky flake8 requests-kerberos
-  - sudo pip3 -q install "requests >= 2.10.0" pytest flaky requests-kerberos
+  - sudo pip3 -q install "requests >= 2.10.0" flaky 
+  - sudo python3 -m pip -q install --upgrade pip
+  - sudo pip3 -q install pytest requests-kerberos
 
 script:
   - mvn $MVN_FLAG -Dmaven.javadoc.skip=true -B -V -e verify


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolve issues with pip as it is no longer supported for Python 3.5. 
(Until we move to Ubuntu 18.04+)

## How was this patch tested?

I set up a Travis job in my own fork and confirmed that it is now passing the Python packages installation phase:
https://app.travis-ci.com/github/Bekbolatov/incubator-livy/builds/254637404