### PR TITLE
[LIVY-995][REPL] JsonParseException is thrown when closing Livy session when using python profile

### DIFF
--- a/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
@@ -254,13 +254,11 @@ abstract class PythonBaseInterpreterSpec extends BaseInterpreterSpec {
     noException should be thrownBy {
       withInterpreter { intp =>
         val response = intp.execute(
-          """import atexit
-            |atexit.register(print, '{}')
+          """import atexit, sys
+            |atexit.register(sys.stdout.write, '{}')
             |""".stripMargin
         )
-        response should equal(Interpreter.ExecuteSuccess(
-          TEXT_PLAIN -> "<built-in function print>"
-        ))
+        response shouldBe a[Interpreter.ExecuteSuccess]
       }
     }
   }
@@ -269,13 +267,11 @@ abstract class PythonBaseInterpreterSpec extends BaseInterpreterSpec {
     noException should be thrownBy {
       withInterpreter { intp =>
         val response = intp.execute(
-          """import atexit
-            |atexit.register(print, 'line1\nline2')
+          """import atexit, sys
+            |atexit.register(sys.stdout.write, 'line1\nline2')
             |""".stripMargin
         )
-        response should equal(Interpreter.ExecuteSuccess(
-          TEXT_PLAIN -> "<built-in function print>"
-        ))
+        response shouldBe a[Interpreter.ExecuteSuccess]
       }
     }
   }

--- a/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
+++ b/repl/src/test/scala/org/apache/livy/repl/PythonInterpreterSpec.scala
@@ -249,6 +249,36 @@ abstract class PythonBaseInterpreterSpec extends BaseInterpreterSpec {
       )
     ))
   }
+
+  it should "work when interpreter exit with json stdout" in {
+    noException should be thrownBy {
+      withInterpreter { intp =>
+        val response = intp.execute(
+          """import atexit
+            |atexit.register(print, '{}')
+            |""".stripMargin
+        )
+        response should equal(Interpreter.ExecuteSuccess(
+          TEXT_PLAIN -> "<built-in function print>"
+        ))
+      }
+    }
+  }
+
+  it should "work when interpreter exit with non-json stdout" in {
+    noException should be thrownBy {
+      withInterpreter { intp =>
+        val response = intp.execute(
+          """import atexit
+            |atexit.register(print, 'line1\nline2')
+            |""".stripMargin
+        )
+        response should equal(Interpreter.ExecuteSuccess(
+          TEXT_PLAIN -> "<built-in function print>"
+        ))
+      }
+    }
+  }
 }
 
 class Python2InterpreterSpec extends PythonBaseInterpreterSpec {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When Livy closes PythonInterpreter, the output may not be in JSON format, so there is no need to deserialize json.
https://issues.apache.org/jira/browse/LIVY-995


## How was this patch tested?
manual tests
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
