### PR TITLE
[LIVY-1000][RSC] Supports reconnection after the RPC link between RSC…

### DIFF
--- a/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
@@ -63,6 +63,8 @@ public class RSCConf extends ClientConf<RSCConf> {
     RPC_SERVER_ADDRESS("rpc.server.address", null),
     RPC_CLIENT_HANDSHAKE_TIMEOUT("server.connect.timeout", "90s"),
     RPC_CLIENT_CONNECT_TIMEOUT("client.connect.timeout", "10s"),
+    RPC_CLIENT_RETRY_INITIAL_WAIT_TIME("client.connect.retry.initial.wait.time", "20s"),
+    RPC_CLIENT_RETRY_MAX_TIMES("client.connect.retry.max.times", "3"),
     RPC_CHANNEL_LOG_LEVEL("channel.log.level", null),
     RPC_MAX_MESSAGE_SIZE("rpc.max.size", 50 * 1024 * 1024),
     RPC_MAX_THREADS("rpc.threads", 8),


### PR DESCRIPTION
…Client and RSCDriver is disconnected

## What changes were proposed in this pull request?

When RSCClient and RSCDriver are disconnected due to some accident, try to re-establish the connection.

https://issues.apache.org/jira/browse/LIVY-1000

## How was this patch tested?

I tried to use the tcpkill to manually kill the link between RSCClient and RSCDriver to verify whether it completed re-establishing the connection.
