### PR TITLE
[LIVY-1049] Remove the '-incubating' designator

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -8,7 +8,7 @@
 (Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
 (If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
 
-Please review https://livy.incubator.apache.org/community/ before opening a pull request.
+Please review https://livy.apache.org/community/ before opening a pull request.
 
 ## Was this patch authored or co-authored using generative AI tooling?
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-api</artifactId>
-  <version>0.10.0-incubating-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-assembly</artifactId>
-  <version>0.10.0-incubating-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/client-common/pom.xml
+++ b/client-common/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-common</artifactId>
-  <version>0.10.0-incubating-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/client-http/pom.xml
+++ b/client-http/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-http</artifactId>
-  <version>0.10.0-incubating-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../scala/pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-core-parent</artifactId>
-  <version>0.10.0-incubating-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/core/scala-2.12/pom.xml
+++ b/core/scala-2.12/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-core_2.12</artifactId>
-  <version>0.10.0-incubating-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-core-parent</artifactId>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>livy-coverage-report</artifactId>
-  <version>0.10.0-incubating-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/dev/docker/README.md
+++ b/dev/docker/README.md
@@ -10,7 +10,7 @@ Following steps use Ubuntu as development environment but most of the instructio
 ```
 $ mvn clean package -Pscala-2.12 -Pspark3 -DskipITs -DskipTests
 ```
-This generates a zip file for livy similar to `assembly/target/apache-livy-0.10.0-incubating-SNAPSHOT_2.12-bin.zip`. It's useful to use the `clean` target to avoid mixing with previously built dependencies/versions.
+This generates a zip file for livy similar to `assembly/target/apache-livy-1.0.0-SNAPSHOT_2.12-bin.zip`. It's useful to use the `clean` target to avoid mixing with previously built dependencies/versions.
 
 ### Build container images locally
 * Build livy-dev-base, livy-dev-spark, livy-dev-server container images using provided script `build-images.sh`

--- a/dev/docker/build-images.sh
+++ b/dev/docker/build-images.sh
@@ -29,7 +29,7 @@ HIVE_PACKAGE="apache-hive-${HIVE_VERSION}-bin.tar.gz"
 SPARK_VERSION=3.2.3
 SPARK_PACKAGE="spark-${SPARK_VERSION}-bin-without-hadoop.tgz"
 SCALA_VERSION=2.12
-LIVY_VERSION="0.10.0-incubating-SNAPSHOT_${SCALA_VERSION}"
+LIVY_VERSION="1.0.0-SNAPSHOT_${SCALA_VERSION}"
 LIVY_PACKAGE="apache-livy-${LIVY_VERSION}-bin.zip"
 LOCALLY_BUILT_LIVY_PACKAGE="${SCRIPT_DIR}/../../assembly/target/${LIVY_PACKAGE}"
 
@@ -59,7 +59,7 @@ fi
 # Download livy if needed
 if [ ! -f "${SCRIPT_DIR}/livy-dev-server/${LIVY_PACKAGE}" ]; then
     curl --fail -L --retry 3 -o "${SCRIPT_DIR}/livy-dev-server/${LIVY_PACKAGE}" \
-      "${APACHE_ARCHIVE_ROOT}/incubator/livy/${LIVY_VERSION}/${LIVY_PACKAGE}"
+      "${APACHE_ARCHIVE_ROOT}/livy/${LIVY_VERSION}/${LIVY_PACKAGE}"
 fi
 
 

--- a/dev/docker/livy-dev-server/Dockerfile
+++ b/dev/docker/livy-dev-server/Dockerfile
@@ -17,7 +17,7 @@
 
 FROM livy-dev-spark:latest
 
-ARG LIVY_VERSION=0.10.0-incubating-SNAPSHOT
+ARG LIVY_VERSION=1.0.0-SNAPSHOT
 ARG ROOT_PATH=/opt
 
 RUN apt-get update \
@@ -35,6 +35,6 @@ RUN unzip ${LIVY_PACKAGE}.zip 1>/dev/null \
   && rm ${LIVY_PACKAGE}.zip
 
 # Uncomment following line or add more such lines to replace the default jars with private builds.
-# COPY livy-core_2.12-0.10.0-incubating-SNAPSHOT.jar ${SPARK_HOME}/repl_2.12-jars/livy-core_2.12-0.10.0-incubating-SNAPSHOT.jar
+# COPY livy-core_2.12-1.0.0-SNAPSHOT.jar ${SPARK_HOME}/repl_2.12-jars/livy-core_2.12-1.0.0-SNAPSHOT.jar
 
 WORKDIR ${LIVY_HOME}

--- a/dev/merge_livy_pr.py
+++ b/dev/merge_livy_pr.py
@@ -19,13 +19,13 @@
 
 # Utility for creating well-formed pull request merges and pushing them to Apache.
 #
-# This utility assumes you already have local a incubator-livy git folder and that you
-# have added remotes corresponding to both (i) the github apache incubator-livy
+# This utility assumes you already have local a livy git folder and that you
+# have added remotes corresponding to both (i) the github apache livy
 # mirror and (ii) the apache git repo.
 #
-# 1. Adding github apache incubator-livy mirror remote to your local repo with name "apache-github"
+# 1. Adding github apache livy mirror remote to your local repo with name "apache-github"
 #    (for example) using "git remote add apache-github ...".
-# 2. Adding apache incubator-livy remote to your local repo with name "apache" (for example) using
+# 2. Adding apache livy remote to your local repo with name "apache" (for example) using
 #    "git remote add apache ..."
 # 3. Invoke this script from LIVY_HOME (./dev/merge_livy_pr.py) and follow the prompted steps.
 # 4. If you want to handle the associated JIRA, JIRA_USERNAME and JIRA_PASSWORD should be set.
@@ -49,7 +49,7 @@ try:
 except ImportError:
     JIRA_IMPORTED = False
 
-# Location of your incubator-livy git development area
+# Location of your livy git development area
 LIVY_HOME = os.environ.get("LIVY_HOME", os.getcwd())
 # Remote name which points to the Gihub site
 PR_REMOTE_NAME = os.environ.get("PR_REMOTE_NAME", "apache-github")
@@ -65,8 +65,8 @@ JIRA_PASSWORD = os.environ.get("JIRA_PASSWORD", "")
 # https://github.com/settings/tokens. This script only requires the "public_repo" scope.
 GITHUB_OAUTH_KEY = os.environ.get("GITHUB_OAUTH_KEY")
 
-GITHUB_BASE = "https://github.com/apache/incubator-livy/pull"
-GITHUB_API_BASE = "https://api.github.com/repos/apache/incubator-livy"
+GITHUB_BASE = "https://github.com/apache/livy/pull"
+GITHUB_API_BASE = "https://api.github.com/repos/apache/livy"
 JIRA_BASE = "https://issues.apache.org/jira/browse"
 JIRA_API_BASE = "https://issues.apache.org/jira"
 # Prefix added to temporary branches
@@ -151,7 +151,7 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc):
     merge_message_flags += ["-m", title]
     if body is not None:
         # We remove @ symbols from the body to avoid triggering e-mails
-        # to people every time someone creates a public fork of incubator-livy.
+        # to people every time someone creates a public fork of livy.
         merge_message_flags += ["-m", body.replace("@", "")]
 
     authors = "\n".join(["Author: %s" % a for a in distinct_authors])

--- a/dev/release-build.sh
+++ b/dev/release-build.sh
@@ -87,9 +87,9 @@ if [ -z "$GPG_PASSPHRASE" ]; then
 fi
 
 # Destination directory on remote server
-RELEASE_STAGING_LOCATION="https://dist.apache.org/repos/dist/dev/incubator/livy"
+RELEASE_STAGING_LOCATION="https://dist.apache.org/repos/dist/dev/livy"
 
-LIVY_REPO=${LIVY_REPO:-https://gitbox.apache.org/repos/asf/incubator-livy.git}
+LIVY_REPO=${LIVY_REPO:-https://gitbox.apache.org/repos/asf/livy.git}
 GPG="gpg --no-tty --batch --pinentry-mode loopback"
 NEXUS_ROOT=https://repository.apache.org/service/local/staging
 NEXUS_PROFILE=91529f2f65d84e # Profile for Livy staging uploads
@@ -102,8 +102,8 @@ rm -rf release-staging
 mkdir release-staging
 cd release-staging
 
-git clone $LIVY_REPO incubator-livy
-cd incubator-livy
+git clone $LIVY_REPO livy
+cd livy
 git checkout $GIT_REF
 git_hash=`git rev-parse --short HEAD`
 echo "Checked out Livy git hash $git_hash"
@@ -127,7 +127,7 @@ SCALA_2_11_PROFILES="-Pscala-2.11"
 if [[ "$1" == "package" ]]; then
   # Source and binary tarballs
   echo "Packaging release tarballs"
-  cp -r incubator-livy $ARCHIVE_NAME_PREFIX
+  cp -r livy $ARCHIVE_NAME_PREFIX
   zip -r $SRC_ARCHIVE $ARCHIVE_NAME_PREFIX
   echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour --output $SRC_ARCHIVE.asc --detach-sig $SRC_ARCHIVE
   shasum -a 512 $SRC_ARCHIVE > $SRC_ARCHIVE.sha512
@@ -138,7 +138,7 @@ if [[ "$1" == "package" ]]; then
     BIN_ARCHIVE="${ARCHIVE_NAME_PREFIX}_$1-bin.zip"
     MVN_FLAGS="clean package -DskipITs -DskipTests -Dgenerate-third-party -e $2"
 
-    cp -r incubator-livy $ARCHIVE_NAME_PREFIX-bin
+    cp -r livy $ARCHIVE_NAME_PREFIX-bin
     cd $ARCHIVE_NAME_PREFIX-bin
 
     $MVN $MVN_FLAGS
@@ -178,7 +178,7 @@ if [[ "$1" == "publish-release" ]]; then
   tmp_repo=$(pwd)
   cd ..
 
-  cd incubator-livy
+  cd livy
   # Publish Livy to Maven release repo
   echo "Publishing Livy checkout at '$GIT_REF' ($git_hash)"
   echo "Publish version is $LIVY_VERSION"

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,13 +61,13 @@ NOTE: To skip the step of building and copying over the Scala and Java API docs,
 jekyll build`.
 
 
-## Publishing Docs to [livy.incubator.apache.org]
+## Publishing Docs to [livy.apache.org]
 
 1. Build Livy Docs (`cd docs` then `bundle exec jekyll build`).
 2. Copy the contents of `docs/target/` excluding `assets/` into a new directory (eg. `0.4.0/`) and
-move it into the `docs/` directory in your local fork of `apache/incubator-livy-website`.
+move it into the `docs/` directory in your local fork of `apache/livy-website`.
 3. If nesesary, update the `latest` symlink to point to the new directory.
-4. Open a pull request to `apache/incubator-livy-website` with the update.
+4. Open a pull request to `apache/livy-website` with the update.
 
 Note: If you made any changes to files in the `assets/` directory you will need to replicate those
-changes in the corresponding files in `apache/incubator-livy-website` in the pull request.
+changes in the corresponding files in `apache/livy-website` in the pull request.

--- a/docs/_data/project.yml
+++ b/docs/_data/project.yml
@@ -16,6 +16,6 @@
 # Apache Project configurations
 #
 name: Apache Livy
-version: 0.10.0-incubating-SNAPSHOT
+version: 1.0.0-SNAPSHOT
 
-podling: true
+podling: false

--- a/docs/programmatic-api.md
+++ b/docs/programmatic-api.md
@@ -35,7 +35,7 @@ Add the Livy client dependency to your application's POM:
 <dependency>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-http</artifactId>
-  <version>0.7.0-incubating</version>
+  <version>1.0.0</version>
 </dependency>
 ```
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-examples</artifactId>
-  <version>0.10.0-incubating-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>livy-integration-test</artifactId>
-  <version>0.10.0-incubating-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -22,11 +22,11 @@
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-main</artifactId>
-  <version>0.10.0-incubating-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Livy Project Parent POM</name>
   <description>Livy Project</description>
-  <url>http://livy.incubating.apache.org/</url>
+  <url>http://livy.apache.org/</url>
 
   <parent>
     <groupId>org.apache</groupId>
@@ -43,9 +43,9 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:git@github.com:apache/incubator-livy.git</connection>
-    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/incubator-livy.git</developerConnection>
-    <url>scm:git:git@github.com:apache/incubator-livy.git</url>
+    <connection>scm:git:git@github.com:apache/livy.git</connection>
+    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/livy.git</developerConnection>
+    <url>scm:git:git@github.com:apache/livy.git</url>
     <tag>HEAD</tag>
   </scm>
 
@@ -57,23 +57,23 @@
   <mailingLists>
     <mailingList>
       <name>Dev Mailing List</name>
-      <post>dev@livy.incubating.apache.org</post>
-      <subscribe>dev-subscribe@livy.incubating.apache.org</subscribe>
-      <unsubscribe>dev-unsubscribe@livy.incubating.apache.org</unsubscribe>
+      <post>dev@livy.apache.org</post>
+      <subscribe>dev-subscribe@livy.apache.org</subscribe>
+      <unsubscribe>dev-unsubscribe@livy.apache.org</unsubscribe>
     </mailingList>
 
     <mailingList>
       <name>User Mailing List</name>
-      <post>user@livy.incubating.apache.org</post>
-      <subscribe>user-subscribe@livy.incubating.apache.org</subscribe>
-      <unsubscribe>user-unsubscribe@livy.incubating.apache.org</unsubscribe>
+      <post>user@livy.apache.org</post>
+      <subscribe>user-subscribe@livy.apache.org</subscribe>
+      <unsubscribe>user-unsubscribe@livy.apache.org</unsubscribe>
     </mailingList>
 
     <mailingList>
       <name>Commits Mailing List</name>
-      <post>commits@livy.incubating.apache.org</post>
-      <subscribe>commits-subscribe@livy.incubating.apache.org</subscribe>
-      <unsubscribe>commits-unsubscribe@livy.incubating.apache.org</unsubscribe>
+      <post>commits@livy.apache.org</post>
+      <subscribe>commits-subscribe@livy.apache.org</subscribe>
+      <unsubscribe>commits-unsubscribe@livy.apache.org</unsubscribe>
     </mailingList>
   </mailingLists>
 

--- a/python-api/pom.xml
+++ b/python-api/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-python-api</artifactId>
-  <version>0.10.0-incubating-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <build>

--- a/python-api/setup.py
+++ b/python-api/setup.py
@@ -37,14 +37,14 @@ requirements = [
 
 setup(
     name='livy-python-api',
-    version="0.10.0-incubating-SNAPSHOT",
+    version="1.0.0-SNAPSHOT",
     packages=["livy", "livy-tests"],
     package_dir={
         "": "src/main/python",
         "livy-tests": "src/test/python/livy-tests",
     },
-    url='https://github.com/apache/incubator-livy',
-    author_email='user@livy.incubator.apache.org',
+    url='https://github.com/apache/livy',
+    author_email='user@livy.apache.org',
     license='Apache License, Version 2.0',
     description=DESCRIPTION,
     platforms=['any'],

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
     <relativePath>../scala/pom.xml</relativePath>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>livy-repl-parent</artifactId>
-  <version>0.10.0-incubating-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/repl/scala-2.12/pom.xml
+++ b/repl/scala-2.12/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-repl_2.12</artifactId>
-  <version>0.10.0-incubating-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-repl-parent</artifactId>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala-api/pom.xml
+++ b/scala-api/pom.xml
@@ -23,12 +23,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../scala/pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-scala-api-parent</artifactId>
-  <version>0.10.0-incubating-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/scala-api/scala-2.12/pom.xml
+++ b/scala-api/scala-2.12/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-scala-api_2.12</artifactId>
-  <version>0.10.0-incubating-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-scala-api-parent</artifactId>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 </project>

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>multi-scala-project-root</artifactId>
-  <version>0.10.0-incubating-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>livy-server</artifactId>
-  <version>0.10.0-incubating-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/test-lib/pom.xml
+++ b/test-lib/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-test-lib</artifactId>
-  <version>0.10.0-incubating-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/thriftserver/client/pom.xml
+++ b/thriftserver/client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/thriftserver/server/pom.xml
+++ b/thriftserver/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/thriftserver/session/pom.xml
+++ b/thriftserver/session/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

As Apache Livy has graduated to a Top-Level Project (TLP), this commit removes the '-incubating' suffix from all files, build configurations and documentation.

See announcement: https://news.apache.org/foundation/entry/the-apache-software-foundation-announces-new-top-level-project-4

## How was this patch tested?

Manually verified

## Was this patch authored or co-authored using generative AI tooling?

No