### PR TITLE
[LIVY-987] NPE when waiting for thrift session to start timeout.

### DIFF
--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
@@ -100,7 +100,7 @@ class LivyThriftSessionManager(val server: LivyThriftServer, val livyConf: LivyC
     } else {
       future.value match {
         case Some(Success(session)) => session
-        case Some(Failure(e)) => throw e.getCause
+        case Some(Failure(e)) => throw Option(e.getCause).getOrElse(e)
         case None => throw new RuntimeException("Future cannot be None when it is completed")
       }
     }
@@ -548,6 +548,11 @@ class LivyThriftSessionManager(val server: LivyThriftServer, val livyConf: LivyC
 
   def getSessionInfo(sessionHandle: SessionHandle): SessionInfo = {
     sessionInfo.get(sessionHandle)
+  }
+
+  private[thriftserver] def _mockLivySession(
+      sessionHandle: SessionHandle, future: Future[InteractiveSession]) = {
+    this.sessionHandleToLivySession.put(sessionHandle, future)
   }
 }
 

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
@@ -95,7 +95,7 @@ class LivyThriftSessionManager(val server: LivyThriftServer, val livyConf: LivyC
     if (!future.isCompleted) {
       Try(Await.result(future, maxSessionWait)) match {
         case Success(session) => session
-        case Failure(e) => throw e.getCause
+        case Failure(e) => throw Option(e.getCause).getOrElse(e)
       }
     } else {
       future.value match {

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyThriftSessionManager.scala
@@ -50,7 +50,7 @@ class LivyThriftSessionManager(val server: LivyThriftServer, val livyConf: LivyC
   extends ThriftService(classOf[LivyThriftSessionManager].getName) with Logging {
 
   private[thriftserver] val operationManager = new LivyOperationManager(this)
-  private val sessionHandleToLivySession =
+  private[thriftserver] val sessionHandleToLivySession =
     new ConcurrentHashMap[SessionHandle, Future[InteractiveSession]]()
   // A map which returns how many incoming connections are open for a Livy session.
   // This map tracks only the sessions created by the Livy thriftserver and not those which have
@@ -548,11 +548,6 @@ class LivyThriftSessionManager(val server: LivyThriftServer, val livyConf: LivyC
 
   def getSessionInfo(sessionHandle: SessionHandle): SessionInfo = {
     sessionInfo.get(sessionHandle)
-  }
-
-  private[thriftserver] def _mockLivySession(
-      sessionHandle: SessionHandle, future: Future[InteractiveSession]) = {
-    this.sessionHandleToLivySession.put(sessionHandle, future)
   }
 }
 

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/TestLivyThriftSessionManager.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/TestLivyThriftSessionManager.scala
@@ -17,11 +17,12 @@
 
 package org.apache.livy.thriftserver
 
-import java.util.concurrent.{TimeUnit, TimeoutException}
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
-import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
 
 import org.apache.hive.service.cli.{HiveSQLException, SessionHandle}
 import org.junit.Assert._

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/TestLivyThriftSessionManager.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/TestLivyThriftSessionManager.scala
@@ -17,8 +17,8 @@
 
 package org.apache.livy.thriftserver
 
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.TimeUnit
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/TestLivyThriftSessionManager.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/TestLivyThriftSessionManager.scala
@@ -170,7 +170,7 @@ class TestLivyThriftSessionManager {
     val thriftSessionMgr = createThriftSessionManager(None)
     val sessionHandle = mock(classOf[SessionHandle])
     val future = Future[InteractiveSession] {
-      throw new TimeoutException("")
+      throw new TimeoutException("Actively throw TimeoutException in Future.")
     }
     thriftSessionMgr._mockLivySession(sessionHandle, future)
     Await.ready(future, Duration(30, TimeUnit.SECONDS))

--- a/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/TestLivyThriftSessionManager.scala
+++ b/thriftserver/server/src/test/scala/org/apache/livy/thriftserver/TestLivyThriftSessionManager.scala
@@ -60,6 +60,7 @@ class TestLivyThriftSessionManager {
     }
     this.createThriftSessionManager(conf)
   }
+
   private def createThriftSessionManager(
       maxSessionWait: Option[String]): LivyThriftSessionManager = {
     val conf = new LivyConf()


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix NPE when waiting for thrift session to start timeout.
https://issues.apache.org/jira/browse/LIVY-987

## How was this patch tested?
manual tests by beeline and set timeout to 10s.

0: jdbc:hive2://username:password@thrift-server> select 123;

RSC client is executing SQL query: select 123, statementId = 681bc017-8f37-4665-a575-da355db77254, session = SessionHandle [c17f1729-6ee1-4260-b82b-aebec3b08e14]

Livy session has not yet started. Please wait for it to be ready...

Error: java.util.concurrent.TimeoutException: Futures timed out after [10000 milliseconds] (state=,code=0)

0: jdbc:hive2://username:password@thrift-server> Closing: 0: jdbc:hive2://username:password@thrift-server


Please review https://livy.incubator.apache.org/community/ before opening a pull request.
