### PR TITLE
[MINOR][DOC] Fix cursor parameter documentation for completion endpoint

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -362,7 +362,7 @@ Returns code completion candidates for the specified code in the session.
   <tr>
     <td>cursor</td>
     <td>cursor position to get proposals</td>
-    <td>string</td>
+    <td>int</td>
   </tr>
 </table>
 


### PR DESCRIPTION
`cursor` request parameter is integer, not string:
https://github.com/apache/incubator-livy/blob/86fc823/core/src/main/scala/org/apache/livy/msgs.scala#L63