### PR TITLE
Bump jackson to 2.12.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,8 @@
     <commons-codec.version>1.9</commons-codec.version>
     <httpclient.version>4.5.3</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>
-    <jackson.version>2.10.1</jackson.version>
+    <jackson.version>2.12.7</jackson.version>
+    <jackson-databind.version>2.12.7.1</jackson-databind.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <jetty.version>9.3.24.v20180605</jetty.version>
     <json4s.spark-2.11.version>3.5.3</json4s.spark-2.11.version>
@@ -289,7 +290,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
+        <version>${jackson-databind.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bumps `jackson` versions to 2.12.7 and `jackson-databind` to 2.12.7.1. Closes #364 

## How was this patch tested?

Local unit/integration tests.