### PR TITLE
Rd 10172 rebase upstream and upgrade scala to 2.10.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ docker run --rm -it -v $(pwd)/../../:/workspace -v $HOME/.m2:/root/.m2 livy mvn 
 
 > **Note**: The `docker run` command maps the maven repository to your host machine's maven cache so subsequent runs will not need to download dependencies.
 
-By default Livy is built against Apache Spark 2.4.5, but the version of Spark used when running
+By default Livy is built against Apache Spark 2.4.6, but the version of Spark used when running
 Livy does not need to match the version used to build Livy. Livy internally handles the differences
 between different Spark versions.
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-api</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-api</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -43,12 +43,6 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>livy-repl_2.11</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>livy-repl_2.12</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-assembly</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-assembly</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/client-common/pom.xml
+++ b/client-common/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-common</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/client-common/pom.xml
+++ b/client-common/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-common</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/client-http/pom.xml
+++ b/client-http/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-http</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/client-http/pom.xml
+++ b/client-http/pom.xml
@@ -140,22 +140,30 @@
                 </filter>
               </filters>
               <relocations>
-                <relocation>
-                  <pattern>com.esotericsoftware</pattern>
-                  <shadedPattern>org.apache.livy.shaded.kryo</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.fasterxml.jackson</pattern>
-                  <shadedPattern>org.apache.livy.shaded.jackson</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.commons</pattern>
-                  <shadedPattern>org.apache.livy.shaded.apache.commons</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.http</pattern>
-                  <shadedPattern>org.apache.livy.shaded.apache.http</shadedPattern>
-                </relocation>
+                  <relocation>
+                      <pattern>com.esotericsoftware.kryo-shaded</pattern>
+                      <shadedPattern>org.apache.livy.shaded.kryo-shaded</shadedPattern>
+                  </relocation>
+                  <relocation>
+                      <pattern>com.esotericsoftware</pattern>
+                      <shadedPattern>org.apache.livy.shaded.kryo</shadedPattern>
+                  </relocation>
+                  <relocation>
+                      <pattern>com.fasterxml.jackson</pattern>
+                      <shadedPattern>org.apache.livy.shaded.jackson</shadedPattern>
+                  </relocation>
+                  <relocation>
+                      <pattern>org.apache.commons</pattern>
+                      <shadedPattern>org.apache.livy.shaded.apache.commons</shadedPattern>
+                  </relocation>
+                  <relocation>
+                      <pattern>org.apache.http</pattern>
+                      <shadedPattern>org.apache.livy.shaded.apache.http</shadedPattern>
+                  </relocation>
+                  <relocation>
+                      <pattern>org.objectweb.asm</pattern>
+                      <shadedPattern>org.apache.livy.shaded.kryo-shaded.com.esotericsoftware.reflectasm.shaded.org.objectweb.asm</shadedPattern>
+                  </relocation>
               </relocations>
             </configuration>
           </execution>

--- a/client-http/pom.xml
+++ b/client-http/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-http</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/client-http/src/main/java/org/apache/livy/client/http/HttpClient.java
+++ b/client-http/src/main/java/org/apache/livy/client/http/HttpClient.java
@@ -40,7 +40,7 @@ import static org.apache.livy.client.common.HttpMessages.*;
  * What is currently missing:
  * - monitoring of spark job IDs launched by jobs
  */
-class HttpClient implements LivyClient {
+public class HttpClient implements LivyClient {
 
   private final HttpConf config;
   private final LivyConnection conn;
@@ -184,7 +184,7 @@ class HttpClient implements LivyClient {
   }
 
   // For testing.
-  int getSessionId() {
+  public int getSessionId() {
     return sessionId;
   }
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../scala/pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-core-parent</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
     <relativePath>../scala/pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-core-parent</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/core/scala-2.11/pom.xml
+++ b/core/scala-2.11/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-core_2.11</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-core-parent</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/core/scala-2.11/pom.xml
+++ b/core/scala-2.11/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-core_2.11</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-core-parent</artifactId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/core/scala-2.12/pom.xml
+++ b/core/scala-2.12/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-core_2.12</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-core-parent</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/core/scala-2.12/pom.xml
+++ b/core/scala-2.12/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-core_2.12</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-core-parent</artifactId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
   </parent>
 
   <artifactId>livy-coverage-report</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
   </parent>
 
   <artifactId>livy-coverage-report</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/docs/_data/project.yml
+++ b/docs/_data/project.yml
@@ -16,6 +16,6 @@
 # Apache Project configurations
 #
 name: Apache Livy
-version: 0.8.0-incubating-SNAPSHOT
+version: 0.8.0-incubating-onedot
 
 podling: true

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-examples</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-examples</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -108,6 +108,10 @@
           <groupId>org.apache.zookeeper</groupId>
           <artifactId>zookeeper</artifactId>
         </exclusion>
+        <exclusion>
+           <groupId>asm</groupId>
+           <artifactId>asm</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
   </parent>
 
   <artifactId>livy-integration-test</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
   </parent>
 
   <artifactId>livy-integration-test</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-main</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>pom</packaging>
   <name>Livy Project Parent POM</name>
   <description>Livy Project</description>
@@ -81,7 +81,7 @@
     <asynchttpclient.version>2.10.1</asynchttpclient.version>
     <hadoop.version>2.7.3</hadoop.version>
     <hadoop.scope>compile</hadoop.scope>
-    <spark.scala-2.11.version>2.4.6</spark.scala-2.11.version>
+<!--    <spark.scala-2.11.version>2.4.6</spark.scala-2.11.version>-->
     <spark.scala-2.12.version>2.4.6</spark.scala-2.12.version>
     <spark.version>${spark.scala-2.12.version}</spark.version>
     <hive.version>3.0.0</hive.version>
@@ -92,7 +92,7 @@
     <jackson-databind.version>2.12.7.1</jackson-databind.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <jetty.version>9.4.50.v20221201</jetty.version>
-    <json4s.spark-2.11.version>3.5.3</json4s.spark-2.11.version>
+<!--    <json4s.spark-2.11.version>3.5.3</json4s.spark-2.11.version>-->
     <json4s.spark-2.12.version>3.5.3</json4s.spark-2.12.version>
     <json4s.version>${json4s.spark-2.12.version}</json4s.version>
     <junit.version>4.13.1</junit.version>
@@ -100,13 +100,13 @@
     <kryo.version>4.0.2</kryo.version>
     <metrics.version>3.1.0</metrics.version>
     <mockito.version>1.10.19</mockito.version>
-    <netty.spark-2.11.version>4.1.86.Final</netty.spark-2.11.version>
+<!--    <netty.spark-2.11.version>4.1.86.Final</netty.spark-2.11.version>-->
     <netty.spark-2.12.version>4.1.86.Final</netty.spark-2.12.version>
     <netty.version>${netty.spark-2.12.version}</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <py4j.version>0.10.7</py4j.version>
-    <scala-2.11.version>2.11.12</scala-2.11.version>
-    <scala-2.12.version>2.12.12</scala-2.12.version>
+<!--    <scala-2.11.version>2.11.12</scala-2.11.version>-->
+    <scala-2.12.version>2.12.15</scala-2.12.version>
     <scala.binary.version>2.12</scala.binary.version>
     <scala.version>${scala-2.12.version}</scala.version>
     <scalatest.version>3.0.8</scalatest.version>
@@ -205,22 +205,22 @@
     <module>client-common</module>
     <module>client-http</module>
     <module>core</module>
-    <module>core/scala-2.11</module>
+<!--    <module>core/scala-2.11</module>-->
     <module>core/scala-2.12</module>
-    <module>coverage</module>
+<!--    <module>coverage</module>-->
     <module>examples</module>
-    <module>python-api</module>
+<!--    <module>python-api</module>-->
     <module>repl</module>
-    <module>repl/scala-2.11</module>
+<!--    <module>repl/scala-2.11</module>-->
     <module>repl/scala-2.12</module>
     <module>rsc</module>
     <module>scala</module>
     <module>scala-api</module>
-    <module>scala-api/scala-2.11</module>
+<!--    <module>scala-api/scala-2.11</module>-->
     <module>scala-api/scala-2.12</module>
     <module>server</module>
     <module>test-lib</module>
-    <module>integration-test</module>
+<!--    <module>integration-test</module>-->
   </modules>
 
   <dependencies>
@@ -639,7 +639,7 @@
         <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
-          <version>4.2.0</version>
+          <version>4.2.4</version>
           <executions>
             <execution>
               <goals>
@@ -1062,14 +1062,14 @@
       </activation>
       <properties>
         <spark.scala-2.12.version>3.0.0</spark.scala-2.12.version>
-        <spark.scala-2.11.version>2.4.6</spark.scala-2.11.version>
-        <spark.version>${spark.scala-2.11.version}</spark.version>
+<!--        <spark.scala-2.11.version>2.4.6</spark.scala-2.11.version>-->
+<!--        <spark.version>${spark.scala-2.11.version}</spark.version>-->
         <netty.spark-2.12.version>4.1.86.Final</netty.spark-2.12.version>
-        <netty.spark-2.11.version>4.1.86.Final</netty.spark-2.11.version>
-        <netty.version>${netty.spark-2.11.version}</netty.version>
+<!--        <netty.spark-2.11.version>4.1.86.Final</netty.spark-2.11.version>-->
+<!--        <netty.version>${netty.spark-2.11.version}</netty.version>-->
         <java.version>1.8</java.version>
         <py4j.version>0.10.9</py4j.version>
-        <json4s.spark-2.11.version>3.5.3</json4s.spark-2.11.version>
+<!--        <json4s.spark-2.11.version>3.5.3</json4s.spark-2.11.version>-->
         <json4s.spark-2.12.version>3.6.6</json4s.spark-2.12.version>
         <json4s.version>${json4s.spark-2.12.version}</json4s.version>
         <spark.bin.download.url>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <hadoop.scope>compile</hadoop.scope>
     <spark.scala-2.11.version>2.4.6</spark.scala-2.11.version>
     <spark.scala-2.12.version>2.4.6</spark.scala-2.12.version>
-    <spark.version>${spark.scala-2.11.version}</spark.version>
+    <spark.version>${spark.scala-2.12.version}</spark.version>
     <hive.version>3.0.0</hive.version>
     <commons-codec.version>1.9</commons-codec.version>
     <httpclient.version>4.5.13</httpclient.version>
@@ -94,7 +94,7 @@
     <jetty.version>9.4.50.v20221201</jetty.version>
     <json4s.spark-2.11.version>3.5.3</json4s.spark-2.11.version>
     <json4s.spark-2.12.version>3.5.3</json4s.spark-2.12.version>
-    <json4s.version>${json4s.spark-2.11.version}</json4s.version>
+    <json4s.version>${json4s.spark-2.12.version}</json4s.version>
     <junit.version>4.13.1</junit.version>
     <libthrift.version>0.9.3</libthrift.version>
     <kryo.version>4.0.2</kryo.version>
@@ -102,7 +102,7 @@
     <mockito.version>1.10.19</mockito.version>
     <netty.spark-2.11.version>4.1.86.Final</netty.spark-2.11.version>
     <netty.spark-2.12.version>4.1.86.Final</netty.spark-2.12.version>
-    <netty.version>${netty.spark-2.11.version}</netty.version>
+    <netty.version>${netty.spark-2.12.version}</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <py4j.version>0.10.7</py4j.version>
     <scala-2.11.version>2.11.12</scala-2.11.version>
@@ -116,17 +116,17 @@
     <execution.root>${user.dir}</execution.root>
     <spark.home>${execution.root}/dev/spark</spark.home>
     <spark.bin.download.url>
-      https://archive.apache.org/dist/spark/spark-2.4.6/spark-2.4.6-bin-hadoop2.7.tgz
+      https://archive.apache.org/dist/spark/spark-2.4.6/spark-2.4.6-bin-without-hadoop-scala-2.12.tgz
     </spark.bin.download.url>
-    <spark.bin.name>spark-2.4.6-bin-hadoop2.7</spark.bin.name>
+    <spark.bin.name>spark-2.4.6-bin-without-hadoop-scala-2.12</spark.bin.name>
     <!--  used for testing, NCSARequestLog use it for access log  -->
     <livy.log.dir>${basedir}/target</livy.log.dir>
 
     <!-- Set this to "true" to skip R tests. -->
-    <skipRTests>false</skipRTests>
+    <skipRTests>true</skipRTests>
 
     <!-- Set this to "true" to skip PySpark3 tests. -->
-    <skipPySpark3Tests>false</skipPySpark3Tests>
+    <skipPySpark3Tests>true</skipPySpark3Tests>
 
     <!-- Required for testing LDAP integration -->
     <apacheds.version>2.0.0.AM26</apacheds.version>

--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
     <asynchttpclient.version>2.10.1</asynchttpclient.version>
     <hadoop.version>2.7.3</hadoop.version>
     <hadoop.scope>compile</hadoop.scope>
-    <spark.scala-2.11.version>2.4.5</spark.scala-2.11.version>
-    <spark.scala-2.12.version>2.4.5</spark.scala-2.12.version>
+    <spark.scala-2.11.version>2.4.6</spark.scala-2.11.version>
+    <spark.scala-2.12.version>2.4.6</spark.scala-2.12.version>
     <spark.version>${spark.scala-2.11.version}</spark.version>
     <hive.version>3.0.0</hive.version>
     <commons-codec.version>1.9</commons-codec.version>
@@ -106,9 +106,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <py4j.version>0.10.7</py4j.version>
     <scala-2.11.version>2.11.12</scala-2.11.version>
-    <scala-2.12.version>2.12.10</scala-2.12.version>
-    <scala.binary.version>2.11</scala.binary.version>
-    <scala.version>${scala-2.11.version}</scala.version>
+    <scala-2.12.version>2.12.12</scala-2.12.version>
+    <scala.binary.version>2.12</scala.binary.version>
+    <scala.version>${scala-2.12.version}</scala.version>
     <scalatest.version>3.0.8</scalatest.version>
     <scalatra.version>2.6.5</scalatra.version>
     <java.version>1.8</java.version>
@@ -116,9 +116,9 @@
     <execution.root>${user.dir}</execution.root>
     <spark.home>${execution.root}/dev/spark</spark.home>
     <spark.bin.download.url>
-      https://archive.apache.org/dist/spark/spark-2.4.5/spark-2.4.5-bin-hadoop2.7.tgz
+      https://archive.apache.org/dist/spark/spark-2.4.6/spark-2.4.6-bin-hadoop2.7.tgz
     </spark.bin.download.url>
-    <spark.bin.name>spark-2.4.5-bin-hadoop2.7</spark.bin.name>
+    <spark.bin.name>spark-2.4.6-bin-hadoop2.7</spark.bin.name>
     <!--  used for testing, NCSARequestLog use it for access log  -->
     <livy.log.dir>${basedir}/target</livy.log.dir>
 
@@ -1062,7 +1062,7 @@
       </activation>
       <properties>
         <spark.scala-2.12.version>3.0.0</spark.scala-2.12.version>
-        <spark.scala-2.11.version>2.4.5</spark.scala-2.11.version>
+        <spark.scala-2.11.version>2.4.6</spark.scala-2.11.version>
         <spark.version>${spark.scala-2.11.version}</spark.version>
         <netty.spark-2.12.version>4.1.86.Final</netty.spark-2.12.version>
         <netty.spark-2.11.version>4.1.86.Final</netty.spark-2.11.version>
@@ -1071,7 +1071,7 @@
         <py4j.version>0.10.9</py4j.version>
         <json4s.spark-2.11.version>3.5.3</json4s.spark-2.11.version>
         <json4s.spark-2.12.version>3.6.6</json4s.spark-2.12.version>
-        <json4s.version>${json4s.spark-2.11.version}</json4s.version>
+        <json4s.version>${json4s.spark-2.12.version}</json4s.version>
         <spark.bin.download.url>
           https://archive.apache.org/dist/spark/spark-3.0.0/spark-3.0.0-bin-hadoop2.7.tgz
         </spark.bin.download.url>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-main</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>pom</packaging>
   <name>Livy Project Parent POM</name>
   <description>Livy Project</description>

--- a/python-api/pom.xml
+++ b/python-api/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-python-api</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <build>

--- a/python-api/pom.xml
+++ b/python-api/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-python-api</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <build>

--- a/python-api/setup.py
+++ b/python-api/setup.py
@@ -40,7 +40,7 @@ requirements = [
 
 setup(
     name='livy-python-api',
-    version="0.8.0-incubating-SNAPSHOT",
+    version="0.8.0-incubating-onedot",
     packages=["livy", "livy-tests"],
     package_dir={
         "": "src/main/python",

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
     <relativePath>../scala/pom.xml</relativePath>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
   </parent>
 
   <artifactId>livy-repl-parent</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
     <relativePath>../scala/pom.xml</relativePath>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
   </parent>
 
   <artifactId>livy-repl-parent</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/repl/scala-2.11/pom.xml
+++ b/repl/scala-2.11/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-repl_2.11</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-repl-parent</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/repl/scala-2.11/pom.xml
+++ b/repl/scala-2.11/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-repl_2.11</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-repl-parent</artifactId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/repl/scala-2.12/pom.xml
+++ b/repl/scala-2.12/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-repl_2.12</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-repl-parent</artifactId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/repl/scala-2.12/pom.xml
+++ b/repl/scala-2.12/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-repl_2.12</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-repl-parent</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -147,6 +147,7 @@
                 <includes>
                   <include>org.apache.livy:livy-client-common</include>
                   <include>com.esotericsoftware:kryo-shaded</include>
+                  <include>com.esotericsoftware:kryo-shaded</include>
                   <include>com.esotericsoftware:minlog</include>
                 </includes>
               </artifactSet>
@@ -164,6 +165,10 @@
                 <relocation>
                   <pattern>com.esotericsoftware</pattern>
                   <shadedPattern>org.apache.livy.shaded.kryo</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.esotericsoftware.kryo-shaded</pattern>
+                  <shadedPattern>org.apache.livy.shaded.kryo-shaded</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -115,6 +115,12 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -148,6 +148,7 @@
                   <include>org.apache.livy:livy-client-common</include>
                   <include>com.esotericsoftware:kryo-shaded</include>
                   <include>com.esotericsoftware:kryo-shaded</include>
+                  <include>com.esotericsoftware:kryo-shaded</include>
                   <include>com.esotericsoftware:minlog</include>
                 </includes>
               </artifactSet>

--- a/scala-api/pom.xml
+++ b/scala-api/pom.xml
@@ -23,12 +23,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
     <relativePath>../scala/pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-scala-api-parent</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/scala-api/pom.xml
+++ b/scala-api/pom.xml
@@ -23,12 +23,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../scala/pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-scala-api-parent</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/scala-api/scala-2.11/pom.xml
+++ b/scala-api/scala-2.11/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-scala-api_2.11</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-scala-api-parent</artifactId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala-api/scala-2.11/pom.xml
+++ b/scala-api/scala-2.11/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-scala-api_2.11</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-scala-api-parent</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala-api/scala-2.12/pom.xml
+++ b/scala-api/scala-2.12/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-scala-api_2.12</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-scala-api-parent</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala-api/scala-2.12/pom.xml
+++ b/scala-api/scala-2.12/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-scala-api_2.12</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-scala-api-parent</artifactId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>multi-scala-project-root</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>multi-scala-project-root</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
   </parent>
 
   <artifactId>livy-server</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
   </parent>
 
   <artifactId>livy-server</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/test-lib/pom.xml
+++ b/test-lib/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-test-lib</artifactId>
-  <version>0.8.0-incubating-onedot</version>
+  <version>0.8.2-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/test-lib/pom.xml
+++ b/test-lib/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-test-lib</artifactId>
-  <version>0.8.0-incubating-SNAPSHOT</version>
+  <version>0.8.0-incubating-onedot</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/thriftserver/client/pom.xml
+++ b/thriftserver/client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/thriftserver/client/pom.xml
+++ b/thriftserver/client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/thriftserver/server/pom.xml
+++ b/thriftserver/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/thriftserver/server/pom.xml
+++ b/thriftserver/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/thriftserver/session/pom.xml
+++ b/thriftserver/session/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-SNAPSHOT</version>
+    <version>0.8.0-incubating-onedot</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/thriftserver/session/pom.xml
+++ b/thriftserver/session/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.8.0-incubating-onedot</version>
+    <version>0.8.2-incubating-onedot</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
Bumped scala to 2.10.15 to match that in Spark 3.3.0 package. There is a problem between scala 2.12.12 and 2.12.15 producing incompatible bytecode