### PR TITLE
[LIVY-1009] Add support for global TTL for sessions

### DIFF
--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -67,6 +67,13 @@
 # How long a finished session state should be kept in LivyServer for query.
 # livy.server.session.state-retain.sec = 600s
 
+# Enabled to check whether TTL Livy sessions should be stopped.
+# livy.server.session.ttl-check = false
+
+# Time in milliseconds on how long Livy will wait before TTL is an inactive session.
+# Note that the inactive session could be busy running jobs.
+# livy.server.session.ttl = 8h
+
 # If livy should impersonate the requesting users when creating a new session.
 # livy.impersonation.enabled = false
 

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -339,6 +339,13 @@ object LivyConf {
   // Max creating session in livyServer
   val SESSION_MAX_CREATION = Entry("livy.server.session.max-creation", 100)
 
+  // Enabled to check whether TTL Livy sessions should be stopped.
+  val SESSION_TTL_CHECK = Entry("livy.server.session.ttl-check", false)
+
+  // Time in milliseconds on how long Livy will wait before TTL is an inactive session.
+  // Note that the inactive session could be busy running jobs.
+  val SESSION_TTL = Entry("livy.server.session.ttl", "8h")
+
   val SESSION_ALLOW_CUSTOM_CLASSPATH = Entry("livy.server.session.allow-custom-classpath", false)
 
   val SPARK_MASTER = "spark.master"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added two new Livy configuration parameters as below:

```
Enabled to check whether TTL Livy sessions should be stopped.
livy.server.session.ttl-check = false

Time in milliseconds on how long Livy will wait before TTL is an inactive session.
Note that the inactive session could be busy running jobs.
livy.server.session.ttl = 8h
```


## How was this patch tested?

Read https://docs.google.com/document/d/1F2hU1RfShmNCKEWWkz_LpjEOev2BwbtZZBEueHpvgHM/edit for details.
