### PR TITLE
Livy 904 - Address Jetty Dependency Upgrades for 0.8.0

### DIFF
--- a/client-http/src/test/scala/org/apache/livy/client/http/LivyConnectionSpec.scala
+++ b/client-http/src/test/scala/org/apache/livy/client/http/LivyConnectionSpec.scala
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 
 import org.apache.http.client.utils.URIBuilder
 import org.eclipse.jetty.security._
+import org.eclipse.jetty.security.UserStore
 import org.eclipse.jetty.security.authentication.BasicAuthenticator
 import org.eclipse.jetty.util.security._
 import org.scalatest.{BeforeAndAfterAll, FunSpecLike}
@@ -38,7 +39,9 @@ class LivyConnectionSpec extends FunSpecLike with BeforeAndAfterAll with LivyBas
       val roles = Array("user")
 
       val l = new HashLoginService()
-      l.putUser(username, Credential.getCredential(password), roles)
+      val userStore = new UserStore()
+      userStore.addUser(username, Credential.getCredential(password), roles)
+      l.setUserStore(userStore)
       l.setName(realm)
 
       val constraint = new Constraint()

--- a/pom.xml
+++ b/pom.xml
@@ -100,8 +100,8 @@
     <kryo.version>4.0.2</kryo.version>
     <metrics.version>3.1.0</metrics.version>
     <mockito.version>1.10.19</mockito.version>
-    <netty.spark-2.11.version>4.1.17.Final</netty.spark-2.11.version>
-    <netty.spark-2.12.version>4.1.17.Final</netty.spark-2.12.version>
+    <netty.spark-2.11.version>4.1.71.Final</netty.spark-2.11.version>
+    <netty.spark-2.12.version>4.1.71.Final</netty.spark-2.12.version>
     <netty.version>${netty.spark-2.11.version}</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <py4j.version>0.10.7</py4j.version>
@@ -1064,8 +1064,8 @@
         <spark.scala-2.12.version>3.0.0</spark.scala-2.12.version>
         <spark.scala-2.11.version>2.4.5</spark.scala-2.11.version>
         <spark.version>${spark.scala-2.11.version}</spark.version>
-        <netty.spark-2.12.version>4.1.47.Final</netty.spark-2.12.version>
-        <netty.spark-2.11.version>4.1.47.Final</netty.spark-2.11.version>
+        <netty.spark-2.12.version>4.1.71.Final</netty.spark-2.12.version>
+        <netty.spark-2.11.version>4.1.71.Final</netty.spark-2.11.version>
         <netty.version>${netty.spark-2.11.version}</netty.version>
         <java.version>1.8</java.version>
         <py4j.version>0.10.9</py4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -129,8 +129,8 @@
     <skipPySpark3Tests>false</skipPySpark3Tests>
 
     <!-- Required for testing LDAP integration -->
-    <apacheds.version>2.0.0-M21</apacheds.version>
-    <ldap-api.version>1.0.0-M33</ldap-api.version>
+    <apacheds.version>2.0.0.AM26</apacheds.version>
+    <ldap-api.version>2.1.2</ldap-api.version>
 
     <curator.version>2.7.1</curator.version>
     <zookeeper.version>3.4.6</zookeeper.version>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <jackson.version>2.12.7</jackson.version>
     <jackson-databind.version>2.12.7.1</jackson-databind.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-    <jetty.version>9.3.24.v20180605</jetty.version>
+    <jetty.version>9.4.50.v20221201</jetty.version>
     <json4s.spark-2.11.version>3.5.3</json4s.spark-2.11.version>
     <json4s.spark-2.12.version>3.5.3</json4s.spark-2.12.version>
     <json4s.version>${json4s.spark-2.11.version}</json4s.version>
@@ -100,8 +100,8 @@
     <kryo.version>4.0.2</kryo.version>
     <metrics.version>3.1.0</metrics.version>
     <mockito.version>1.10.19</mockito.version>
-    <netty.spark-2.11.version>4.1.71.Final</netty.spark-2.11.version>
-    <netty.spark-2.12.version>4.1.71.Final</netty.spark-2.12.version>
+    <netty.spark-2.11.version>4.1.17.Final</netty.spark-2.11.version>
+    <netty.spark-2.12.version>4.1.17.Final</netty.spark-2.12.version>
     <netty.version>${netty.spark-2.11.version}</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <py4j.version>0.10.7</py4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -100,8 +100,8 @@
     <kryo.version>4.0.2</kryo.version>
     <metrics.version>3.1.0</metrics.version>
     <mockito.version>1.10.19</mockito.version>
-    <netty.spark-2.11.version>4.1.17.Final</netty.spark-2.11.version>
-    <netty.spark-2.12.version>4.1.17.Final</netty.spark-2.12.version>
+    <netty.spark-2.11.version>4.1.86.Final</netty.spark-2.11.version>
+    <netty.spark-2.12.version>4.1.86.Final</netty.spark-2.12.version>
     <netty.version>${netty.spark-2.11.version}</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <py4j.version>0.10.7</py4j.version>
@@ -1064,8 +1064,8 @@
         <spark.scala-2.12.version>3.0.0</spark.scala-2.12.version>
         <spark.scala-2.11.version>2.4.5</spark.scala-2.11.version>
         <spark.version>${spark.scala-2.11.version}</spark.version>
-        <netty.spark-2.12.version>4.1.71.Final</netty.spark-2.12.version>
-        <netty.spark-2.11.version>4.1.71.Final</netty.spark-2.11.version>
+        <netty.spark-2.12.version>4.1.86.Final</netty.spark-2.12.version>
+        <netty.spark-2.11.version>4.1.86.Final</netty.spark-2.11.version>
         <netty.version>${netty.spark-2.11.version}</netty.version>
         <java.version>1.8</java.version>
         <py4j.version>0.10.9</py4j.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump version of Jetty to latest on the 9.4.x line to 9.4.50.v20221201

Also, address the incompatibility in LivyConnectionSpec.scala to make compatible with new Jetty dependency.

## How was this patch tested?

Build with unit and integration tests
