### PR TITLE
[LIVY-993][SERVER] In Livy logs, user cannot find out on whether session is deleted due to session timed out or session state retained value expired

### DIFF
--- a/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
@@ -193,9 +193,9 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
     Future.sequence(all().filter(expired).map { s =>
       s.state match {
         case st: FinishedSessionState =>
-          info(s"Deleting $s because it finished before ${sessionStateRetainedInSec / 1e9} secs.")
+          info(s"Deleting $s because session state retained time is expired in ${sessionStateRetainedInSec / 1e9} secs.")
         case _ =>
-          info(s"Deleting $s because it was inactive or the time to leave the period is over.")
+          info(s"Deleting $s because either session timed out or ttl expired.")
       }
       delete(s)
     })


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changes done in log info so as to provide more details on the reason behind deleting the session. This will help to know the actual reason behind deleting the session
https://issues.apache.org/jira/browse/LIVY-993 

## How was this patch tested?

Created interactive sessions. Waited for session to be timed out. Then observed logs. In another scenario, waited for session state retained time out to expire after successfully completing the session. Then automatically session got deleted. After this, again observed logs.
