### PR TITLE
Add IPv6 preferred JVM support

### DIFF
--- a/repl/src/main/resources/fake_shell.py
+++ b/repl/src/main/resources/fake_shell.py
@@ -576,14 +576,15 @@ def main():
             from pyspark.context import SparkContext
             from pyspark.sql import SQLContext, HiveContext, Row
             # Connect to the gateway
+            gateway_host = os.environ["PYSPARK_GATEWAY_HOST"]
             gateway_port = int(os.environ["PYSPARK_GATEWAY_PORT"])
             try:
                 from py4j.java_gateway import GatewayParameters
                 gateway_secret = os.environ["PYSPARK_GATEWAY_SECRET"]
                 gateway = JavaGateway(gateway_parameters=GatewayParameters(
-                    port=gateway_port, auth_token=gateway_secret, auto_convert=True))
+                    address=gateway_host, port=gateway_port, auth_token=gateway_secret, auto_convert=True))
             except:
-                gateway = JavaGateway(GatewayClient(port=gateway_port), auto_convert=True)
+                gateway = JavaGateway(GatewayClient(address=gateway_host, port=gateway_port), auto_convert=True)
 
             # Import the classes used by PySpark
             java_import(gateway.jvm, "org.apache.spark.SparkConf")

--- a/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/PythonInterpreter.scala
@@ -67,6 +67,7 @@ object PythonInterpreter extends Logging {
     env.put("PYSPARK_PYTHON", pythonExec)
     env.put("PYTHONPATH", pythonPath.mkString(File.pathSeparator))
     env.put("PYTHONUNBUFFERED", "YES")
+    env.put("PYSPARK_GATEWAY_HOST", gatewayServer.getAddress.getHostAddress)
     env.put("PYSPARK_GATEWAY_PORT", "" + gatewayServer.getListeningPort)
     env.put("PYSPARK_GATEWAY_SECRET", secretKey)
     env.put("SPARK_HOME", sys.env.getOrElse("SPARK_HOME", "."))


### PR DESCRIPTION
## What changes were proposed in this pull request?
Now loopback address is 127.0.0.1 always.
But it's not work for JVM that was run with `-Djava.net.preferIPv6Addresses=true`. It's better to pass host (that will be ::1 for IPv6) to py4j gateway creation.

## How was this patch tested?
Livy with this fix is using on IPv6 machines now.