### PR TITLE
[LIVY-986][SERVER] Adding null pointer check for SessionInfo

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -92,14 +92,34 @@ class InteractiveSessionServlet(
         Nil
       }
 
+    val conf = if (session.conf != null) {
+      session.conf.asJava
+    } else null
+
+    val archives = if (session.archives != null) {
+      session.archives.asJava
+    } else null
+
+    val jars = if (session.jars != null) {
+      session.jars.asJava
+    } else null
+
+    val pyFiles = if (session.pyFiles != null) {
+      session.pyFiles.asJava
+    } else null
+
+    val files = if (session.files != null) {
+      session.files.asJava
+    } else null
+
     new SessionInfo(session.id, session.name.orNull, session.appId.orNull,
       session.owner, session.state.toString, session.kind.toString,
       session.appInfo.asJavaMap, logs.asJava,
       session.proxyUser.orNull, session.driverMemory.orNull,
       session.driverCores.getOrElse(0), session.executorMemory.orNull,
-      session.executorCores.getOrElse(0), session.conf.asJava, session.archives.asJava,
-      session.files.asJava, session.heartbeatTimeoutS, session.jars.asJava,
-      session.numExecutors.getOrElse(0), session.proxyUser.orNull, session.pyFiles.asJava,
+      session.executorCores.getOrElse(0), conf, archives,
+      files, session.heartbeatTimeoutS, jars,
+      session.numExecutors.getOrElse(0), session.proxyUser.orNull, pyFiles,
       session.queue.orNull)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

[LIVY-986][SERVER] Adding null pointer check for SessionInfo

## What changes were proposed in this pull request?

Adding null check for SessionInfo parameters "conf", "archives", "jars", "pyFiles" and "files"
JIRA: https://issues.apache.org/jira/browse/LIVY-986

## How was this patch tested?

Tested manually by running session recovery.

Please review https://livy.incubator.apache.org/community/ before opening a pull request.