### PR TITLE
[LIVY-978][SERVER] Update the application tag generation logic in Livy

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
@@ -62,7 +62,7 @@ object BatchSession extends Logging {
       proxyUser: Option[String],
       sessionStore: SessionStore,
       mockApp: Option[SparkApp] = None): BatchSession = {
-    val appTag = s"livy-batch-$id-${Random.alphanumeric.take(8).mkString}"
+    val appTag = s"livy-batch-$id-${Random.alphanumeric.take(8).mkString}".toLowerCase()
     val impersonatedUser = accessManager.checkImpersonation(proxyUser, owner)
 
     def createSparkApp(s: BatchSession): SparkApp = {

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -89,7 +89,7 @@ object InteractiveSession extends Logging {
       ttl: Option[String],
       mockApp: Option[SparkApp] = None,
       mockClient: Option[RSCClient] = None): InteractiveSession = {
-    val appTag = s"livy-session-$id-${Random.alphanumeric.take(8).mkString}"
+    val appTag = s"livy-session-$id-${Random.alphanumeric.take(8).mkString}".toLowerCase()
     val impersonatedUser = accessManager.checkImpersonation(proxyUser, owner)
 
     val client = mockClient.orElse {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The following issue occurs:

```
ERROR org.apache.livy.utils.SparkYarnApp: Error whiling refreshing YARN state
java.lang.IllegalStateException: No YARN application is found with tag livy-batch-2-per2hlwa in 120 seconds. This may be because 1) spark-submit fail to submit application to YARN; or 2) YARN cluster doesn't have enough resources to start the application in time. Please check Livy log and YARN log to know the details.
```

if the below configuration parameter is set in YARN:
```
yarn.resourcemanager.application-tag-based-placement.force-lowercase=false
```
We can fix this in InteractiveSession / BatchSession by updating app tag generation logic to generate appTag always in lowercase characters.

JIRA: https://issues.apache.org/jira/browse/LIVY-978

## How was this patch tested?

Verified manually by creating interactive / batch sessions via REST API call in a local Yarn cluster.
