### PR TITLE
[LIVY-981] Exclude test and provided scopes from THIRD-PARTY license generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,8 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
+    <!-- Exclude test and provided licenses when generating the THIRD-PARTY license file -->
+    <license.excludedScopes>test,provided</license.excludedScopes>
   </properties>
 
   <repositories>


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Added `test,provided` to `excludedScopes` property for license maven plugin.
- https://issues.apache.org/jira/browse/LIVY-981

## How was this patch tested?

- Generated licenses manually, identified test-scope license removed from generated file

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
