### PR TITLE
[LIVY-1013][SERVER][RSC] Livy statements api stuck when session failed to startup.

### DIFF
--- a/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
@@ -237,7 +237,7 @@ public class RSCClient implements LivyClient {
           } catch (Exception e) {
             LOG.warn("Error stopping RPC.", e);
           }
-        } else {
+        } else if (!driverRpc.isDone()){
           driverRpc.setFailure(ex);
           LOG.warn("Set driverRpc as failure in stopping RSCClient.");
         }

--- a/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCClient.java
@@ -230,19 +230,23 @@ public class RSCClient implements LivyClient {
         LOG.warn("Exception while waiting for end session reply.", e);
         Utils.propagate(e);
       } finally {
+        IOException ex = new IOException("RSCClient instance stopped.");
         if (driverRpc.isSuccess()) {
           try {
             driverRpc.get().close();
           } catch (Exception e) {
             LOG.warn("Error stopping RPC.", e);
           }
+        } else {
+          driverRpc.setFailure(ex);
+          LOG.warn("Set driverRpc as failure in stopping RSCClient.");
         }
 
         // Report failure for all pending jobs, so that clients can react.
         for (Map.Entry<String, JobHandleImpl<?>> e : jobs.entrySet()) {
           LOG.info("Failing pending job {} due to shutdown.", e.getKey());
           try {
-            e.getValue().setFailure(new IOException("RSCClient instance stopped."));
+            e.getValue().setFailure(ex);
           } catch (Exception e2) {
             LOG.info("Job " + e.getKey() + " already failed.", e2);
           }

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -356,6 +356,8 @@ object LivyConf {
 
   val SESSION_ALLOW_CUSTOM_CLASSPATH = Entry("livy.server.session.allow-custom-classpath", false)
 
+  val REQUEST_TIMEOUT = Entry("livy.server.request.timeout", "3s")
+
   val SPARK_MASTER = "spark.master"
   val SPARK_DEPLOY_MODE = "spark.submit.deployMode"
   val SPARK_JARS = "spark.jars"

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -567,13 +567,15 @@ class InteractiveSession(
 
   def statements: IndexedSeq[Statement] = {
     ensureRunning()
-    val r = client.get.getReplJobResults().get()
+    val r = client.get.getReplJobResults().get(
+      livyConf.getTimeAsMs(LivyConf.REQUEST_TIMEOUT), TimeUnit.MILLISECONDS)
     r.statements.toIndexedSeq
   }
 
   def getStatement(stmtId: Int): Option[Statement] = {
     ensureRunning()
-    val r = client.get.getReplJobResults(stmtId, 1).get()
+    val r = client.get.getReplJobResults(stmtId, 1).get(
+      livyConf.getTimeAsMs(LivyConf.REQUEST_TIMEOUT), TimeUnit.MILLISECONDS)
     if (r.statements.length < 1) {
       None
     } else {

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -629,13 +629,15 @@ class InteractiveSession(
   def addFile(uri: URI): Unit = {
     ensureRunning()
     recordActivity()
-    client.get.addFile(resolveURI(uri, livyConf)).get()
+    client.get.addFile(resolveURI(uri, livyConf)).get(
+      livyConf.getTimeAsMs(LivyConf.REQUEST_TIMEOUT), TimeUnit.MILLISECONDS)
   }
 
   def addJar(uri: URI): Unit = {
     ensureRunning()
     recordActivity()
-    client.get.addJar(resolveURI(uri, livyConf)).get()
+    client.get.addJar(resolveURI(uri, livyConf)).get(
+      livyConf.getTimeAsMs(LivyConf.REQUEST_TIMEOUT), TimeUnit.MILLISECONDS)
   }
 
   def jobStatus(id: Long): Any = {
@@ -643,7 +645,8 @@ class InteractiveSession(
     val clientJobId = operations(id)
     recordActivity()
     // TODO: don't block indefinitely?
-    val status = client.get.getBypassJobStatus(clientJobId).get()
+    val status = client.get.getBypassJobStatus(clientJobId).get(
+      livyConf.getTimeAsMs(LivyConf.REQUEST_TIMEOUT), TimeUnit.MILLISECONDS)
     new JobStatus(id, status.state, status.result, status.error)
   }
 

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -566,13 +566,13 @@ class InteractiveSession(
   }
 
   def statements: IndexedSeq[Statement] = {
-    ensureActive()
+    ensureRunning()
     val r = client.get.getReplJobResults().get()
     r.statements.toIndexedSeq
   }
 
   def getStatement(stmtId: Int): Option[Statement] = {
-    ensureActive()
+    ensureRunning()
     val r = client.get.getReplJobResults(stmtId, 1).get()
     if (r.statements.length < 1) {
       None
@@ -625,19 +625,19 @@ class InteractiveSession(
   }
 
   def addFile(uri: URI): Unit = {
-    ensureActive()
+    ensureRunning()
     recordActivity()
     client.get.addFile(resolveURI(uri, livyConf)).get()
   }
 
   def addJar(uri: URI): Unit = {
-    ensureActive()
+    ensureRunning()
     recordActivity()
     client.get.addJar(resolveURI(uri, livyConf)).get()
   }
 
   def jobStatus(id: Long): Any = {
-    ensureActive()
+    ensureRunning()
     val clientJobId = operations(id)
     recordActivity()
     // TODO: don't block indefinitely?
@@ -646,7 +646,7 @@ class InteractiveSession(
   }
 
   def cancelJob(id: Long): Unit = {
-    ensureActive()
+    ensureRunning()
     recordActivity()
     operations.remove(id).foreach { client.get.cancel }
   }
@@ -689,7 +689,7 @@ class InteractiveSession(
   }
 
   private def performOperation(job: Array[Byte], jobType: String, sync: Boolean): Long = {
-    ensureActive()
+    ensureRunning()
     recordActivity()
     val future = client.get.bypass(ByteBuffer.wrap(job), jobType, sync)
     val opId = operationCounter.incrementAndGet()


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. should set driverRpc failure when rscClient stop.
2. should ensureRunning before list statements and so on.
3. should timeout the request instead of stuck without response.

(Please fill in changes proposed in this fix)
(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)
https://issues.apache.org/jira/browse/LIVY-1013

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
