### PR TITLE
LIVY-973 Always close RSCClient's EventLoopGroup

### DIFF
--- a/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
@@ -241,7 +241,11 @@ public class RSCClient implements LivyClient {
         // Report failure for all pending jobs, so that clients can react.
         for (Map.Entry<String, JobHandleImpl<?>> e : jobs.entrySet()) {
           LOG.info("Failing pending job {} due to shutdown.", e.getKey());
-          e.getValue().setFailure(new IOException("RSCClient instance stopped."));
+          try {
+            e.getValue().setFailure(new IOException("RSCClient instance stopped."));
+          }catch (Exception ex){
+            LOG.info("Job " +e.getKey() + " already failed. ", ex);
+          }
         }
 
         eventLoopGroup.shutdownGracefully();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added try-catch block to jobs' `setFailure()`and  log entries if there is any exception. `eventLoopGroup.shutdownGracefully();` statement will be executed after exception is caught.

https://issues.apache.org/jira/browse/LIVY-973

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

