### PR TITLE
[LIVY-971] Support to get session variables when using JDBC to connect to Livy thrift server.

### DIFF
--- a/integration-test/src/thriftserver/test/scala/org/apache/livy/test/JdbcIT.scala
+++ b/integration-test/src/thriftserver/test/scala/org/apache/livy/test/JdbcIT.scala
@@ -19,6 +19,7 @@ package org.apache.livy.test
 
 import java.sql.Date
 
+import org.apache.livy.sessions.SessionState
 import org.apache.livy.test.framework.BaseThriftIntegrationTestSuite
 
 class JdbcIT extends BaseThriftIntegrationTestSuite {
@@ -64,9 +65,10 @@ class JdbcIT extends BaseThriftIntegrationTestSuite {
 
       checkQuery(c, "DESC LIVY SESSION") { resultSet =>
         resultSet.next()
-        assert(resultSet.getString(1).toInt >= 0)
-        assert(resultSet.getString(2).startsWith("application_"))
-        assert(resultSet.getString(4).contains(resultSet.getString(2)))
+        assert(resultSet.getString("id").toInt >= 0)
+        assert(resultSet.getString("appId").startsWith("application_"))
+        assert(resultSet.getString("state").nonEmpty)
+        assert(resultSet.getString("stderr").contains(resultSet.getString("appId")))
       }
     }
   }

--- a/integration-test/src/thriftserver/test/scala/org/apache/livy/test/JdbcIT.scala
+++ b/integration-test/src/thriftserver/test/scala/org/apache/livy/test/JdbcIT.scala
@@ -68,7 +68,7 @@ class JdbcIT extends BaseThriftIntegrationTestSuite {
         assert(resultSet.getString("id").toInt >= 0)
         assert(resultSet.getString("appId").startsWith("application_"))
         assert(resultSet.getString("state").nonEmpty)
-        assert(resultSet.getString("stderr").contains(resultSet.getString("appId")))
+        assert(resultSet.getString("logs").contains(resultSet.getString("appId")))
       }
     }
   }

--- a/integration-test/src/thriftserver/test/scala/org/apache/livy/test/JdbcIT.scala
+++ b/integration-test/src/thriftserver/test/scala/org/apache/livy/test/JdbcIT.scala
@@ -61,6 +61,13 @@ class JdbcIT extends BaseThriftIntegrationTestSuite {
           assert(resultSet.getString(3) == "{1:\"a\",2:\"b\"}")
           assert(!resultSet.next())
       }
+
+      checkQuery(c, "DESC LIVY SESSION") { resultSet =>
+        resultSet.next()
+        assert(resultSet.getString(1).toInt >= 0)
+        assert(resultSet.getString(2).startsWith("application_"))
+        assert(resultSet.getString(4).contains(resultSet.getString(2)))
+      }
     }
   }
 }

--- a/server/src/main/scala/org/apache/livy/utils/SparkYarnApp.scala
+++ b/server/src/main/scala/org/apache/livy/utils/SparkYarnApp.scala
@@ -155,7 +155,7 @@ class SparkYarnApp private[utils] (
         // We cannot kill the YARN app without the app id.
         // There's a chance the YARN app hasn't been submitted during a livy-server failure.
         // We don't want a stuck session that can't be deleted. Emit a warning and move on.
-        case _: TimeoutException | _: InterruptedException =>
+        case _: TimeoutException | _: InterruptedException | _: IllegalStateException =>
           warn("Deleting a session while its YARN application is not found.")
           yarnAppMonitorThread.interrupt()
       } finally {

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
@@ -221,14 +221,15 @@ class LivyThriftSessionManager(val server: LivyThriftServer, val livyConf: LivyC
       delegationToken: String): SessionHandle = {
     val sessionHandle = new SessionHandle(protocol)
     incrementConnections(username, ipAddress, SessionInfo.getForwardedAddresses)
+    val nextId = server.livySessionManager.nextId()
     sessionInfo.put(sessionHandle,
-      new SessionInfo(username, ipAddress, SessionInfo.getForwardedAddresses, protocol))
+      new SessionInfo(nextId, username, ipAddress, SessionInfo.getForwardedAddresses, protocol))
     val (initStatements, createInteractiveRequest, sessionId) =
       LivyThriftSessionManager.processSessionConf(sessionConf, supportUseDatabase)
     val createLivySession = () => {
       createInteractiveRequest.kind = Spark
       val newSession = InteractiveSession.create(
-        server.livySessionManager.nextId(),
+        nextId,
         createInteractiveRequest.name,
         username,
         None,

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/SessionInfo.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/SessionInfo.scala
@@ -23,7 +23,9 @@ import org.apache.hive.service.rpc.thrift.TProtocolVersion
 
 import org.apache.livy.Logging
 
-case class SessionInfo(username: String,
+case class SessionInfo(
+    sessionId: Int,
+    username: String,
     ipAddress: String,
     forwardedAddresses: util.List[String],
     protocolVersion: TProtocolVersion) {

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/operation/DescLivySessionOperation.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/operation/DescLivySessionOperation.scala
@@ -61,6 +61,7 @@ class DescLivySessionOperation(sessionHandle: SessionHandle,
     val session = sessionManager.getLivySession(sessionHandle)
     if (hasNext) {
       sessionVar.addRow(Array(session.id.toString, session.appId.orNull,
+        session.state.state,
         session.logLines(Some("stdout")).mkString("\n"),
         session.logLines(Some("stderr")).mkString("\n"),
         session.logLines(Some("yarnDiagnostics")).mkString("\n")))
@@ -74,6 +75,7 @@ object DescLivySessionOperation {
   val SCHEMA: Schema = Schema(
     Field("id", BasicDataType("string"), "Livy session id."),
     Field("appId", BasicDataType("string"), "Spark application id."),
+    Field("state", BasicDataType("string"), "Livy session state"),
     Field("stdout", BasicDataType("string"), "Spark application client stdout log."),
     Field("stderr", BasicDataType("string"), "Spark application client stderr log."),
     Field("yarnDiagnostics", BasicDataType("string"),

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/operation/DescLivySessionOperation.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/operation/DescLivySessionOperation.scala
@@ -60,11 +60,14 @@ class DescLivySessionOperation(sessionHandle: SessionHandle,
       sessionManager.getSessionInfo(sessionHandle).protocolVersion)
     val session = sessionManager.getLivySession(sessionHandle)
     if (hasNext) {
-      sessionVar.addRow(Array(session.id.toString, session.appId.orNull,
-        session.state.state,
-        session.logLines(Some("stdout")).mkString("\n"),
-        session.logLines(Some("stderr")).mkString("\n"),
-        session.logLines(Some("yarnDiagnostics")).mkString("\n")))
+      sessionVar.addRow(
+        Array(
+          session.id.toString,
+          session.appId.orNull,
+          session.state.state,
+          session.logLines().mkString("\n")
+        )
+      )
       hasNext = false
     }
     sessionVar
@@ -76,8 +79,6 @@ object DescLivySessionOperation {
     Field("id", BasicDataType("string"), "Livy session id."),
     Field("appId", BasicDataType("string"), "Spark application id."),
     Field("state", BasicDataType("string"), "Livy session state"),
-    Field("stdout", BasicDataType("string"), "Spark application client stdout log."),
-    Field("stderr", BasicDataType("string"), "Spark application client stderr log."),
-    Field("yarnDiagnostics", BasicDataType("string"),
-      "Spark application client yarnDiagnostics log"))
+    Field("logs", BasicDataType("string"), "Spark application logs.")
+  )
 }

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/operation/DescLivySessionOperation.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/operation/DescLivySessionOperation.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.thriftserver.operation
+
+import org.apache.hive.service.cli.{FetchOrientation, OperationState, OperationType, SessionHandle}
+
+import org.apache.livy.thriftserver.LivyThriftSessionManager
+import org.apache.livy.thriftserver.serde.ThriftResultSet
+import org.apache.livy.thriftserver.types.{BasicDataType, Field, Schema}
+
+class DescLivySessionOperation(sessionHandle: SessionHandle,
+     sessionManager: LivyThriftSessionManager)
+  extends Operation(sessionHandle, OperationType.EXECUTE_STATEMENT) {
+
+  private var hasNext: Boolean = true
+
+  override protected def runInternal(): Unit = {
+    setState(OperationState.PENDING)
+    setHasResultSet(true) // avoid no resultset for async run
+    setState(OperationState.RUNNING)
+    setState(OperationState.FINISHED)
+  }
+
+  override def cancel(stateAfterCancel: OperationState): Unit = {
+    setState(OperationState.CANCELED)
+  }
+
+  override def close(): Unit = {
+    setState(OperationState.CLOSED)
+  }
+
+  override def getResultSetSchema: Schema = {
+    assertState(Seq(OperationState.FINISHED))
+    DescLivySessionOperation.SCHEMA
+  }
+
+  override def getNextRowSet(orientation: FetchOrientation,
+      maxRows: Long): ThriftResultSet = {
+
+    validateFetchOrientation(orientation)
+    assertState(Seq(OperationState.FINISHED))
+    setHasResultSet(true)
+
+    val sessionVar = ThriftResultSet(this.getResultSetSchema,
+      sessionManager.getSessionInfo(sessionHandle).protocolVersion)
+    val session = sessionManager.getLivySession(sessionHandle)
+    if (hasNext) {
+      sessionVar.addRow(Array(session.id.toString, session.appId.orNull,
+        session.logLines(Some("stdout")).mkString("\n"),
+        session.logLines(Some("stderr")).mkString("\n"),
+        session.logLines(Some("yarnDiagnostics")).mkString("\n")))
+      hasNext = false
+    }
+    sessionVar
+  }
+}
+
+object DescLivySessionOperation {
+  val SCHEMA: Schema = Schema(
+    Field("id", BasicDataType("string"), "Livy session id."),
+    Field("appId", BasicDataType("string"), "Spark application id."),
+    Field("stdout", BasicDataType("string"), "Spark application client stdout log."),
+    Field("stderr", BasicDataType("string"), "Spark application client stderr log."),
+    Field("yarnDiagnostics", BasicDataType("string"),
+      "Spark application client yarnDiagnostics log"))
+}


### PR DESCRIPTION
… to Livy thrift server.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
Add `DescLivySessionOperation` to support fetching sessionId, applicationId, sessionState, sessionLogs from Livy thrift service.
Solve the bug that the thrift api gets stuck when creating an interactive session fails.

(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)
https://issues.apache.org/jira/browse/LIVY-971

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
integration tests

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
