### PR TITLE
Fix testing with Python3

### DIFF
--- a/server/src/test/scala/org/apache/livy/server/batch/BatchServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/BatchServletSpec.scala
@@ -43,7 +43,7 @@ class BatchServletSpec extends BaseSessionServletSpec[BatchSession, BatchRecover
     try {
       writer.write(
         """
-          |print "hello world"
+          |print("hello world")
         """.stripMargin)
     } finally {
       writer.close()

--- a/server/src/test/scala/org/apache/livy/server/batch/BatchSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/BatchSessionSpec.scala
@@ -48,7 +48,7 @@ class BatchSessionSpec
     try {
       writer.write(
         """
-          |print "hello world"
+          |print("hello world")
         """.stripMargin)
     } finally {
       writer.close()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix print statement in tests to be Python 2 and Python 3 compatible.
https://github.com/apache/incubator-livy/issues/408

Created an account in JIRA, waiting for approval so I can submit a ticket there as well.

## How was this patch tested?

Using the docker build for Spark 3

```bash
docker run --rm -it -v $(pwd):/workspace -v $HOME/.m2:/root/.m2 livy-ci mvn package -Pspark3 
```
