### PR TITLE
Support for escaping backtick from spark-submit arguments

### DIFF
--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -267,6 +267,10 @@ object LivyConf {
 
   val SESSION_ALLOW_CUSTOM_CLASSPATH = Entry("livy.server.session.allow-custom-classpath", false)
 
+  // Escape backticks for spark-submit arguments in SparkProcessBuilder
+  // https://github.com/apache/incubator-livy/issues/415
+  val SPARK_SUBMIT_ESCAPE_BACKTICKS = Entry("livy.server.escapeBackTicks", false)
+
   val SPARK_MASTER = "spark.master"
   val SPARK_DEPLOY_MODE = "spark.submit.deployMode"
   val SPARK_JARS = "spark.jars"

--- a/server/src/test/scala/org/apache/livy/utils/SparkProcessBuilderSuite.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkProcessBuilderSuite.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.utils
+
+import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
+import org.scalatest.{BeforeAndAfter, FunSpec}
+
+class SparkProcessBuildSuite
+  extends FunSpec
+    with BeforeAndAfter
+    with org.scalatest.Matchers
+    with LivyBaseUnitTestSuite {
+
+  it("should only escape unescaped backticks") {
+    val livyConf = new LivyConf
+    livyConf.set(LivyConf.SPARK_SUBMIT_ESCAPE_BACKTICKS, true)
+
+    val builder = new SparkProcessBuilder(livyConf)
+
+    assert(builder.escapeBackTicks("test_db.test_table") == "test_db.test_table")
+    assert(builder.escapeBackTicks("test_db.`test_table`") == "test_db.\\`test_table\\`")
+    assert(builder.escapeBackTicks("test_db.\\`test_table\\`") == "test_db.\\`test_table\\`")
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes - #415 

Adding support for escaping backticks from spark-submit arguments.
- This feature will be behind a flag `livy.server.escapeBackTicks` (default: false)
- This also handles the case where the user is already escaping backtick and livy won't perform double escaping.

## How was this patch tested?

- Added unit test for escape backticks function.

