### PR TITLE
[LIVY-975][SERVER] Fix compatibility issue related to a change on the Spark side

### DIFF
--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -185,3 +185,7 @@
 # livy.server.auth.<custom>.class = <class of custom auth filter>
 # livy.server.auth.<custom>.param.<foo1> = <bar1>
 # livy.server.auth.<custom>.param.<foo2> = <bar2>
+
+# Enable to allow custom classpath by proxy user in cluster mode
+# The below configuration parameter is disabled by default.
+# livy.server.session.allow-custom-classpath = true

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -262,6 +262,8 @@ object LivyConf {
   // Max creating session in livyServer
   val SESSION_MAX_CREATION = Entry("livy.server.session.max-creation", 100)
 
+  val SESSION_ALLOW_CUSTOM_CLASSPATH = Entry("livy.server.session.allow-custom-classpath", false)
+
   val SPARK_MASTER = "spark.master"
   val SPARK_DEPLOY_MODE = "spark.submit.deployMode"
   val SPARK_JARS = "spark.jars"

--- a/server/src/test/scala/org/apache/livy/sessions/SessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/SessionSpec.scala
@@ -65,6 +65,18 @@ class SessionSpec extends FunSuite with LivyBaseUnitTestSuite {
     intercept[IllegalArgumentException] {
       Session.prepareConf(Map("spark.do_not_set" -> "1"), Nil, Nil, Nil, Nil, conf)
     }
+
+    // Test for "spark.submit.deployMode".
+    intercept[IllegalArgumentException] {
+      Session.prepareConf(Map("spark.submit.deployMode" -> "standalone"), Nil, Nil, Nil, Nil, conf)
+    }
+
+    // Test for "spark.submit.proxyUser.allowCustomClasspathInClusterMode".
+    intercept[IllegalArgumentException] {
+      Session.prepareConf(Map("spark.submit.proxyUser.allowCustomClasspathInClusterMode"
+                -> "false"), Nil, Nil, Nil, Nil, conf)
+    }
+
     conf.sparkFileLists.foreach { key =>
       intercept[IllegalArgumentException] {
         Session.prepareConf(Map(key -> "file:/not_allowed"), Nil, Nil, Nil, Nil, conf)
@@ -93,6 +105,22 @@ class SessionSpec extends FunSuite with LivyBaseUnitTestSuite {
     val baseConf = userLists.map { key => (key -> base) }.toMap
     val result = Session.prepareConf(baseConf, other, other, other, other, conf)
     userLists.foreach { key => assert(result.get(key) === expected) }
+  }
+
+
+  test("conf validation to allow custom classpath") {
+    val conf = new LivyConf(false)
+    conf.set(LivyConf.SESSION_ALLOW_CUSTOM_CLASSPATH, true)
+
+    // Test for "spark.submit.deployMode".
+    assert(Session.prepareConf(Map("spark.submit.deployMode" -> "standalone"), Nil, Nil, Nil,
+      Nil, conf) === Map("spark.submit.deployMode" -> "standalone", "spark.master" -> "local"))
+
+    // Test for "spark.submit.proxyUser.allowCustomClasspathInClusterMode".
+    assert(Session.prepareConf(Map("spark.submit.proxyUser.allowCustomClasspathInClusterMode" ->
+      "false"), Nil, Nil, Nil, Nil, conf) === Map("spark.master" -> "local",
+      "spark.submit.proxyUser.allowCustomClasspathInClusterMode" -> "false"))
+
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Recent change in spark required us to fix compatibility issue related to a change on the Spark side.

JIRA: https://issues.apache.org/jira/browse/LIVY-975

## How was this patch tested?

Verified manually by creating interactive / batch sessions via REST API call in a local Yarn cluster. Also, we have updated the unit tests.
