### PR TITLE
LIVY-1062: Handle HTTP 307 redirects for POST/DELETE in LivyConnection

### DIFF
--- a/client-http/src/main/java/org/apache/livy/client/http/LivyConnection.java
+++ b/client-http/src/main/java/org/apache/livy/client/http/LivyConnection.java
@@ -24,6 +24,7 @@ import java.security.Principal;
 import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
@@ -59,6 +60,7 @@ class LivyConnection {
 
   static final String SESSIONS_URI = "/sessions";
   private static final String APPLICATION_JSON = "application/json";
+  private static final int MAX_REDIRECTS = 1;
 
   private final URI server;
   private final String uriRoot;
@@ -215,24 +217,38 @@ class LivyConnection {
       uriRoot + String.format(uri, uriParams), null, null));
     // It is no harm to set X-Requested-By when csrf protection is disabled.
     if (req instanceof HttpPost || req instanceof HttpDelete || req instanceof HttpPut
-            || req instanceof  HttpPatch) {
+            || req instanceof HttpPatch) {
       req.addHeader("X-Requested-By", "livy");
     }
-    try (CloseableHttpResponse res = client.execute(req)) {
-      int status = (res.getStatusLine().getStatusCode() / 100) * 100;
-      HttpEntity entity = res.getEntity();
-      if (status == HttpStatus.SC_OK) {
-        if (!Void.class.equals(retType)) {
-          return mapper.readValue(entity.getContent(), retType);
-        } else {
-          return null;
+    int redirectCount = 0;
+    do {
+      try (CloseableHttpResponse res = client.execute(req)) {
+        int statusCode = res.getStatusLine().getStatusCode();
+        int statusClass = (statusCode / 100) * 100;
+        HttpEntity entity = res.getEntity();
+        if (statusClass == HttpStatus.SC_OK) {
+          if (!Void.class.equals(retType)) {
+            return mapper.readValue(entity.getContent(), retType);
+          } else {
+            return null;
+          }
         }
-      } else {
-        String error = EntityUtils.toString(entity);
-        throw new IOException(String.format("%s: %s", res.getStatusLine().getReasonPhrase(),
-          error));
+        if (statusCode == HttpStatus.SC_TEMPORARY_REDIRECT) {
+          // Redirect to active server when Livy is running in HA mode.
+          Header locationHeader = res.getFirstHeader(HttpHeaders.LOCATION);
+          if (locationHeader == null || locationHeader.getValue().isEmpty()) {
+            throw new IOException("Temporary Redirect without Location header");
+          }
+          EntityUtils.consume(entity);
+          req.setURI(new URI(locationHeader.getValue()));
+        } else {
+          String error = EntityUtils.toString(entity);
+          throw new IOException(String.format("%s: %s", res.getStatusLine().getReasonPhrase(),
+            error));
+        }
       }
-    }
+    } while (++redirectCount <= MAX_REDIRECTS);
+    throw new IOException("Too many redirects");
   }
 
 }

--- a/client-http/src/test/scala/org/apache/livy/client/http/LivyConnectionSpec.scala
+++ b/client-http/src/test/scala/org/apache/livy/client/http/LivyConnectionSpec.scala
@@ -18,8 +18,16 @@
 package org.apache.livy.client.http
 
 import java.io.IOException
+import java.net.URI
 import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Files
+import java.util.concurrent.ConcurrentLinkedQueue
+import javax.servlet.ServletContext
+import javax.servlet.http.HttpServletRequest
 
+import scala.collection.JavaConverters._
+
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.http.client.utils.URIBuilder
 import org.eclipse.jetty.security._
 import org.eclipse.jetty.security.UserStore
@@ -27,9 +35,11 @@ import org.eclipse.jetty.security.authentication.BasicAuthenticator
 import org.eclipse.jetty.util.security._
 import org.scalatest.{BeforeAndAfterAll, FunSpecLike}
 import org.scalatest.Matchers._
+import org.scalatra.{LifeCycle, ScalatraServlet}
 import org.scalatra.servlet.ScalatraListener
 
 import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
+import org.apache.livy.client.common.HttpMessages.{CreateClientRequest, SessionInfo}
 import org.apache.livy.server.WebServer
 
 class LivyConnectionSpec extends FunSpecLike with BeforeAndAfterAll with LivyBaseUnitTestSuite {
@@ -74,7 +84,7 @@ class LivyConnectionSpec extends FunSpecLike with BeforeAndAfterAll with LivyBas
 
       val uri = new URIBuilder()
         .setScheme(server.protocol)
-        .setHost(server.host)
+        .setHost("127.0.0.1")
         .setPort(server.port)
         .setUserInfo(username, password)
         .build()
@@ -119,5 +129,313 @@ class LivyConnectionSpec extends FunSpecLike with BeforeAndAfterAll with LivyBas
       val pwd = "test-password" * 100
       test(pwd, livyConf)
     }
+  }
+
+  describe("LivyConnection HA redirect handling") {
+    def serverBaseUrl(server: WebServer): String =
+      s"${server.protocol}://127.0.0.1:${server.port}"
+
+    def startActiveServer(): WebServer = {
+      val server = new WebServer(new LivyConf(), "0.0.0.0", 0)
+      server.context.setResourceBase("src/main/org/apache/livy/server")
+      server.context.setInitParameter(ScalatraListener.LifeCycleKey,
+        classOf[ActiveServerBootstrap].getCanonicalName)
+      server.context.addEventListener(new ScalatraListener)
+      server.start()
+      server
+    }
+
+    def startStandbyServer(bootstrap: Class[_ <: LifeCycle]): WebServer = {
+      val server = new WebServer(new LivyConf(), "0.0.0.0", 0)
+      server.context.setResourceBase("src/main/org/apache/livy/server")
+      server.context.setInitParameter(ScalatraListener.LifeCycleKey, bootstrap.getCanonicalName)
+      server.context.addEventListener(new ScalatraListener)
+      server.start()
+      server
+    }
+
+    def standbyUri(server: WebServer): URI =
+      new URIBuilder().setScheme(server.protocol).setHost("127.0.0.1").setPort(server.port).build()
+
+    def withHaServers(
+        bootstrap: Class[_ <: LifeCycle] = classOf[StandbyRedirectBootstrap],
+        includeActive: Boolean = true)(
+        testFn: (URI, Option[WebServer], WebServer) => Unit): Unit = {
+      HaTestContext.reset()
+      var activeServer: WebServer = null
+      var standbyServer: WebServer = null
+      try {
+        val activeOpt = if (includeActive) {
+          activeServer = startActiveServer()
+          HaTestContext.activeServerUrl = serverBaseUrl(activeServer)
+          Some(activeServer)
+        } else {
+          None
+        }
+        standbyServer = startStandbyServer(bootstrap)
+        testFn(standbyUri(standbyServer), activeOpt, standbyServer)
+      } finally {
+        if (standbyServer != null) {
+          standbyServer.stop()
+          standbyServer.join()
+        }
+        if (activeServer != null) {
+          activeServer.stop()
+          activeServer.join()
+        }
+      }
+    }
+
+    def header(req: RecordedRequest, name: String): Option[String] =
+      req.headers.get(name.toLowerCase)
+
+    it("should follow 307 redirects and preserve request contract on active server") {
+      withHaServers() { (uri, _, _) =>
+        val conn = new LivyConnection(uri, new HttpConf(null))
+        val tmpFile = Files.createTempFile("livy-ha-test", ".jar").toFile
+        try {
+          Files.write(tmpFile.toPath, "test-jar-content".getBytes(UTF_8))
+
+          val create = new CreateClientRequest(Map("spark.app.name" -> "test").asJava)
+          val info = conn.post(create, classOf[SessionInfo], "/")
+          conn.delete(classOf[java.lang.Void], "/%d", Int.box(42))
+          conn.post(tmpFile, classOf[java.lang.Void], "jar", "/%d/upload-jar", Int.box(1))
+
+          info.id should be (1)
+          info.state should be ("idle")
+          info.kind should be ("spark")
+
+          HaTestContext.standbyRequests.asScala should have size 3
+          HaTestContext.activeRequests.asScala should have size 3
+
+          val postActive = HaTestContext.activeRequests.asScala.toList(0)
+          postActive.method should be ("POST")
+          postActive.path should be ("/sessions/")
+          header(postActive, "Content-Type") should contain ("application/json")
+          header(postActive, "Accept") should contain ("application/json")
+          header(postActive, "X-Requested-By") should contain ("livy")
+          postActive.body.get should include ("spark.app.name")
+
+          val deleteActive = HaTestContext.activeRequests.asScala.toList(1)
+          deleteActive.method should be ("DELETE")
+          deleteActive.path should be ("/sessions/42")
+          header(deleteActive, "X-Requested-By") should contain ("livy")
+
+          val multipartActive = HaTestContext.activeRequests.asScala.toList(2)
+          multipartActive.method should be ("POST")
+          multipartActive.path should be ("/sessions/1/upload-jar")
+          header(multipartActive, "Content-Type").get should startWith ("multipart/")
+          multipartActive.body.get should include ("test-jar-content")
+
+          HaTestContext.standbyRequests.asScala.map(_.method).toList should
+            equal(List("POST", "DELETE", "POST"))
+        } finally {
+          conn.close()
+          tmpFile.delete()
+        }
+      }
+    }
+
+    it("should fail fast on invalid redirect responses without contacting active server") {
+      case class FailureScenario(
+          bootstrap: Class[_ <: LifeCycle],
+          setup: (Option[WebServer], WebServer) => Unit,
+          action: LivyConnection => Unit,
+          expectedMsg: String,
+          activeCount: Int,
+          standbyCount: Int,
+          includeActive: Boolean = true)
+
+      val scenarios = Seq(
+        FailureScenario(
+          classOf[StandbyNoLocationBootstrap],
+          (_, _) => (),
+          _.post(null, classOf[SessionInfo], "/"),
+          "Temporary Redirect without Location header",
+          activeCount = 0,
+          standbyCount = 1),
+        FailureScenario(
+          classOf[StandbyEmptyLocationBootstrap],
+          (_, _) => (),
+          _.delete(classOf[java.lang.Void], "/%d", Int.box(0)),
+          "Temporary Redirect without Location header",
+          activeCount = 0,
+          standbyCount = 1),
+        FailureScenario(
+          classOf[StandbyRedirectLoopBootstrap],
+          (_, standby) => HaTestContext.redirectLoopUrl = serverBaseUrl(standby),
+          _.get(classOf[SessionInfo], "/"),
+          "Too many redirects",
+          activeCount = 0,
+          standbyCount = 2,
+          includeActive = false),
+        FailureScenario(
+          classOf[StandbyErrorBootstrap],
+          (_, _) => (),
+          _.post(null, classOf[SessionInfo], "/"),
+          "Not Found",
+          activeCount = 0,
+          standbyCount = 1))
+
+      scenarios.foreach { scenario =>
+        withHaServers(scenario.bootstrap, scenario.includeActive) { (uri, activeOpt, standby) =>
+          scenario.setup(activeOpt, standby)
+          val conn = new LivyConnection(uri, new HttpConf(null))
+          try {
+            val ex = intercept[IOException](scenario.action(conn))
+            ex.getMessage should include (scenario.expectedMsg)
+            HaTestContext.activeRequests.asScala should have size scenario.activeCount
+            HaTestContext.standbyRequests.asScala should have size scenario.standbyCount
+          } finally {
+            conn.close()
+          }
+        }
+      }
+    }
+  }
+}
+
+private case class RecordedRequest(
+    server: String,
+    method: String,
+    path: String,
+    headers: Map[String, String],
+    body: Option[String])
+
+private object HaTestContext {
+  val standbyRequests = new ConcurrentLinkedQueue[RecordedRequest]()
+  val activeRequests = new ConcurrentLinkedQueue[RecordedRequest]()
+  var activeServerUrl: String = _
+  var redirectLoopUrl: String = _
+  private val mapper = new ObjectMapper()
+
+  def reset(): Unit = {
+    standbyRequests.clear()
+    activeRequests.clear()
+    activeServerUrl = null
+    redirectLoopUrl = null
+  }
+
+  def sessionInfoJson(id: Int): String = {
+    val info = new SessionInfo(id, null, null, null, "idle", "spark",
+      Map.empty[String, String].asJava, List.empty[String].asJava, null, null, null, 0, null, 0,
+      Map.empty[String, String].asJava, List.empty[String].asJava, List.empty[String].asJava, 0,
+      List.empty[String].asJava, 0, null, List.empty[String].asJava, null)
+    mapper.writeValueAsString(info)
+  }
+}
+
+private object HaTestServlet {
+  def log(server: String, req: HttpServletRequest, content: Option[String] = None): Unit = {
+    val headers = req.getHeaderNames.asScala.flatMap { name =>
+      req.getHeaders(name).asScala.map(value => name.toLowerCase -> value)
+    }.toMap
+    val recorded = RecordedRequest(server, req.getMethod, req.getRequestURI, headers, content)
+    if (server == "standby") {
+      HaTestContext.standbyRequests.add(recorded)
+    } else {
+      HaTestContext.activeRequests.add(recorded)
+    }
+  }
+}
+
+private class ActiveLivyServlet extends ScalatraServlet {
+  before() {
+    contentType = "application/json"
+  }
+
+  get("/") {
+    HaTestServlet.log("active", request)
+    HaTestContext.sessionInfoJson(0)
+  }
+
+  post("/") {
+    HaTestServlet.log("active", request, Some(request.body))
+    HaTestContext.sessionInfoJson(1)
+  }
+
+  delete("/:id") {
+    HaTestServlet.log("active", request)
+    status = 200
+    "{}"
+  }
+
+  post("/:id/upload-jar") {
+    HaTestServlet.log("active", request, Some(request.body))
+    status = 200
+    "{}"
+  }
+}
+
+private class ActiveServerBootstrap extends LifeCycle {
+  override def init(context: ServletContext): Unit = {
+    context.mount(new ActiveLivyServlet, s"${LivyConnection.SESSIONS_URI}/*")
+  }
+}
+
+private class StandbyRedirectServlet(location: String => String) extends ScalatraServlet {
+  private def redirect(): Unit = {
+    HaTestServlet.log("standby", request, Some(request.body))
+    response.setStatus(307)
+    response.setHeader("Location", location(request.getRequestURI))
+    halt(307, "Temporary Redirect")
+  }
+
+  get("/*") { redirect() }
+  post("/*") { redirect() }
+  delete("/*") { redirect() }
+}
+
+private class StandbyRedirectBootstrap extends LifeCycle {
+  override def init(context: ServletContext): Unit = {
+    context.mount(new StandbyRedirectServlet((uri: String) =>
+      HaTestContext.activeServerUrl.stripSuffix("/") + uri),
+      s"${LivyConnection.SESSIONS_URI}/*")
+  }
+}
+
+private class StandbyNoLocationBootstrap extends LifeCycle {
+  override def init(context: ServletContext): Unit = {
+    context.mount(new ScalatraServlet {
+      post("/*") {
+        HaTestServlet.log("standby", request)
+        response.setStatus(307)
+        halt(307, "Temporary Redirect")
+      }
+    }, s"${LivyConnection.SESSIONS_URI}/*")
+  }
+}
+
+private class StandbyEmptyLocationBootstrap extends LifeCycle {
+  override def init(context: ServletContext): Unit = {
+    context.mount(new ScalatraServlet {
+      delete("/*") {
+        HaTestServlet.log("standby", request)
+        response.setStatus(307)
+        response.setHeader("Location", "")
+        halt(307, "Temporary Redirect")
+      }
+    }, s"${LivyConnection.SESSIONS_URI}/*")
+  }
+}
+
+private class StandbyRedirectLoopBootstrap extends LifeCycle {
+  override def init(context: ServletContext): Unit = {
+    context.mount(new StandbyRedirectServlet((uri: String) =>
+      HaTestContext.redirectLoopUrl.stripSuffix("/") + uri),
+      s"${LivyConnection.SESSIONS_URI}/*")
+  }
+}
+
+private class StandbyErrorBootstrap extends LifeCycle {
+  override def init(context: ServletContext): Unit = {
+    context.mount(new ScalatraServlet {
+      post("/*") {
+        HaTestServlet.log("standby", request)
+        status = 404
+        contentType = "application/json"
+        """{"msg":"session not found"}"""
+      }
+    }, s"${LivyConnection.SESSIONS_URI}/*")
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Handle HTTP **307 Temporary Redirect** in `LivyConnection.sendRequest()` so the Java HTTP client (`client-http`) retries POST, DELETE, and multipart requests to the `Location` URL instead of failing with `IOException: Temporary Redirect`.

Apache HttpClient follows redirects automatically for GET, but not for non-idempotent methods. `LivyConnection.sendRequest()` previously treated any non-200 response as fatal, so POST/DELETE/multipart calls failed whenever the server returned 307.


Also validates that `Location` is present/non-empty and consumes the redirect response entity before retry.

JIRA: [LIVY-1062](https://issues.apache.org/jira/browse/LIVY-1062)

## How was this patch tested?

Unit tests in `LivyConnectionSpec`:

- **Happy path:** POST (JSON), DELETE, and multipart POST via a mock standby server returning 307 to an active server — verifies method, headers (`X-Requested-By`), body, and response type are preserved.
- **Failure paths:** missing/empty `Location`, redirect loop, non-redirect 404.

## Was this patch authored or co-authored using generative AI tooling?

Yes, this was co-authored using Cursor to write the new test cases.

Generated-by: Cursor Composer, Cursor 3.13.21