### PR TITLE
[LIVY-970][SERVER] Ordering and pagination support in GET /statement

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -251,6 +251,27 @@ Gets the log lines from this session.
 
 Returns all the statements in a session.
 
+#### Request Parameters
+
+<table class="table">
+  <tr><th>Name</th><th>Description</th><th>Type</th></tr>
+  <tr>
+    <td>from</td>
+    <td>The start index to fetch sessions</td>
+    <td>int</td>
+  </tr>
+  <tr>
+    <td>size</td>
+    <td>Number of sessions to fetch</td>
+    <td>int</td>
+  </tr>
+  <tr>
+    <td>order</td>
+    <td>Provide value as "latest" to get latest statement first </td>
+    <td>string</td>
+  </tr>
+</table>
+
 #### Response Body
 
 <table class="table">

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -267,7 +267,7 @@ Returns all the statements in a session.
   </tr>
   <tr>
     <td>order</td>
-    <td>Provide value as "latest" to get latest statement first </td>
+    <td>Provide value as "desc" to get statements in descending order (By default, the list is in ascending order)</td>
     <td>string</td>
   </tr>
 </table>

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -113,7 +113,12 @@ class InteractiveSessionServlet(
 
   get("/:id/statements") {
     withViewAccessSession { session =>
-      val statements = session.statements
+      val order = params.get("order")
+      val statements = if (order.map(_.trim).exists(_.equalsIgnoreCase("latest"))) {
+        session.statements.reverse
+      } else {
+        session.statements
+      }
       val from = params.get("from").map(_.toInt).getOrElse(0)
       val size = params.get("size").map(_.toInt).getOrElse(statements.length)
 

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -114,7 +114,7 @@ class InteractiveSessionServlet(
   get("/:id/statements") {
     withViewAccessSession { session =>
       val order = params.get("order")
-      val statements = if (order.map(_.trim).exists(_.equalsIgnoreCase("latest"))) {
+      val statements = if (order.map(_.trim).exists(_.equalsIgnoreCase("desc"))) {
         session.statements.reverse
       } else {
         session.statements


### PR DESCRIPTION
## What changes were proposed in this pull request?

GET /sessions/id/statements returns a list of statements run in a session. However the ordering of the statements are older ones first. Livy could expose a parameter (something like orderBy=latest) that will order the list of statements as latest first.
JIRA: https://issues.apache.org/jira/browse/LIVY-970

## How was this patch tested?

Verified manually by creating interactive session and statements via REST API call in a local Yarn cluster.
