### PR TITLE
[LIVY-1007]: Livy should not spawn one thread per job to track the job on Kubernetes

### DIFF
--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -216,6 +216,10 @@
 
 # If Livy can't find the Kubernetes app within this time, consider it lost.
 # livy.server.kubernetes.app-lookup-timeout = 600s
+# If Livy can't find the Kubernetes app within this max times, consider it lost.
+# livy.server.kubernetes.app-lookup.max-failed.times = 120
+# The size of thread pool to monitor all Kubernetes apps.
+# livy.server.kubernetes.app-lookup.thread-pool.size = 4
 # When the cluster is busy, we may fail to launch yarn app in app-lookup-timeout, then it would
 # cause session leakage, so we need to check session leakage.
 # How long to check livy session leakage

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -271,6 +271,13 @@ object LivyConf {
 
   // If Livy can't find the Kubernetes app within this time, consider it lost.
   val KUBERNETES_APP_LOOKUP_TIMEOUT = Entry("livy.server.kubernetes.app-lookup-timeout", "600s")
+  // If Livy can't find the Kubernetes app within this max times, consider it lost.
+  val KUBERNETES_APP_LOOKUP_MAX_FAILED_TIMES =
+    Entry("livy.server.kubernetes.app-lookup.max-failed.times", 120)
+  // The size of thread pool to monitor all Kubernetes apps.
+  val KUBERNETES_APP_LOOKUP_THREAD_POOL_SIZE =
+    Entry("livy.server.kubernetes.app-lookup.thread-pool.size", 4)
+
   // How often Livy polls Kubernetes to refresh Kubernetes app state.
   val KUBERNETES_POLL_INTERVAL = Entry("livy.server.kubernetes.poll-interval", "15s")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Instead of spawning a monitor thread for every session, create a centralised thread to monitor all Kubernetes apps.

JIRA link:https://issues.apache.org/jira/browse/LIVY-1007

## How was this patch tested?

**Unit Tests:** The patch has been verified through comprehensive unit tests.
**Manual Testing:** Conducted manual testing using Kubernetes on Docker Desktop.

Environment: Helm charts. For detailed instructions on testing using Helm charts, please refer to the documentation available at [livycluster](https://github.com/askhatri/livycluster).
