### PR TITLE
add jvm import org.apache.spark.sql.api.python.*

### DIFF
--- a/repl/src/main/resources/fake_shell.py
+++ b/repl/src/main/resources/fake_shell.py
@@ -591,6 +591,7 @@ def main():
             java_import(gateway.jvm, "org.apache.spark.api.python.*")
             java_import(gateway.jvm, "org.apache.spark.mllib.api.python.*")
             java_import(gateway.jvm, "org.apache.spark.sql.*")
+            java_import(gateway.jvm, "org.apache.spark.sql.api.python.*")
             java_import(gateway.jvm, "org.apache.spark.sql.hive.*")
             java_import(gateway.jvm, "scala.Tuple2")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

jvm import org.apache.spark.sql.api.python.*. Or else pandas dataframe to spark dataframe will fail.  

## How was this patch tested?

```python
import pandas as pd
from pyspark.sql import SparkSession

pandas_df = pd.DataFrame({
    'A': [1, 2, 3],
    'B': ['a', 'b', 'c']
})

spark = SparkSession.builder.getOrCreate()
spark_df = spark.createDataFrame(pandas_df)
spark_df.show()
```

this failed before, and now it's OK.
