### PR TITLE
[LIVY-992][SERVER] In livy logs, user is not able to differentiate between interactive session and batch session

### DIFF
--- a/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
@@ -128,7 +128,7 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
   }
 
   def delete(session: S): Future[Unit] = {
-    info(s"Deleting session ${session.id}")
+    info(s"Deleting ${session}")
     session.stop().map { case _ =>
       try {
         sessionStore.remove(sessionType, session.id)
@@ -141,7 +141,7 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
           error("Exception was thrown during stop session:", e)
           throw e
       } finally {
-        info(s"Deleted session ${session.id}")
+        info(s"Deleted ${session}")
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changes done in log info to differentiate session type (interactive or batch) so that it will be easier to identify while deleting sessions
https://issues.apache.org/jira/browse/LIVY-992 

## How was this patch tested?

Created both interactive and batch sessions. Then deleted sessions manually with DELETE API. Then checked logs to verify session type
