### PR TITLE
[LIVY-786] Interrupt interpreter threads when cancelling statements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,8 +189,6 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
-    <!-- Exclude test and provided licenses when generating the THIRD-PARTY license file -->
-    <license.excludedScopes>test,provided</license.excludedScopes>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,8 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
+    <!-- Exclude test and provided licenses when generating the THIRD-PARTY license file -->
+    <license.excludedScopes>test,provided</license.excludedScopes>
   </properties>
 
   <repositories>

--- a/repl/src/main/scala/org/apache/livy/repl/Session.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/Session.scala
@@ -184,6 +184,7 @@ class Session(
         if (Thread.interrupted()) {
           logWarning(s"Thread was interrupted during execution of statement $statementId; interrupt flag cleared.")
         }
+      }
     }(interpreterExecutor)
 
     statementId

--- a/repl/src/main/scala/org/apache/livy/repl/Session.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/Session.scala
@@ -182,7 +182,7 @@ class Session(
         statementThreads.remove(statementId, currentThread)
         // Clear the interrupt flag, but log if the thread was interrupted.
         if (Thread.interrupted()) {
-          logWarning(s"Thread was interrupted during execution of statement $statementId; " +
+          warn(s"Thread was interrupted during execution of statement $statementId; " +
             "interrupt flag cleared.")
         }
       }

--- a/repl/src/main/scala/org/apache/livy/repl/Session.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/Session.scala
@@ -182,7 +182,8 @@ class Session(
         statementThreads.remove(statementId, currentThread)
         // Clear the interrupt flag, but log if the thread was interrupted.
         if (Thread.interrupted()) {
-          logWarning(s"Thread was interrupted during execution of statement $statementId; interrupt flag cleared.")
+          logWarning(s"Thread was interrupted during execution of statement $statementId; " +
+            "interrupt flag cleared.")
         }
       }
     }(interpreterExecutor)

--- a/repl/src/main/scala/org/apache/livy/repl/Session.scala
+++ b/repl/src/main/scala/org/apache/livy/repl/Session.scala
@@ -19,7 +19,7 @@ package org.apache.livy.repl
 
 import java.util.{LinkedHashMap => JLinkedHashMap}
 import java.util.Map.Entry
-import java.util.concurrent.Executors
+import java.util.concurrent.{ConcurrentHashMap, Executors}
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.JavaConverters._
@@ -62,6 +62,8 @@ class Session(
 
   private val cancelExecutor = ExecutionContext.fromExecutorService(
     Executors.newSingleThreadExecutor())
+
+  private val statementThreads = new ConcurrentHashMap[Int, Thread]()
 
   private implicit val formats = DefaultFormats
 
@@ -161,18 +163,27 @@ class Session(
     _statements.synchronized { _statements(statementId) = statement }
 
     Future {
-      setJobGroup(tpe, statementId)
-      statement.compareAndTransit(StatementState.Waiting, StatementState.Running)
+      val currentThread = Thread.currentThread()
+      statementThreads.put(statementId, currentThread)
+      try {
+        setJobGroup(tpe, statementId)
+        statement.compareAndTransit(StatementState.Waiting, StatementState.Running)
 
-      if (statement.state.get() == StatementState.Running) {
-        statement.started = System.currentTimeMillis()
-        statement.output = executeCode(interpreter(tpe), statementId, code)
-      }
+        if (statement.state.get() == StatementState.Running) {
+          statement.started = System.currentTimeMillis()
+          statement.output = executeCode(interpreter(tpe), statementId, code)
+        }
 
-      statement.compareAndTransit(StatementState.Running, StatementState.Available)
-      statement.compareAndTransit(StatementState.Cancelling, StatementState.Cancelled)
-      statement.updateProgress(1.0)
-      statement.completed = System.currentTimeMillis()
+        statement.compareAndTransit(StatementState.Running, StatementState.Available)
+        statement.compareAndTransit(StatementState.Cancelling, StatementState.Cancelled)
+        statement.updateProgress(1.0)
+        statement.completed = System.currentTimeMillis()
+      } finally {
+        statementThreads.remove(statementId, currentThread)
+        // Clear the interrupt flag, but log if the thread was interrupted.
+        if (Thread.interrupted()) {
+          logWarning(s"Thread was interrupted during execution of statement $statementId; interrupt flag cleared.")
+        }
     }(interpreterExecutor)
 
     statementId
@@ -212,6 +223,7 @@ class Session(
           info(s"Failed to cancel statement $statementId.")
           statement.compareAndTransit(StatementState.Cancelling, StatementState.Cancelled)
         } else {
+          Option(statementThreads.get(statementId)).foreach(_.interrupt())
           sc.cancelJobGroup(statementId.toString)
           if (statement.state.get() == StatementState.Cancelling) {
             Thread.sleep(livyConf.getTimeAsMs(RSCConf.Entry.JOB_CANCEL_TRIGGER_INTERVAL))


### PR DESCRIPTION
## What changes were proposed in this pull request?
 - Cancel API doesn't cancel anything running on the Spark driver
 - track the interpreter thread for each running statement and interrupt it during cancel
 -  Clean up the threads and reset interrupt after statement completion

## How was this patch tested?
 - Unit test added

Closes LIVY-786 