### PR TITLE
rsc: Don't set spark configuration values to an empty string

### DIFF
--- a/rsc/src/main/java/org/apache/livy/rsc/ContextLauncher.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/ContextLauncher.java
@@ -254,7 +254,9 @@ class ContextLauncher {
 
   private static void merge(RSCConf conf, String key, String livyConf, String sep) {
     String confValue = Utils.join(Arrays.asList(livyConf, conf.get(key)), sep);
-    conf.set(key, confValue);
+    if (confValue != null && !confValue.isEmpty()) {
+      conf.set(key, confValue);
+    }
   }
 
   /**


### PR DESCRIPTION
It's better to leave out a key rather than set the value to an empty string