### PR TITLE
[LIVY-974][SERVER] Remove verbose output on Livy UI error pages

### DIFF
--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -48,6 +48,9 @@
 # livy.server.request-header.size = 131072
 # livy.server.response-header.size = 131072
 
+# Whether or not to send server version in http response.
+# livy.server.send-server-version = false
+
 # Enabled to check whether timeout Livy sessions should be stopped.
 # livy.server.session.timeout-check = true
 #

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -67,6 +67,8 @@ object LivyConf {
   val REQUEST_HEADER_SIZE = Entry("livy.server.request-header.size", 131072)
   val RESPONSE_HEADER_SIZE = Entry("livy.server.response-header.size", 131072)
 
+  val SEND_SERVER_VERSION = Entry("livy.server.send-server-version", false)
+
   val CSRF_PROTECTION = Entry("livy.server.csrf-protection.enabled", false)
 
   val IMPERSONATION_ENABLED = Entry("livy.impersonation.enabled", false)

--- a/server/src/main/scala/org/apache/livy/server/WebServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/WebServer.scala
@@ -39,12 +39,14 @@ class WebServer(livyConf: LivyConf, var host: String, var port: Int) extends Log
       val http = new HttpConfiguration()
       http.setRequestHeaderSize(livyConf.getInt(LivyConf.REQUEST_HEADER_SIZE))
       http.setResponseHeaderSize(livyConf.getInt(LivyConf.RESPONSE_HEADER_SIZE))
+      http.setSendServerVersion(livyConf.getBoolean(LivyConf.SEND_SERVER_VERSION))
       (new ServerConnector(server, new HttpConnectionFactory(http)), "http")
 
     case Some(keystore) =>
       val https = new HttpConfiguration()
       https.setRequestHeaderSize(livyConf.getInt(LivyConf.REQUEST_HEADER_SIZE))
       https.setResponseHeaderSize(livyConf.getInt(LivyConf.RESPONSE_HEADER_SIZE))
+      https.setSendServerVersion(livyConf.getBoolean(LivyConf.SEND_SERVER_VERSION))
       https.addCustomizer(new SecureRequestCustomizer())
 
       val sslContextFactory = new SslContextFactory()


### PR DESCRIPTION
## What changes were proposed in this pull request?

On error, the Livy UI shows verbose output on error pages including the Jetty version number. This could be considered as a security vulnerability. We can make it configurable and avoid sending server version details. The Jetty version is there in every response header as well.

JIRA: https://issues.apache.org/jira/browse/LIVY-974

## How was this patch tested?

Verified manually by calling get sessions via REST API call in a local Yarn cluster.
